### PR TITLE
feat: 어드민 Quote API 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
@@ -1,10 +1,15 @@
 package com.typingpractice.typing_practice_be.quote.controller;
 
+import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.domain.MemberRole;
 import com.typingpractice.typing_practice_be.member.exception.NotAdminException;
 import com.typingpractice.typing_practice_be.member.service.MemberService;
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.dto.QuoteResponse;
+import com.typingpractice.typing_practice_be.quote.dto.QuoteUpdateRequest;
 import com.typingpractice.typing_practice_be.quote.service.AdminQuoteService;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -26,43 +31,72 @@ public class AdminQuoteController {
 
   // 승인 대기 목록 조회
   @GetMapping("/admin/quotes/pending")
-  public void getPendingQuotes() {
+  public ApiResponse<List<QuoteResponse>> getPendingQuotes() {
     validateAdmin();
+
+    List<Quote> pendingQuotes = adminQuoteService.findPendingQuotes();
+
+    return ApiResponse.ok(pendingQuotes.stream().map(QuoteResponse::from).toList());
   }
 
   // 승인
   @PostMapping("/admin/quotes/{quoteId}/approve")
-  public void approvePendingQuote(@PathVariable Long quoteId) {
+  public ApiResponse<QuoteResponse> approvePendingQuote(@PathVariable Long quoteId) {
     validateAdmin();
+
+    Quote quote = adminQuoteService.approvePublish(quoteId);
+
+    return ApiResponse.ok(QuoteResponse.from(quote));
   }
 
   // 거부
   @PostMapping("/admin/quotes/{quoteId}/reject")
-  public void rejectPendingQuote(@PathVariable Long quoteId) {
+  public ApiResponse<QuoteResponse> rejectPendingQuote(@PathVariable Long quoteId) {
     validateAdmin();
+
+    Quote quote = adminQuoteService.rejectPublish(quoteId);
+
+    return ApiResponse.ok(QuoteResponse.from(quote));
   }
 
   // 공개 문장 수정
   @PatchMapping("/admin/quotes/{quoteId}")
-  public void patchQuote(@PathVariable Long quoteId) {
+  public ApiResponse<QuoteResponse> patchQuote(
+      @PathVariable Long quoteId, @RequestBody QuoteUpdateRequest request) {
     validateAdmin();
+
+    Quote quote = adminQuoteService.updateQuote(quoteId, request);
+
+    return ApiResponse.ok(QuoteResponse.from(quote));
   }
 
   // 삭제
   @DeleteMapping("/admin/quotes/{quoteId}")
-  public void deleteQuote(@PathVariable Long quoteId) {
+  public ApiResponse<Void> deleteQuote(@PathVariable Long quoteId) {
     validateAdmin();
+
+    adminQuoteService.deleteQuote(quoteId);
+
+    return ApiResponse.ok(null);
   }
 
   // 숨김 목록
   @GetMapping("/admin/quotes/hidden")
-  public void getHiddenQuotes() {
+  public ApiResponse<List<QuoteResponse>> getHiddenQuotes() {
     validateAdmin();
+
+    List<Quote> hiddenQuotes = adminQuoteService.findHiddenQuotes();
+
+    return ApiResponse.ok(hiddenQuotes.stream().map(QuoteResponse::from).toList());
   }
 
   // 숨김 해제
   @PostMapping("/admin/quotes/{quoteId}/restore")
-  public void restoreHiddenQuotes(@PathVariable Long quoteId) {
+  public ApiResponse<QuoteResponse> restoreHiddenQuotes(@PathVariable Long quoteId) {
     validateAdmin();
+
+    Quote quote = adminQuoteService.cancelHidden(quoteId);
+
+    return ApiResponse.ok(QuoteResponse.from(quote));
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -50,6 +50,26 @@ public class Quote extends BaseEntity {
     return quote;
   }
 
+  public void approvePublish() {
+    this.type = QuoteType.PUBLIC;
+    this.status = QuoteStatus.ACTIVE;
+  }
+
+  public void rejectPublish() {
+    this.type = QuoteType.PRIVATE;
+    this.status = QuoteStatus.ACTIVE;
+  }
+
+  public void update(String sentence, String author) {
+    if (sentence != null) {
+      this.sentence = sentence;
+    }
+
+    if (author != null) {
+      this.author = StringUtils.hasText(author) ? author : DEFAULT_AUTHOR;
+    }
+  }
+
   public void updateSentence(String sentence) {
     this.sentence = sentence;
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
@@ -16,7 +16,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -54,15 +53,7 @@ public class QuoteService {
       throw new QuoteNotProcessableException();
     }
 
-    if (request.getAuthor() != null) {
-      String author =
-          StringUtils.hasText(request.getAuthor()) ? request.getAuthor() : Quote.DEFAULT_AUTHOR;
-      quote.updateAuthor(author);
-    }
-
-    if (request.getSentence() != null) {
-      quote.updateSentence(request.getSentence());
-    }
+    quote.update(request.getSentence(), request.getAuthor());
 
     return quote;
   }


### PR DESCRIPTION
어드민용 문장 관리 API 로직 구현 완료.

## AdminQuoteController
- GET /admin/quotes/pending: 승인 대기 목록 조회
- POST /admin/quotes/{id}/approve: 공개 승인
- POST /admin/quotes/{id}/reject: 공개 거부
- PATCH /admin/quotes/{id}: 공개 문장 수정
- DELETE /admin/quotes/{id}: 문장 삭제
- GET /admin/quotes/hidden: 숨김 목록 조회
- POST /admin/quotes/{id}/restore: 숨김 해제

## AdminQuoteService
- findPendingQuotes: PENDING 상태 목록 조회
- findHiddenQuotes: HIDDEN 상태 목록 조회
- approvePublish: PUBLIC/PENDING → PUBLIC/ACTIVE
- rejectPublish: PUBLIC/PENDING → PRIVATE/ACTIVE
- updateQuote: PUBLIC 문장 수정 (PENDING, ACTIVE, HIDDEN 모두 가능)
- deleteQuote: 문장 삭제
- cancelHidden: HIDDEN → ACTIVE

## Quote 엔티티
- approvePublish(), rejectPublish() 메서드 추가
- update() 공통 수정 메서드 추가

## 기타
- QuoteService.updatePrivateQuote()에서 update() 메서드 사용
- 불필요한 QuoteService 의존성 제거