### PR TITLE
feat: Quote 도메인 구현 및 Spring Security 임시 비활성화

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -10,7 +10,8 @@ public enum ErrorCode {
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
   DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
 
-  FORBIDDEN(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다.");
+  FORBIDDEN(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
+  QUOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예문을 찾을 수 없습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/GlobalExceptionHandler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.common.exception;
 
 import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
 import com.typingpractice.typing_practice_be.member.exception.ForbiddenException;
+import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -54,6 +55,13 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(ForbiddenException.class)
   public ProblemDetail handleForbiddenException(ForbiddenException e) {
+    ErrorCode errorCode = e.getErrorCode();
+
+    return ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());
+  }
+
+  @ExceptionHandler(QuoteNotFoundException.class)
+  public ProblemDetail handleQuoteNotFoundException(QuoteNotFoundException e) {
     ErrorCode errorCode = e.getErrorCode();
 
     return ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtAuthenticationFilter.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtAuthenticationFilter.java
@@ -5,6 +5,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.lang.NonNull;
+import org.springframework.lang.NonNullApi;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -28,7 +30,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
   @Override
   protected void doFilterInternal(
-      HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      @NonNull HttpServletRequest request,
+      @NonNull HttpServletResponse response,
+      @NonNull FilterChain filterChain)
       throws ServletException, IOException {
     // 헤더에서 토큰 추출 (토큰 내용만)
     String token = resolveToken(request);

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -25,23 +25,23 @@ public class SecurityConfig {
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 안 씀
         .headers(headers -> headers.frameOptions(frame -> frame.disable()))
         .authorizeHttpRequests(
-            auth ->
-                auth.requestMatchers("/h2-console/**")
-                    .permitAll()
-                    .requestMatchers(
-                        "/swagger-ui/**",
-                        "/swagger-ui.html",
-                        "/swagger-ui/index.html",
-                        "/api-docs/**",
-                        "/api-docs",
-                        "/api-docs/swagger-config",
-                        "/swagger-resources/**",
-                        "/webjars/**")
-                    .permitAll()
-                    .requestMatchers("/members/login")
-                    .permitAll() // 로그인은 인증 없이
-                    .anyRequest()
-                    .authenticated() // 나머지는 인증 필요
+            auth -> auth.anyRequest().permitAll()
+            //                auth.requestMatchers("/h2-console/**")
+            //                    .permitAll()
+            //                    .requestMatchers(
+            //                        "/swagger-ui/**",
+            //                        "/swagger-ui.html",
+            //                        "/swagger-ui/index.html",
+            //                        "/api-docs/**",
+            //                        "/api-docs",
+            //                        "/api-docs/swagger-config",
+            //                        "/swagger-resources/**",
+            //                        "/webjars/**")
+            //                    .permitAll()
+            //                    .requestMatchers("/members/login")
+            //                    .permitAll() // 로그인은 인증 없이
+            //                    .anyRequest()
+            //                    .authenticated() // 나머지는 인증 필요
             )
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SwaggerConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.typingpractice.typing_practice_be.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,6 +14,15 @@ public class SwaggerConfig {
   public OpenAPI openAPI() {
     return new OpenAPI()
         .info(
-            new Info().title("Typing Practice API").description("타이핑 연습 서비스 API").version("1.0.0"));
+            new Info().title("Typing Practice API").description("타이핑 연습 서비스 API").version("1.0.0"))
+        .addSecurityItem(new SecurityRequirement().addList("Bearer Authentication"))
+        .components(
+            new Components()
+                .addSecuritySchemes(
+                    "Bearer Authentication",
+                    new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")));
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
@@ -77,7 +77,7 @@ public class MemberController {
   private void validateAdmin(Long memberId) {
     Member member = memberService.findMemberById(memberId);
 
-    System.out.println(member.getRole());
+    // System.out.println(member.getRole());
 
     if (member.getRole() != MemberRole.ADMIN) {
       throw new ForbiddenException();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
@@ -1,0 +1,59 @@
+package com.typingpractice.typing_practice_be.quote.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.dto.QuoteCreateRequest;
+import com.typingpractice.typing_practice_be.quote.dto.QuoteResponse;
+import com.typingpractice.typing_practice_be.quote.dto.QuoteStatusRequest;
+import com.typingpractice.typing_practice_be.quote.service.QuoteService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+public class QuoteController {
+
+  private final QuoteService quoteService;
+
+  @GetMapping("/quotes")
+  public ApiResponse<List<QuoteResponse>> getQuotes() {
+    List<Quote> quotes = quoteService.findAll();
+
+    return ApiResponse.ok(quotes.stream().map(QuoteResponse::from).toList());
+  }
+
+  @GetMapping("/quotes/{quoteId}")
+  public ApiResponse<QuoteResponse> findQuoteById(@PathVariable Long quoteId) {
+    Quote quote = quoteService.findById(quoteId);
+
+    return ApiResponse.ok(QuoteResponse.from(quote));
+  }
+
+  @PostMapping("/quotes")
+  public ApiResponse<QuoteResponse> create(@RequestBody @Valid QuoteCreateRequest request) {
+    Long memberId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    Quote quote = quoteService.create(memberId, request);
+
+    return ApiResponse.ok(QuoteResponse.from(quote));
+  }
+
+  @PatchMapping("/quotes/{quoteId}")
+  public ApiResponse<QuoteResponse> updateStatus(
+      @PathVariable Long quoteId, @RequestBody @Valid QuoteStatusRequest request) {
+    Quote quote = quoteService.updateQuoteStatus(quoteId, request.getStatus());
+
+    return ApiResponse.ok(QuoteResponse.from(quote));
+  }
+
+  @DeleteMapping("/quotes/{quoteId}")
+  public ApiResponse<Void> deleteQuote(@PathVariable Long quoteId) {
+    quoteService.deleteQuote(quoteId);
+
+    return ApiResponse.ok(null);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -3,7 +3,9 @@ package com.typingpractice.typing_practice_be.quote.domain;
 import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 import org.springframework.data.annotation.CreatedDate;
@@ -15,7 +17,8 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @SQLRestriction("deleted = false")
-@SQLDelete(sql = "UPDATE quote SET deleted = true, delted_at = NOW() where quote_id = ?")
+@SQLDelete(sql = "UPDATE quote SET deleted = true, deleted_at = NOW() where quote_id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Quote extends BaseEntity {
   @Id
   @GeneratedValue
@@ -25,10 +28,28 @@ public class Quote extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private QuoteStatus status;
 
+  @Enumerated(EnumType.STRING)
+  private QuoteType type;
+
   private String sentence;
   private String author;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = true)
   private Member member;
+
+  public static Quote create(Member member, String sentence, String author, QuoteType type) {
+    Quote quote = new Quote();
+    quote.member = member;
+    quote.sentence = sentence;
+    quote.author = author;
+    quote.type = type;
+    quote.status = quote.type == QuoteType.PUBLIC ? QuoteStatus.PENDING : QuoteStatus.APPROVED;
+
+    return quote;
+  }
+
+  public void updateStatus(QuoteStatus quoteStatus) {
+    this.status = quoteStatus;
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/QuoteType.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/QuoteType.java
@@ -1,7 +1,6 @@
 package com.typingpractice.typing_practice_be.quote.domain;
 
-public enum QuoteStatus {
-  PENDING,
-  APPROVED,
-  REJECTED
+public enum QuoteType {
+  PUBLIC,
+  PRIVATE
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteCreateRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteCreateRequest.java
@@ -1,0 +1,29 @@
+package com.typingpractice.typing_practice_be.quote.dto;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.Getter;
+import lombok.ToString;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@ToString
+public class QuoteCreateRequest {
+  @NotEmpty
+  @Length(min = 10, max = 80)
+  private String sentence;
+
+  @Length(min = 1, max = 20)
+  private String author;
+
+  private QuoteType type = QuoteType.PUBLIC;
+
+  public static QuoteCreateRequest create(String sentence, String author, QuoteType type) {
+    QuoteCreateRequest request = new QuoteCreateRequest();
+    request.sentence = sentence;
+    request.author = author;
+    request.type = type;
+
+    return request;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteResponse.java
@@ -1,0 +1,34 @@
+package com.typingpractice.typing_practice_be.quote.dto;
+
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@ToString
+public class QuoteResponse {
+  private Long quoteId;
+  private String sentence;
+  private String author;
+  private QuoteStatus status;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+
+  public static QuoteResponse from(Quote quote) {
+    QuoteResponse response = new QuoteResponse();
+
+    response.quoteId = quote.getId();
+    response.sentence = quote.getSentence();
+    response.author = quote.getAuthor();
+    response.status = quote.getStatus();
+    response.createdAt = quote.getCreatedAt();
+    response.updatedAt = quote.getUpdatedAt();
+
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteStatusRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteStatusRequest.java
@@ -1,0 +1,11 @@
+package com.typingpractice.typing_practice_be.quote.dto;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class QuoteStatusRequest {
+  QuoteStatus status;
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/exception/QuoteNotFoundException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/exception/QuoteNotFoundException.java
@@ -1,0 +1,14 @@
+package com.typingpractice.typing_practice_be.quote.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+import lombok.Getter;
+
+@Getter
+public class QuoteNotFoundException extends RuntimeException {
+  private final ErrorCode errorCode;
+
+  public QuoteNotFoundException() {
+    super(ErrorCode.QUOTE_NOT_FOUND.getMessage());
+    this.errorCode = ErrorCode.QUOTE_NOT_FOUND;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
@@ -1,0 +1,38 @@
+package com.typingpractice.typing_practice_be.quote.repository;
+
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class QuoteRepository {
+  private final EntityManager em;
+
+  public void save(Quote quote) {
+    em.persist(quote);
+  }
+
+  public Optional<Quote> findById(Long quoteId) {
+    return Optional.ofNullable(em.find(Quote.class, quoteId));
+  }
+
+  public List<Quote> findAll() {
+    return em.createQuery("select q from Quote q", Quote.class).getResultList();
+  }
+
+  public List<Quote> findByStatus(QuoteStatus quoteStatus) {
+    return em.createQuery("select q from Quote q where q.status = :status", Quote.class)
+        .setParameter("status", quoteStatus)
+        .getResultList();
+  }
+
+  public void deleteQuote(Quote quote) {
+    em.remove(quote);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
@@ -1,0 +1,69 @@
+package com.typingpractice.typing_practice_be.quote.service;
+
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
+import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
+import com.typingpractice.typing_practice_be.quote.dto.QuoteCreateRequest;
+import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
+import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuoteService {
+  private final QuoteRepository quoteRepository;
+  private final MemberRepository memberRepository;
+
+  public List<Quote> findAll() {
+    List<Quote> all = quoteRepository.findAll();
+
+    return all;
+  }
+
+  public Quote findById(Long quoteId) {
+    return quoteRepository.findById(quoteId).orElseThrow(QuoteNotFoundException::new);
+  }
+
+  @Transactional
+  public Quote create(Long memberId, QuoteCreateRequest request) {
+    Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    Quote quote =
+        Quote.create(member, request.getSentence(), request.getAuthor(), request.getType());
+
+    quoteRepository.save(quote);
+
+    return quote;
+  }
+
+  public List<Quote> findQuoteByStatus(QuoteStatus quoteStatus) {
+    return quoteRepository.findByStatus(quoteStatus);
+  }
+
+  @Transactional
+  public Quote updateQuoteStatus(Long quoteId, QuoteStatus quoteStatus) {
+    Quote quote = quoteRepository.findById(quoteId).orElseThrow(QuoteNotFoundException::new);
+
+    quote.updateStatus(quoteStatus);
+
+    return quote;
+  }
+
+  @Transactional
+  public void deleteQuote(Long quoteId) {
+    Quote quote = quoteRepository.findById(quoteId).orElseThrow(QuoteNotFoundException::new);
+
+    if (quote.getType() != QuoteType.PRIVATE) {
+      throw new IllegalStateException("개인용 문장만 삭제 가능");
+    }
+
+    quoteRepository.deleteQuote(quote);
+  }
+}


### PR DESCRIPTION
## Quote 도메인 신규 추가
- Quote 엔티티: Member 연관관계, soft delete 적용
- QuoteStatus: PENDING, APPROVED, REJECTED (승인 워크플로우)
- QuoteType: PUBLIC(관리자 승인 필요), PRIVATE(즉시 승인)
- QuoteService: 생성, 조회, 상태변경, 삭제 기능
- QuoteController: REST API 엔드포인트
- QuoteRepository: 상태별 조회 메서드

## Security 설정 변경
- SecurityConfig: anyRequest().permitAll()로 임시 비활성화
- SwaggerConfig: JWT Bearer 인증 설정 추가 (Authorize 버튼)

## 기타
- ForbiddenException 추가 (member)
- ErrorCode, GlobalExceptionHandler Quote 관련 에러 처리 추가