### PR TITLE
feat: AdminMember 회원 관리 기능 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
   DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
+  MEMBER_NOT_PROCESSABLE(HttpStatus.BAD_REQUEST, "처리할 수 없는 회원입니다."),
 
   NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
   QUOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예문을 찾을 수 없습니다."),

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/AdminMemberController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/AdminMemberController.java
@@ -3,9 +3,7 @@ package com.typingpractice.typing_practice_be.member.controller;
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.domain.MemberRole;
-import com.typingpractice.typing_practice_be.member.dto.MemberListResponse;
-import com.typingpractice.typing_practice_be.member.dto.MemberPaginationRequest;
-import com.typingpractice.typing_practice_be.member.dto.MemberResponseDto;
+import com.typingpractice.typing_practice_be.member.dto.*;
 import com.typingpractice.typing_practice_be.member.exception.NotAdminException;
 import com.typingpractice.typing_practice_be.member.service.AdminMemberService;
 import com.typingpractice.typing_practice_be.member.service.MemberService;
@@ -48,8 +46,40 @@ public class AdminMemberController {
   }
 
   @GetMapping("/admin/members/{memberId}")
-  public void findMemberById(@PathVariable Long memberId) {}
+  public ApiResponse<MemberResponseDto> findMemberById(@PathVariable Long memberId) {
+    validateAdmin();
+
+    Member member = adminMemberService.findMemberById(memberId);
+
+    return ApiResponse.ok(MemberResponseDto.from(member));
+  }
 
   @PatchMapping("/admin/members/{memberId}/role")
-  public void updateMemberRole(@PathVariable Long memberId) {}
+  public ApiResponse<MemberResponseDto> updateMemberRole(
+      @PathVariable Long memberId, @RequestBody UpdateMemberRoleRequest request) {
+    validateAdmin();
+
+    Member member = adminMemberService.updateRole(memberId, request.getRole());
+
+    return ApiResponse.ok(MemberResponseDto.from(member));
+  }
+
+  @PostMapping("/admin/members/{memberId}/ban")
+  public ApiResponse<MemberResponseDto> banMember(
+      @PathVariable Long memberId, @RequestBody BanMemberRequest request) {
+    validateAdmin();
+
+    Member member = adminMemberService.banMember(memberId, request);
+
+    return ApiResponse.ok(MemberResponseDto.from(member));
+  }
+
+  @PostMapping("/admin/members/{memberId}/unban")
+  public ApiResponse<MemberResponseDto> unbanMember(@PathVariable Long memberId) {
+    validateAdmin();
+
+    Member member = adminMemberService.unbanMember(memberId);
+
+    return ApiResponse.ok(MemberResponseDto.from(member));
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/Member.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/Member.java
@@ -1,6 +1,5 @@
 package com.typingpractice.typing_practice_be.member.domain;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import jakarta.persistence.*;
@@ -53,7 +52,10 @@ public class Member extends BaseEntity {
 
   public void ban(String reason) {
     this.role = MemberRole.BANNED;
-    this.banReason = reason;
+
+    if (reason != null) {
+      this.banReason = reason;
+    }
   }
 
   public void unban() {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/BanMemberRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/BanMemberRequest.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.member.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class BanMemberRequest {
+  private String banReason;
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/UpdateMemberRoleRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/UpdateMemberRoleRequest.java
@@ -1,0 +1,13 @@
+package com.typingpractice.typing_practice_be.member.dto;
+
+import com.typingpractice.typing_practice_be.member.domain.MemberRole;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class UpdateMemberRoleRequest {
+  @NotNull(message = "필수값 누락")
+  private MemberRole role;
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/MemberNotProcessableException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/MemberNotProcessableException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.member.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class MemberNotProcessableException extends BusinessException {
+  public MemberNotProcessableException() {
+    super(ErrorCode.MEMBER_NOT_PROCESSABLE);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/AdminMemberService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/AdminMemberService.java
@@ -2,15 +2,19 @@ package com.typingpractice.typing_practice_be.member.service;
 
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.domain.MemberRole;
+import com.typingpractice.typing_practice_be.member.dto.BanMemberRequest;
 import com.typingpractice.typing_practice_be.member.dto.MemberPaginationRequest;
 import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
+import com.typingpractice.typing_practice_be.member.exception.MemberNotProcessableException;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class AdminMemberService {
   private final MemberRepository memberRepository;
 
@@ -20,10 +24,41 @@ public class AdminMemberService {
     return members;
   }
 
+  public Member findMemberById(Long memberId) {
+    return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+  }
+
+  @Transactional
   public Member updateRole(Long memberId, MemberRole role) {
     Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
+    if (member.getRole() == MemberRole.ADMIN) {
+      throw new MemberNotProcessableException();
+    }
+
     member.updateRole(role);
+
+    return member;
+  }
+
+  @Transactional
+  public Member banMember(Long memberId, BanMemberRequest request) {
+    Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+
+    if (member.getRole() == MemberRole.ADMIN) {
+      throw new MemberNotProcessableException();
+    }
+
+    member.ban(request.getBanReason());
+
+    return member;
+  }
+
+  @Transactional
+  public Member unbanMember(Long memberId) {
+    Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+
+    member.unban();
 
     return member;
   }


### PR DESCRIPTION
## AdminMemberController
- GET /admin/members: 회원 목록 조회 (페이징, 정렬, 역할 필터링)
- PATCH /admin/members/{memberId}/role: 권한 변경
- POST /admin/members/{memberId}/ban: 회원 밴
- POST /admin/members/{memberId}/unban: 밴 해제

## AdminMemberService
- findAllMembers: 페이징된 회원 목록 조회
- updateRole: 권한 변경 (ADMIN은 변경 불가)
- banMember: 회원 밴 처리 (ADMIN은 밴 불가)
- unbanMember: 밴 해제

## Member 엔티티
- banReason 필드 추가
- ban(), unban() 메서드 추가

## DTO
- MemberPaginationRequest: page, size, role, orderBy, sortDirection
- MemberListResponse: content, page, size, hasNext
- UpdateMemberRoleRequest, BanMemberRequest

## 예외
- MemberNotProcessableException: ADMIN 권한 변경/밴 시도 시

## 페이징
- offset 기반, hasNext 방식 (size + 1 조회)