### PR TITLE
feat: 임시 Member 도메인 핵심 기능 구현

### DIFF
--- a/typing-practice-be/build.gradle
+++ b/typing-practice-be/build.gradle
@@ -1,7 +1,7 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.8'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.8'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.typingpractice'
@@ -9,37 +9,38 @@ version = '0.0.1-SNAPSHOT'
 description = 'typing-practice backend server'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-security'
-	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
-	compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
+    compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.security:spring-security-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/ApiResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/ApiResponse.java
@@ -1,0 +1,9 @@
+package com.typingpractice.typing_practice_be.common;
+
+import java.time.LocalDateTime;
+
+public record ApiResponse<T>(boolean success, T data, LocalDateTime timestamp) {
+  public static <T> ApiResponse<T> ok(T data) {
+    return new ApiResponse<>(true, data, LocalDateTime.now());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/domain/BaseEntity.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/domain/BaseEntity.java
@@ -1,0 +1,22 @@
+package com.typingpractice.typing_practice_be.common.domain;
+
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+public abstract class BaseEntity {
+  @CreatedDate private LocalDateTime createdAt;
+
+  @LastModifiedDate private LocalDateTime updatedAt;
+
+  private boolean deleted = false;
+  private LocalDateTime deletedAt;
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -1,0 +1,15 @@
+package com.typingpractice.typing_practice_be.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+  MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
+  DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다.");
+
+  private final HttpStatus status;
+  private final String message;
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/GlobalExceptionHandler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,46 @@
+package com.typingpractice.typing_practice_be.common.exception;
+
+import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ProblemDetail handleValidationException(MethodArgumentNotValidException e) {
+    String message =
+        e.getBindingResult().getFieldErrors().stream()
+            .map(error -> error.getField() + ": " + error.getDefaultMessage())
+            .findFirst()
+            .orElse("유효성 검사 실패");
+
+    ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, message);
+
+    problemDetail.setTitle("Validation Error");
+
+    return problemDetail;
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ProblemDetail handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
+    String message = String.format("'%s'는 유효하지 않은 값입니다.", e.getValue());
+
+    ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, message);
+    problemDetail.setTitle("Invalid Parameter Type");
+
+    return problemDetail;
+  }
+
+  @ExceptionHandler(MemberNotFoundException.class)
+  public ProblemDetail handleMemberNotFoundException(MemberNotFoundException e) {
+
+    ErrorCode errorCode = e.getErrorCode();
+
+    return ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SwaggerConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SwaggerConfig.java
@@ -1,0 +1,16 @@
+package com.typingpractice.typing_practice_be.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+  @Bean
+  public OpenAPI openAPI() {
+    return new OpenAPI()
+        .info(
+            new Info().title("Typing Practice API").description("타이핑 연습 서비스 API").version("1.0.0"));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
@@ -1,0 +1,53 @@
+package com.typingpractice.typing_practice_be.member.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.member.dto.LoginDto;
+import com.typingpractice.typing_practice_be.member.dto.MemberResponseDto;
+import com.typingpractice.typing_practice_be.member.dto.UpdateNicknameDto;
+import com.typingpractice.typing_practice_be.member.service.MemberService;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController()
+@RequestMapping("/members")
+@RequiredArgsConstructor
+public class MemberController {
+  private final MemberService memberService;
+
+  @PostMapping("/login")
+  public ApiResponse<MemberResponseDto> login(@Valid @RequestBody LoginDto loginDto) {
+    Member member = this.memberService.loginOrSignIn(loginDto);
+
+    return ApiResponse.ok(MemberResponseDto.from(member));
+  }
+
+  @GetMapping
+  public ApiResponse<List<MemberResponseDto>> memberList() {
+    List<Member> members = memberService.findAllMembers();
+    return ApiResponse.ok(members.stream().map(MemberResponseDto::from).toList());
+  }
+
+  @GetMapping("/{memberId}")
+  public ApiResponse<MemberResponseDto> findMember(@PathVariable(name = "memberId") Long memberId) {
+    Member member = memberService.findMemberById(memberId);
+
+    return ApiResponse.ok(MemberResponseDto.from(member));
+  }
+
+  @PatchMapping("/{memberId}")
+  public ApiResponse<MemberResponseDto> updateNickname(
+      @PathVariable Long memberId, @RequestBody UpdateNicknameDto updateNicknameDto) {
+    Member member = memberService.updateNickname(memberId, updateNicknameDto.getNickname());
+
+    return ApiResponse.ok(MemberResponseDto.from(member));
+  }
+
+  @DeleteMapping("/{memberId}")
+  public void deleteMember(@PathVariable Long memberId) {
+    memberService.deleteMember(memberId);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/Member.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/Member.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.member.domain;
 
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
 import jakarta.persistence.*;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -11,10 +12,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
-@EntityListeners(AuditingEntityListener.class)
+// @EntityListeners(AuditingEntityListener.class)
 @SQLRestriction("deleted = false")
 @SQLDelete(sql = "UPDATE member SET deleted = true, deleted_at = NOW() where member_id = ?")
-public class Member {
+public class Member extends BaseEntity {
   @Id
   @GeneratedValue
   @Column(name = "member_id")
@@ -28,10 +29,10 @@ public class Member {
   @Enumerated(EnumType.STRING)
   private MemberRole role;
 
-  @CreatedDate private LocalDateTime createdAt;
-  @LastModifiedDate private LocalDateTime updatedAt;
-  private boolean deleted = false;
-  private LocalDateTime deletedAt;
+  //  @CreatedDate private LocalDateTime createdAt;
+  //  @LastModifiedDate private LocalDateTime updatedAt;
+  //  private boolean deleted = false;
+  //  private LocalDateTime deletedAt;
 
   public static Member createMember(String email, String password, String nickname) {
     Member member = new Member();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/CreateMemberDto.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/CreateMemberDto.java
@@ -13,4 +13,13 @@ public class CreateMemberDto {
   @NotNull
   @Length(min = 2, max = 10)
   private String nickname;
+
+  public static CreateMemberDto create(String email, String password, String nickname) {
+    CreateMemberDto createMemberDto = new CreateMemberDto();
+    createMemberDto.email = email;
+    createMemberDto.password = password;
+    createMemberDto.nickname = nickname;
+
+    return createMemberDto;
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/LoginDto.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/LoginDto.java
@@ -1,0 +1,19 @@
+package com.typingpractice.typing_practice_be.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class LoginDto {
+  @NotNull private String email;
+
+  @NotNull private String password;
+
+  public static LoginDto create(String email, String password) {
+    LoginDto loginDto = new LoginDto();
+    loginDto.email = email;
+    loginDto.password = password;
+
+    return loginDto;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/MemberResponseDto.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/MemberResponseDto.java
@@ -1,0 +1,12 @@
+package com.typingpractice.typing_practice_be.member.dto;
+
+import com.typingpractice.typing_practice_be.member.domain.Member;
+
+import java.time.LocalDateTime;
+
+public record MemberResponseDto(Long id, String email, String nickname, LocalDateTime createdAt) {
+  public static MemberResponseDto from(Member member) {
+    return new MemberResponseDto(
+        member.getId(), member.getEmail(), member.getNickname(), member.getCreatedAt());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/UpdateNicknameDto.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/UpdateNicknameDto.java
@@ -1,0 +1,12 @@
+package com.typingpractice.typing_practice_be.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+public class UpdateNicknameDto {
+  @NotNull
+  @Length(min = 2, max = 10)
+  private String nickname;
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/DuplicateEmailException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/DuplicateEmailException.java
@@ -1,0 +1,14 @@
+package com.typingpractice.typing_practice_be.member.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class DuplicateEmailException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  public DuplicateEmailException() {
+    super(ErrorCode.DUPLICATE_EMAIL.getMessage());
+    this.errorCode = ErrorCode.DUPLICATE_EMAIL;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/MemberNotFoundException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/MemberNotFoundException.java
@@ -1,0 +1,14 @@
+package com.typingpractice.typing_practice_be.member.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class MemberNotFoundException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  public MemberNotFoundException() {
+    super(ErrorCode.MEMBER_NOT_FOUND.getMessage());
+    this.errorCode = ErrorCode.MEMBER_NOT_FOUND;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepository.java
@@ -2,12 +2,17 @@ package com.typingpractice.typing_practice_be.member.repository;
 
 import com.typingpractice.typing_practice_be.member.domain.Member;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository {
+  List<Member> findAll();
+
   Optional<Member> findById(Long memberId);
 
   Optional<Member> findByEmail(String email);
+
+  Optional<Member> login(String email, String password);
 
   Long save(Member member);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepositoryImpl.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepositoryImpl.java
@@ -2,6 +2,8 @@ package com.typingpractice.typing_practice_be.member.repository;
 
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import jakarta.persistence.EntityManager;
+
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -12,6 +14,11 @@ public class MemberRepositoryImpl implements MemberRepository {
   private final EntityManager em;
 
   @Override
+  public List<Member> findAll() {
+    return em.createQuery("select m from Member m", Member.class).getResultList();
+  }
+
+  @Override
   public Optional<Member> findById(Long memberId) {
     return em.createQuery("select m from Member m where m.id = :memberId", Member.class)
         .setParameter("memberId", memberId)
@@ -20,6 +27,7 @@ public class MemberRepositoryImpl implements MemberRepository {
         .findFirst();
   }
 
+  @Override
   public Optional<Member> findByEmail(String email) {
     return em.createQuery("select m from Member m where m.email = :email", Member.class)
         .setParameter("email", email)
@@ -28,12 +36,26 @@ public class MemberRepositoryImpl implements MemberRepository {
         .findFirst();
   }
 
+  @Override
+  public Optional<Member> login(String email, String password) {
+    return em.createQuery(
+            "select m from Member m where m.email = :email and m.password = :password",
+            Member.class)
+        .setParameter("email", email)
+        .setParameter("password", password)
+        .setMaxResults(1)
+        .getResultStream()
+        .findFirst();
+  }
+
+  @Override
   public Long save(Member member) {
     em.persist(member);
 
     return member.getId();
   }
 
+  @Override
   public void deleteMember(Member member) {
 
     em.remove(member);

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MockMemberRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MockMemberRepository.java
@@ -1,0 +1,63 @@
+package com.typingpractice.typing_practice_be.member.repository;
+
+import com.typingpractice.typing_practice_be.member.domain.Member;
+
+import java.util.*;
+
+public class MockMemberRepository implements MemberRepository {
+  private final Map<Long, Member> store = new HashMap<>();
+  private Long sequence = 1L;
+
+  @Override
+  public List<Member> findAll() {
+    return new ArrayList<>(store.values());
+  }
+
+  @Override
+  public Optional<Member> findById(Long memberId) {
+    return Optional.ofNullable(store.get(memberId));
+  }
+
+  @Override
+  public Optional<Member> findByEmail(String email) {
+    return store.values().stream().filter(member -> member.getEmail().equals(email)).findFirst();
+  }
+
+  @Override
+  public Optional<Member> login(String email, String password) {
+    return store.values().stream()
+        .filter(member -> member.getEmail().equals(email) && member.getPassword().equals(password))
+        .findFirst();
+  }
+
+  @Override
+  public Long save(Member member) {
+    // ID가 없으면 새로 할당 (신규 저장)
+    if (member.getId() == null) {
+      // Reflection으로 ID 설정 (Member에 setter 없어서)
+      try {
+        var idField = Member.class.getDeclaredField("id");
+        idField.setAccessible(true);
+        idField.set(member, sequence);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+      store.put(sequence, member);
+      return sequence++;
+    }
+
+    // ID가 있으면 업데이트
+    store.put(member.getId(), member);
+    return member.getId();
+  }
+
+  @Override
+  public void deleteMember(Member member) {
+    store.remove(member.getId());
+  }
+
+  public void clear() {
+    store.clear();
+    sequence = 1L;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.quote.domain;
 
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import jakarta.persistence.*;
 import lombok.Getter;
@@ -13,10 +14,10 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@EntityListeners(AuditingEntityListener.class)
+// @EntityListeners(AuditingEntityListener.class)
 @SQLRestriction("deleted = false")
 @SQLDelete(sql = "UPDATE quote SET deleted = true, delted_at = NOW() where quote_id = ?")
-public class Quote {
+public class Quote extends BaseEntity {
   @Id
   @GeneratedValue
   @Column(name = "quote_id")
@@ -28,10 +29,10 @@ public class Quote {
   private String sentence;
   private String author;
 
-  @CreatedDate private LocalDateTime createdAt;
-  @LastModifiedDate private LocalDateTime updatedAt;
-  private boolean deleted = false;
-  private LocalDateTime deletedAt;
+  //  @CreatedDate private LocalDateTime createdAt;
+  //  @LastModifiedDate private LocalDateTime updatedAt;
+  //  private boolean deleted = false;
+  //  private LocalDateTime deletedAt;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = true)

--- a/typing-practice-be/src/main/resources/application.yaml
+++ b/typing-practice-be/src/main/resources/application.yaml
@@ -16,5 +16,11 @@ spring:
       enabled: true
       path: /h2-console
 
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+
 server:
   port: 8080

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/member/service/MemberServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/member/service/MemberServiceTest.java
@@ -1,0 +1,103 @@
+package com.typingpractice.typing_practice_be.member.service;
+
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.member.dto.LoginDto;
+import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
+import com.typingpractice.typing_practice_be.member.repository.MockMemberRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.*;
+
+class MemberServiceTest {
+
+  private MockMemberRepository mockRepository;
+  private MemberService memberService;
+
+  @BeforeEach
+  void setUp() {
+    mockRepository = new MockMemberRepository();
+    memberService = new MemberService(mockRepository);
+  }
+
+  @AfterEach
+  void tearDown() {
+    mockRepository.clear();
+  }
+
+  @Test
+  void findMemberById() {
+    // given
+    LoginDto loginDto = LoginDto.create("email", "password");
+    Member member = memberService.loginOrSignIn(loginDto);
+
+    // when
+    Member findMember = memberService.findMemberById(member.getId());
+
+    // then
+    assertThat(findMember).isEqualTo(member);
+  }
+
+  @Test
+  void findAllMembers() {
+    // given
+    LoginDto loginA = LoginDto.create("memberA", "a");
+    LoginDto loginB = LoginDto.create("memberB", "b");
+
+    memberService.loginOrSignIn(loginA);
+    memberService.loginOrSignIn(loginB);
+
+    // when
+    List<Member> allMembers = memberService.findAllMembers();
+
+    // then
+    assertThat(allMembers.size()).isEqualTo(2);
+  }
+
+  @Test
+  void loginOrSignIn() {
+    // given
+    LoginDto loginDto = LoginDto.create("memberA", "A");
+    Member memberA = memberService.loginOrSignIn(loginDto); // 회원가입
+
+    // when
+    Member loginMember = memberService.loginOrSignIn(loginDto);
+
+    // then
+    // assertThat(loginMember.getEmail()).isEqualTo(loginDto.getEmail());
+    assertThat(loginMember).isEqualTo(memberA);
+    List<Member> allMembers = memberService.findAllMembers();
+    assertThat(allMembers.size()).isEqualTo(1);
+  }
+
+  @Test
+  void updateNickname() {
+    // given
+    LoginDto loginDto = LoginDto.create("memberA", "a");
+    Member memberA = memberService.loginOrSignIn(loginDto); // 회원가입
+
+    // when
+    memberService.updateNickname(memberA.getId(), "new_nickname");
+    Member findMember = memberService.findMemberById(memberA.getId());
+
+    // then
+    assertThat(findMember.getNickname()).isEqualTo("new_nickname");
+  }
+
+  @Test
+  void deleteMember() {
+    // given
+    LoginDto loginDto = LoginDto.create("memberA", "a");
+    Member memberA = memberService.loginOrSignIn(loginDto);
+
+    // when
+    memberService.deleteMember(memberA.getId());
+
+    // then
+    assertThatThrownBy(() -> memberService.findMemberById(memberA.getId()))
+        .isInstanceOf(MemberNotFoundException.class);
+  }
+}


### PR DESCRIPTION
- 엔티티 설계
  - BaseEntity 추가 (createdAt, updatedAt, 논리 삭제 필드 공통화)
  - Member, Quote 엔티티에 @SQLDelete, @SQLRestriction 적용
  - Member에 정적 팩토리 메서드 추가

- Member CRUD API 구현
  - MemberController: 조회, 로그인/회원가입, 수정, 삭제 엔드포인트
  - MemberService: 비즈니스 로직 처리, 트랜잭션 관리
  - MemberRepository: EntityManager 기반 구현

- DTO 설계
  - LoginDto: 로그인/회원가입용
  - CreateMemberDto: 회원가입 검증 (@Valid)
  - UpdateMemberDto: 회원 정보 수정
  - MemberResponseDto: API 응답용 (민감정보 제외)

- 공통 응답 및 예외 처리
  - ApiResponse<T>: 제네릭 기반 통합 응답 포맷
  - GlobalExceptionHandler: ProblemDetail 기반 예외 처리
  - ErrorCode: enum 기반 에러 메시지 관리
  - 커스텀 예외: MemberNotFoundException, DuplicateEmailException

- 테스트 코드
  - MockMemberRepository: 테스트용 인메모리 저장소
  - MemberServiceTest: 서비스 계층 단위 테스트

- 기타
  - Swagger 설정 (SpringDoc 2.7.0)
  - H2 DB 파일 모드로 변경
  - Security 임시 전체 허용 설정