### PR TITLE
feat: Report 도메인 서비스 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -15,7 +15,12 @@ public enum ErrorCode {
   QUOTE_NOT_OWNED(HttpStatus.FORBIDDEN, "문장에 대한 권한이 없습니다."),
   QUOTE_NOT_PROCESSABLE(HttpStatus.BAD_REQUEST, "처리할 수 없는 문장입니다."),
 
-  EMPTY_UPDATE_REQUEST(HttpStatus.BAD_REQUEST, "수정할 내용이 없습니다.");
+  EMPTY_UPDATE_REQUEST(HttpStatus.BAD_REQUEST, "수정할 내용이 없습니다."),
+
+  REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "신고 내역을 찾을 수 없습니다."),
+  DUPLICATE_REPORT(HttpStatus.BAD_REQUEST, "중복된 신고 내역이 존재합니다."),
+  QUOTE_NOT_REPORTABLE(HttpStatus.BAD_REQUEST, "신고 불가능한 문장입니다."),
+  REPORT_NOT_PROCESSABLE(HttpStatus.BAD_REQUEST, "처리할 수 없는 신고 내역입니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -43,6 +43,7 @@ public class Quote extends BaseEntity {
   private List<Report> reports = new ArrayList<>();
 
   public static final String DEFAULT_AUTHOR = "작자 미상";
+  public static final int HIDDEN_THRESHOLD = 5; // 자동 숨김 기준값
 
   public static Quote create(Member member, String sentence, String author, QuoteType type) {
     Quote quote = new Quote();
@@ -90,5 +91,17 @@ public class Quote extends BaseEntity {
 
   public void updateStatus(QuoteStatus quoteStatus) {
     this.status = quoteStatus;
+  }
+
+  public void increaseReportCount() {
+    this.reportCount++;
+  }
+
+  public void resetReportCount() {
+    this.reportCount = 0;
+  }
+
+  public boolean shouldBeHidden() {
+    return this.reportCount >= Quote.HIDDEN_THRESHOLD;
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportCreateRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportCreateRequest.java
@@ -1,0 +1,23 @@
+package com.typingpractice.typing_practice_be.report.dto;
+
+import com.typingpractice.typing_practice_be.report.domain.ReportReason;
+import lombok.Getter;
+import lombok.ToString;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@ToString
+public class ReportCreateRequest {
+  private ReportReason reason;
+
+  @Length(min = 1, max = 200)
+  private String detail;
+
+  public static ReportCreateRequest create(ReportReason reason, String detail) {
+    ReportCreateRequest request = new ReportCreateRequest();
+    request.reason = reason;
+    request.detail = detail;
+
+    return request;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportProcessRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportProcessRequest.java
@@ -1,0 +1,23 @@
+package com.typingpractice.typing_practice_be.report.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@ToString
+public class ReportProcessRequest {
+  @Length(min = 5, max = 100)
+  private String sentence;
+
+  @Length(min = 1, max = 20)
+  private String author;
+
+  public static ReportProcessRequest create(String sentence, String author) {
+    ReportProcessRequest request = new ReportProcessRequest();
+    request.sentence = sentence;
+    request.author = author;
+
+    return request;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportRequest.java
@@ -1,0 +1,18 @@
+package com.typingpractice.typing_practice_be.report.dto;
+
+import com.typingpractice.typing_practice_be.report.domain.ReportStatus;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ReportRequest {
+  private ReportStatus status;
+
+  public static ReportRequest create(ReportStatus status) {
+    ReportRequest request = new ReportRequest();
+    request.status = status;
+
+    return request;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportResponse.java
@@ -1,0 +1,24 @@
+package com.typingpractice.typing_practice_be.report.dto;
+
+import com.typingpractice.typing_practice_be.report.domain.Report;
+import com.typingpractice.typing_practice_be.report.domain.ReportReason;
+import com.typingpractice.typing_practice_be.report.domain.ReportStatus;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ReportResponse {
+  private ReportReason reason;
+  private ReportStatus status;
+  private String detail;
+
+  public static ReportResponse from(Report report) {
+    ReportResponse response = new ReportResponse();
+    response.reason = report.getReason();
+    response.status = report.getStatus();
+    response.detail = report.getDetail();
+
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/exception/DuplicateReportException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/exception/DuplicateReportException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.report.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class DuplicateReportException extends BusinessException {
+  public DuplicateReportException() {
+    super(ErrorCode.DUPLICATE_REPORT);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/exception/QuoteNotReportableException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/exception/QuoteNotReportableException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.report.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class QuoteNotReportableException extends BusinessException {
+  public QuoteNotReportableException() {
+    super(ErrorCode.QUOTE_NOT_REPORTABLE);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/exception/ReportExceptionHandler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/exception/ReportExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.typingpractice.typing_practice_be.report.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ReportExceptionHandler {
+  @ExceptionHandler(BusinessException.class)
+  public ProblemDetail handleReportException(BusinessException e) {
+    log.warn("[Report] {}: {}", e.getClass().getSimpleName(), e.getMessage());
+
+    ErrorCode errorCode = e.getErrorCode();
+    ProblemDetail pd =
+        ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());
+
+    pd.setTitle("Report Domain Error");
+
+    return pd;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/exception/ReportNotFoundException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/exception/ReportNotFoundException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.report.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class ReportNotFoundException extends BusinessException {
+  public ReportNotFoundException() {
+    super(ErrorCode.REPORT_NOT_FOUND);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/exception/ReportNotProcessableException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/exception/ReportNotProcessableException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.report.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class ReportNotProcessableException extends BusinessException {
+  public ReportNotProcessableException() {
+    super(ErrorCode.REPORT_NOT_PROCESSABLE);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/repository/ReportRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/repository/ReportRepository.java
@@ -4,6 +4,7 @@ import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.domain.ReportStatus;
+import com.typingpractice.typing_practice_be.report.dto.ReportRequest;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import lombok.RequiredArgsConstructor;
@@ -24,21 +25,21 @@ public class ReportRepository {
     return report;
   }
 
-  public List<Report> findAll(ReportStatus status) {
+  public List<Report> findAll(ReportRequest request) {
     //    return em.createQuery("select r from Report r where r.status = :status", Report.class)
     //        .setParameter("status", status)
     //        .getResultList();
 
     String jpql = "select r from Report r";
 
-    if (status != null) {
+    if (request.getStatus() != null) {
       jpql += " where r.status = :status";
     }
 
     TypedQuery<Report> query = em.createQuery(jpql, Report.class);
 
-    if (status != null) {
-      query.setParameter("status", status);
+    if (request.getStatus() != null) {
+      query.setParameter("status", request.getStatus());
     }
 
     return query.getResultList();
@@ -46,6 +47,12 @@ public class ReportRepository {
 
   public Optional<Report> findById(Long reportId) {
     return Optional.ofNullable(em.find(Report.class, reportId));
+  }
+
+  public List<Report> findMyReports(Member member) {
+    return em.createQuery("select r from Report r where r.member.id = :memberId", Report.class)
+        .setParameter("memberId", member.getId())
+        .getResultList();
   }
 
   public List<Report> findByQuote(Quote quote) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/service/AdminReportService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/service/AdminReportService.java
@@ -1,0 +1,52 @@
+package com.typingpractice.typing_practice_be.report.service;
+
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
+import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
+import com.typingpractice.typing_practice_be.report.domain.Report;
+import com.typingpractice.typing_practice_be.report.dto.ReportProcessRequest;
+import com.typingpractice.typing_practice_be.report.dto.ReportRequest;
+import com.typingpractice.typing_practice_be.report.exception.ReportNotFoundException;
+import com.typingpractice.typing_practice_be.report.repository.ReportRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminReportService {
+  private final QuoteRepository quoteRepository;
+  private final ReportRepository reportRepository;
+
+  public List<Report> findReports(ReportRequest request) {
+    List<Report> all = reportRepository.findAll(request);
+
+    return all;
+  }
+
+  @Transactional
+  public void processReport(Long quoteId, ReportProcessRequest request) {
+    Quote targetQuote = quoteRepository.findById(quoteId).orElseThrow(QuoteNotFoundException::new);
+
+    // DTO 에 값이 없으면 삭제
+    if (request.getSentence() == null && request.getAuthor() == null) {
+      quoteRepository.deleteQuote(targetQuote);
+
+    } else {
+      // DTO 에 값이 있으면 수정
+      targetQuote.update(request.getSentence(), request.getAuthor());
+      targetQuote.resetReportCount();
+
+      reportRepository.processReportByQuote(targetQuote);
+    }
+  }
+
+  @Transactional
+  public void deleteReport(Long reportId) {
+    Report report = reportRepository.findById(reportId).orElseThrow(ReportNotFoundException::new);
+
+    reportRepository.delete(report);
+  }
+}


### PR DESCRIPTION
사용자/어드민 신고 서비스 및 예외 처리 구현.

## ReportService (사용자)
- createReport: 신고 생성 (PUBLIC/ACTIVE 체크, 중복 체크, 5회 자동 HIDDEN)
- findMyReports: 내 신고 내역 조회
- deleteReport: 본인 신고 삭제

## AdminReportService (어드민)
- findReports: 신고 목록 조회 (상태 필터링)
- processReport: 신고 처리 (문장 수정/삭제 + 신고 내역 일괄 처리)
- deleteReport: 신고 삭제

## 예외 클래스
- ReportNotFoundException
- ReportNotProcessableException
- DuplicateReportException
- QuoteNotReportableException
- ReportExceptionHandler

## Quote 엔티티 메서드 추가
- increaseReportCount()
- resetReportCount()
- shouldBeHidden()