### PR TITLE
feat: PostgreSQL 전환 및 Report 도메인 기초 구현

### DIFF
--- a/typing-practice-be/build.gradle
+++ b/typing-practice-be/build.gradle
@@ -37,10 +37,11 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
-    runtimeOnly 'com.h2database:h2'
+//    runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
+    runtimeOnly 'org.postgresql:postgresql'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/typing-practice-be/docker-compose.yaml
+++ b/typing-practice-be/docker-compose.yaml
@@ -1,0 +1,15 @@
+services:
+  postgres:
+    image: postgres:16
+    restart: always
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: user
+      POSTGRES_DB: typing
+
+volumes:
+  postgres-data:

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -23,12 +23,9 @@ public class SecurityConfig {
     http.csrf(AbstractHttpConfigurer::disable)
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 안 씀
-        .headers(headers -> headers.frameOptions(frame -> frame.disable()))
         .authorizeHttpRequests(
             auth -> auth.anyRequest().permitAll()
-            //                auth.requestMatchers("/h2-console/**")
-            //                    .permitAll()
-            //                    .requestMatchers(
+            //                auth.requestMatchers(
             //                        "/swagger-ui/**",
             //                        "/swagger-ui.html",
             //                        "/swagger-ui/index.html",
@@ -47,19 +44,4 @@ public class SecurityConfig {
 
     return http.build();
   }
-
-  //  @Bean
-  //  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-  //    http.csrf(csrf -> csrf.disable())
-  //        .headers(headers -> headers.frameOptions(frame -> frame.disable()))
-  //        .authorizeHttpRequests(
-  //            auth ->
-  //                auth.requestMatchers("/h2-console/**")
-  //                    .permitAll()
-  //                    .anyRequest()
-  //                    .permitAll() // 일단 전체 허용, 나중에 수정
-  //            );
-  //
-  //    return http.build();
-  //  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/Member.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/Member.java
@@ -1,14 +1,13 @@
 package com.typingpractice.typing_practice_be.member.domain;
 
 import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import com.typingpractice.typing_practice_be.report.domain.Report;
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.Getter;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Getter
@@ -27,6 +26,9 @@ public class Member extends BaseEntity {
 
   @Enumerated(EnumType.STRING)
   private MemberRole role;
+
+  @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
+  private List<Report> reports = new ArrayList<>();
 
   public static Member createMember(String email, String password, String nickname) {
     Member member = new Member();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -2,7 +2,10 @@ package com.typingpractice.typing_practice_be.quote.domain;
 
 import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
 import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.report.domain.Report;
 import jakarta.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -35,6 +38,9 @@ public class Quote extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id", nullable = true)
   private Member member;
+
+  @OneToMany(mappedBy = "quote", cascade = CascadeType.REMOVE)
+  private List<Report> reports = new ArrayList<>();
 
   public static final String DEFAULT_AUTHOR = "작자 미상";
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/domain/Report.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/domain/Report.java
@@ -1,0 +1,55 @@
+package com.typingpractice.typing_practice_be.report.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@SQLRestriction("deleted = false")
+@SQLDelete(sql = "UPDATE report SET deleted = true, deleted_at = NOW() where report_id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Report extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "report_id")
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  private ReportStatus status; // 처리 상태
+
+  @Enumerated(EnumType.STRING)
+  private ReportReason reason; // 사유: 수정, 삭제
+
+  private String detail; // 상세 사유
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "quote_id")
+  private Quote quote;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  public static Report create(Member member, Quote quote, ReportReason reason, String detail) {
+    Report report = new Report();
+    report.status = ReportStatus.PENDING;
+    report.reason = reason;
+    report.detail = detail;
+
+    report.quote = quote;
+    report.member = member;
+
+    return report;
+  }
+
+  public void updateStatus(ReportStatus status) {
+    this.status = status;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/domain/ReportReason.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/domain/ReportReason.java
@@ -1,0 +1,6 @@
+package com.typingpractice.typing_practice_be.report.domain;
+
+public enum ReportReason {
+  MODIFY,
+  DELETE
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/domain/ReportStatus.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/domain/ReportStatus.java
@@ -1,0 +1,6 @@
+package com.typingpractice.typing_practice_be.report.domain;
+
+public enum ReportStatus {
+  PENDING,
+  PROCESSED
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/repository/ReportRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/repository/ReportRepository.java
@@ -1,0 +1,84 @@
+package com.typingpractice.typing_practice_be.report.repository;
+
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.report.domain.Report;
+import com.typingpractice.typing_practice_be.report.domain.ReportStatus;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportRepository {
+  private final EntityManager em;
+
+  public Report save(Report report) {
+    em.persist(report);
+
+    return report;
+  }
+
+  public List<Report> findAll(ReportStatus status) {
+    //    return em.createQuery("select r from Report r where r.status = :status", Report.class)
+    //        .setParameter("status", status)
+    //        .getResultList();
+
+    String jpql = "select r from Report r";
+
+    if (status != null) {
+      jpql += " where r.status = :status";
+    }
+
+    TypedQuery<Report> query = em.createQuery(jpql, Report.class);
+
+    if (status != null) {
+      query.setParameter("status", status);
+    }
+
+    return query.getResultList();
+  }
+
+  public Optional<Report> findById(Long reportId) {
+    return Optional.ofNullable(em.find(Report.class, reportId));
+  }
+
+  public List<Report> findByQuote(Quote quote) {
+    return em.createQuery(
+            "select r from Report r join r.quote q where q.id = :quoteId", Report.class)
+        .setParameter("quoteId", quote.getId())
+        .getResultList();
+  }
+
+  public void processReportByQuote(Quote quote) {
+    // quote 에 해당하는 모든 신고내역 처리
+    em.createQuery(
+            "update Report r set r.status = :status, r.updatedAt = :updatedAt where r.quote.id = :quoteId")
+        .setParameter("status", ReportStatus.PROCESSED)
+        .setParameter("updatedAt", LocalDateTime.now())
+        .setParameter("quoteId", quote.getId())
+        .executeUpdate();
+  }
+
+  public boolean existsByQuoteAndMember(Quote quote, Member member) {
+    List<Report> resultList =
+        em.createQuery(
+                "select r from Report r join r.quote q join r.member m where q.id = :quoteId and m.id = :memberId",
+                Report.class)
+            .setParameter("quoteId", quote.getId())
+            .setParameter("memberId", member.getId())
+            .setMaxResults(1)
+            .getResultList();
+
+    return !resultList.isEmpty();
+  }
+
+  public void delete(Report report) {
+    em.remove(report);
+  }
+}


### PR DESCRIPTION
H2에서 PostgreSQL로 데이터베이스 전환하고,
Report 도메인 엔티티 및 Repository 구현.

## PostgreSQL 전환
- docker-compose.yaml 추가 (PostgreSQL 16)
- build.gradle에 PostgreSQL 의존성 추가, H2 주석처리

## Report 도메인
- Report 엔티티: 신고 정보 관리
- ReportReason enum: MODIFY, DELETE
- ReportStatus enum: PENDING, PROCESSED
- ReportRepository: 기본 CRUD 및 벌크 업데이트

## ReportRepository 메서드
- save: 신고 저장
- findAll: 전체/상태별 조회
- findById: 단건 조회
- findByQuote: Quote별 신고 목록
- existsByQuoteAndMember: 중복 신고 체크
- processReportByQuote: 벌크 상태 업데이트

## 연관관계 설정
- Member, Quote에 Report cascade 추가