### PR TITLE
feat: Report 컨트롤러 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/AdminReportController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/AdminReportController.java
@@ -1,0 +1,63 @@
+package com.typingpractice.typing_practice_be.report.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.member.domain.MemberRole;
+import com.typingpractice.typing_practice_be.member.exception.NotAdminException;
+import com.typingpractice.typing_practice_be.member.service.MemberService;
+import com.typingpractice.typing_practice_be.report.domain.Report;
+import com.typingpractice.typing_practice_be.report.dto.ReportProcessRequest;
+import com.typingpractice.typing_practice_be.report.dto.ReportRequest;
+import com.typingpractice.typing_practice_be.report.dto.ReportResponse;
+import com.typingpractice.typing_practice_be.report.service.AdminReportService;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminReportController {
+  private final MemberService memberService;
+  private final AdminReportService adminReportService;
+
+  private void validateAdmin() {
+    Long memberId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    Member member = memberService.findMemberById(memberId);
+
+    if (member.getRole() != MemberRole.ADMIN) {
+      throw new NotAdminException();
+    }
+  }
+
+  @GetMapping("/admin/reports")
+  public ApiResponse<List<ReportResponse>> getReports(
+      @ModelAttribute @Valid ReportRequest request) {
+    validateAdmin();
+
+    List<Report> reports = adminReportService.findReports(request);
+
+    return ApiResponse.ok(reports.stream().map(ReportResponse::from).toList());
+  }
+
+  @PostMapping("/admin/reports/{quoteId}/process")
+  public ApiResponse<Void> processReport(
+      @PathVariable Long quoteId, @RequestBody @Valid ReportProcessRequest request) {
+    validateAdmin();
+
+    adminReportService.processReport(quoteId, request);
+
+    return ApiResponse.ok(null);
+  }
+
+  @DeleteMapping("/admin/reports/{reportId}")
+  public ApiResponse<Void> deleteReport(@PathVariable Long reportId) {
+    validateAdmin();
+
+    adminReportService.deleteReport(reportId);
+
+    return ApiResponse.ok(null);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/ReportController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/ReportController.java
@@ -1,0 +1,50 @@
+package com.typingpractice.typing_practice_be.report.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.report.domain.Report;
+import com.typingpractice.typing_practice_be.report.dto.ReportCreateRequest;
+import com.typingpractice.typing_practice_be.report.dto.ReportResponse;
+import com.typingpractice.typing_practice_be.report.service.ReportService;
+import java.util.List;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class ReportController {
+  private final ReportService reportService;
+
+  private Long getMemberId() {
+    return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+  }
+
+  @PostMapping("/reports")
+  public ApiResponse<ReportResponse> reportQuote(@RequestBody @Valid ReportCreateRequest request) {
+    Long memberId = getMemberId();
+
+    Report report = reportService.createReport(memberId, request.getQuoteId(), request);
+
+    return ApiResponse.ok(ReportResponse.from(report));
+  }
+
+  @GetMapping("/reports/my")
+  public ApiResponse<List<ReportResponse>> getMyReports() {
+    Long memberId = getMemberId();
+
+    List<Report> myReports = reportService.findMyReports(memberId);
+
+    return ApiResponse.ok(myReports.stream().map(ReportResponse::from).toList());
+  }
+
+  @DeleteMapping("/reports/{reportId}")
+  public ApiResponse<Void> deleteMyReport(@PathVariable Long reportId) {
+    Long memberId = getMemberId();
+
+    reportService.deleteReport(memberId, reportId);
+
+    return ApiResponse.ok(null);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportCreateRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportCreateRequest.java
@@ -1,6 +1,8 @@
 package com.typingpractice.typing_practice_be.report.dto;
 
 import com.typingpractice.typing_practice_be.report.domain.ReportReason;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.ToString;
 import org.hibernate.validator.constraints.Length;
@@ -8,13 +10,19 @@ import org.hibernate.validator.constraints.Length;
 @Getter
 @ToString
 public class ReportCreateRequest {
+  @NotNull(message = "신고 대상 오류")
+  @Positive(message = "신고 대상 오류")
+  private Long quoteId;
+
+  @NotNull(message = "신고 사유 오류")
   private ReportReason reason;
 
   @Length(min = 1, max = 200)
   private String detail;
 
-  public static ReportCreateRequest create(ReportReason reason, String detail) {
+  public static ReportCreateRequest create(Long quoteId, ReportReason reason, String detail) {
     ReportCreateRequest request = new ReportCreateRequest();
+    request.quoteId = quoteId;
     request.reason = reason;
     request.detail = detail;
 


### PR DESCRIPTION
사용자/어드민 신고 API 구현.

## ReportController (사용자)
- POST /reports: 문장 신고
- GET /reports/my: 내 신고 내역 조회
- DELETE /reports/{reportId}: 신고 삭제

## AdminReportController (어드민)
- GET /admin/reports: 신고 목록 조회 (상태 필터링)
- POST /admin/reports/{quoteId}/process: 신고 처리 (문장 수정/삭제)
- DELETE /admin/reports/{reportId}: 신고 삭제

## DTO
- ReportCreateRequest: quoteId, reason, detail (validation 적용)
- ReportResponse: 신고 응답
- ReportProcessRequest: 신고 처리 요청
- ReportRequest: 목록 조회 필터