### PR TITLE
refactor: 예외 처리 구조 개선 및 도메인별 ExceptionHandler 분리

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/BusinessException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/BusinessException.java
@@ -1,0 +1,13 @@
+package com.typingpractice.typing_practice_be.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public abstract class BusinessException extends RuntimeException {
+  protected ErrorCode errorCode;
+
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -10,8 +10,12 @@ public enum ErrorCode {
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
   DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
 
-  FORBIDDEN(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
-  QUOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예문을 찾을 수 없습니다.");
+  NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
+  QUOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예문을 찾을 수 없습니다."),
+  QUOTE_NOT_OWNED(HttpStatus.FORBIDDEN, "문장에 대한 권한이 없습니다."),
+  QUOTE_NOT_PROCESSABLE(HttpStatus.BAD_REQUEST, "처리할 수 없는 문장입니다."),
+
+  EMPTY_UPDATE_REQUEST(HttpStatus.BAD_REQUEST, "수정할 내용이 없습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/GlobalExceptionHandler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/GlobalExceptionHandler.java
@@ -1,8 +1,5 @@
 package com.typingpractice.typing_practice_be.common.exception;
 
-import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
-import com.typingpractice.typing_practice_be.member.exception.NotAdminException;
-import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -43,27 +40,5 @@ public class GlobalExceptionHandler {
     problemDetail.setTitle("Invalid Parameter Type");
 
     return problemDetail;
-  }
-
-  @ExceptionHandler(MemberNotFoundException.class)
-  public ProblemDetail handleMemberNotFoundException(MemberNotFoundException e) {
-
-    ErrorCode errorCode = e.getErrorCode();
-
-    return ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());
-  }
-
-  @ExceptionHandler(NotAdminException.class)
-  public ProblemDetail handleForbiddenException(NotAdminException e) {
-    ErrorCode errorCode = e.getErrorCode();
-
-    return ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());
-  }
-
-  @ExceptionHandler(QuoteNotFoundException.class)
-  public ProblemDetail handleQuoteNotFoundException(QuoteNotFoundException e) {
-    ErrorCode errorCode = e.getErrorCode();
-
-    return ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/DuplicateEmailException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/DuplicateEmailException.java
@@ -1,14 +1,10 @@
 package com.typingpractice.typing_practice_be.member.exception;
 
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
 import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
-import lombok.Getter;
 
-@Getter
-public class DuplicateEmailException extends RuntimeException {
-  private final ErrorCode errorCode;
-
+public class DuplicateEmailException extends BusinessException {
   public DuplicateEmailException() {
-    super(ErrorCode.DUPLICATE_EMAIL.getMessage());
-    this.errorCode = ErrorCode.DUPLICATE_EMAIL;
+    super(ErrorCode.DUPLICATE_EMAIL);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/MemberExceptionHandler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/MemberExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.typingpractice.typing_practice_be.member.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "com.typingpractice.typing_practice_be.member")
+public class MemberExceptionHandler {
+  @ExceptionHandler(BusinessException.class)
+  public ProblemDetail handleMemberException(BusinessException e) {
+    log.warn("[Member] {}: {}", e.getClass().getSimpleName(), e.getMessage());
+
+    ErrorCode errorCode = e.getErrorCode();
+    ProblemDetail pd =
+        ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());
+
+    pd.setTitle("Member Domain Error");
+
+    return pd;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/MemberNotFoundException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/MemberNotFoundException.java
@@ -1,14 +1,10 @@
 package com.typingpractice.typing_practice_be.member.exception;
 
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
 import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
-import lombok.Getter;
 
-@Getter
-public class MemberNotFoundException extends RuntimeException {
-  private final ErrorCode errorCode;
-
+public class MemberNotFoundException extends BusinessException {
   public MemberNotFoundException() {
-    super(ErrorCode.MEMBER_NOT_FOUND.getMessage());
-    this.errorCode = ErrorCode.MEMBER_NOT_FOUND;
+    super(ErrorCode.MEMBER_NOT_FOUND);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/NotAdminException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/NotAdminException.java
@@ -1,14 +1,10 @@
 package com.typingpractice.typing_practice_be.member.exception;
 
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
 import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
-import lombok.Getter;
 
-@Getter
-public class NotAdminException extends RuntimeException {
-  private final ErrorCode errorCode;
-
+public class NotAdminException extends BusinessException {
   public NotAdminException() {
-    super(ErrorCode.FORBIDDEN.getMessage());
-    this.errorCode = ErrorCode.FORBIDDEN;
+    super(ErrorCode.NOT_ADMIN);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
@@ -5,13 +5,13 @@ import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteCreateRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteResponse;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteUpdateRequest;
+import com.typingpractice.typing_practice_be.quote.exception.EmptyUpdateRequestException;
 import com.typingpractice.typing_practice_be.quote.service.QuoteService;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -64,7 +64,7 @@ public class QuoteController {
   public ApiResponse<QuoteResponse> updatePrivateQuote(
       @PathVariable Long quoteId, @RequestBody @Valid QuoteUpdateRequest request) {
     if (request.getSentence() == null && request.getAuthor() == null) {
-      throw new IllegalArgumentException("수정할 내용이 없습니다.");
+      throw new EmptyUpdateRequestException();
     }
 
     Long memberId = getMemberId();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -36,11 +36,13 @@ public class Quote extends BaseEntity {
   @JoinColumn(name = "member_id", nullable = true)
   private Member member;
 
+  public static final String DEFAULT_AUTHOR = "작자 미상";
+
   public static Quote create(Member member, String sentence, String author, QuoteType type) {
     Quote quote = new Quote();
     quote.member = member;
     quote.sentence = sentence;
-    quote.author = StringUtils.hasText(author) ? author : "작자 미상";
+    quote.author = StringUtils.hasText(author) ? author : DEFAULT_AUTHOR;
     quote.type = type;
     quote.reportCount = 0;
     quote.status = quote.type == QuoteType.PUBLIC ? QuoteStatus.PENDING : QuoteStatus.ACTIVE;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/exception/EmptyUpdateRequestException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/exception/EmptyUpdateRequestException.java
@@ -3,8 +3,8 @@ package com.typingpractice.typing_practice_be.quote.exception;
 import com.typingpractice.typing_practice_be.common.exception.BusinessException;
 import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
 
-public class QuoteNotFoundException extends BusinessException {
-  public QuoteNotFoundException() {
-    super(ErrorCode.QUOTE_NOT_FOUND);
+public class EmptyUpdateRequestException extends BusinessException {
+  public EmptyUpdateRequestException() {
+    super(ErrorCode.EMPTY_UPDATE_REQUEST);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/exception/QuoteExceptionHandler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/exception/QuoteExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.typingpractice.typing_practice_be.quote.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "com.typingpractice.typing_practice_be.quote")
+public class QuoteExceptionHandler {
+  @ExceptionHandler(BusinessException.class)
+  public ProblemDetail handleQuoteException(BusinessException e) {
+    log.warn("[Quote] {}: {}", e.getClass().getSimpleName(), e.getMessage());
+
+    ErrorCode errorCode = e.getErrorCode();
+    ProblemDetail pd =
+        ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());
+
+    pd.setTitle("Quote Domain Error");
+
+    return pd;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/exception/QuoteNotOwnedException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/exception/QuoteNotOwnedException.java
@@ -3,8 +3,9 @@ package com.typingpractice.typing_practice_be.quote.exception;
 import com.typingpractice.typing_practice_be.common.exception.BusinessException;
 import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
 
-public class QuoteNotFoundException extends BusinessException {
-  public QuoteNotFoundException() {
-    super(ErrorCode.QUOTE_NOT_FOUND);
+public class QuoteNotOwnedException extends BusinessException {
+
+  public QuoteNotOwnedException() {
+    super(ErrorCode.QUOTE_NOT_OWNED);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/exception/QuoteNotProcessableException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/exception/QuoteNotProcessableException.java
@@ -3,8 +3,8 @@ package com.typingpractice.typing_practice_be.quote.exception;
 import com.typingpractice.typing_practice_be.common.exception.BusinessException;
 import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
 
-public class QuoteNotFoundException extends BusinessException {
-  public QuoteNotFoundException() {
-    super(ErrorCode.QUOTE_NOT_FOUND);
+public class QuoteNotProcessableException extends BusinessException {
+  public QuoteNotProcessableException() {
+    super(ErrorCode.QUOTE_NOT_PROCESSABLE);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
@@ -3,9 +3,11 @@ package com.typingpractice.typing_practice_be.quote.service;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AdminQuoteService {
   private final QuoteRepository quoteRepository;
 }


### PR DESCRIPTION
예외 클래스들을 BusinessException 기반으로 통일하고,
도메인별 ExceptionHandler를 분리하여 로깅 및 관리 용이하게 변경.

## 공통 예외 구조
- BusinessException 추가 (공통 부모 클래스)
- 모든 도메인 예외가 BusinessException 상속
- GlobalExceptionHandler는 공통 예외만 처리 (Validation, TypeMismatch)

## 도메인별 ExceptionHandler 분리
- QuoteExceptionHandler: Quote 도메인 예외 처리 + 로깅
- MemberExceptionHandler: Member 도메인 예외 처리 + 로깅

## Quote 예외 클래스 추가
- QuoteNotOwnedException: 본인 문장이 아닐 때
- QuoteNotProcessableException: 처리할 수 없는 상태일 때
- EmptyUpdateRequestException: 수정 내용 없을 때

## 기타
- Quote.DEFAULT_AUTHOR 상수 추가 ("작자 미상")
- QuoteService 불필요한 주석 제거
- ErrorCode에 NOT_ADMIN 추가