### PR TITLE
feat: Report 페이징 적용 및 DTO 분리

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/GlobalExceptionHandler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/GlobalExceptionHandler.java
@@ -19,6 +19,7 @@ public class GlobalExceptionHandler {
 
   @ExceptionHandler(MethodArgumentNotValidException.class)
   public ProblemDetail handleValidationException(MethodArgumentNotValidException e) {
+
     String message =
         e.getBindingResult().getFieldErrors().stream()
             .map(error -> error.getField() + ": " + error.getDefaultMessage())

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/QuoteOrderBy.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/QuoteOrderBy.java
@@ -4,5 +4,6 @@ public enum QuoteOrderBy {
   id,
   status,
   type,
-  reportCount
+  reportCount,
+  createdAt
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
@@ -25,6 +25,11 @@ public class QuoteService {
   private final QuoteRepository quoteRepository;
   private final MemberRepository memberRepository;
 
+  /**
+   * 추후 랜덤 조회로 변경할 예정
+   *
+   * @return List<Quote>
+   */
   public List<Quote> findPublicQuotes() {
     List<Quote> all = quoteRepository.findPublicQuotes();
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/AdminReportController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/AdminReportController.java
@@ -6,9 +6,7 @@ import com.typingpractice.typing_practice_be.member.domain.MemberRole;
 import com.typingpractice.typing_practice_be.member.exception.NotAdminException;
 import com.typingpractice.typing_practice_be.member.service.MemberService;
 import com.typingpractice.typing_practice_be.report.domain.Report;
-import com.typingpractice.typing_practice_be.report.dto.ReportProcessRequest;
-import com.typingpractice.typing_practice_be.report.dto.ReportRequest;
-import com.typingpractice.typing_practice_be.report.dto.ReportResponse;
+import com.typingpractice.typing_practice_be.report.dto.*;
 import com.typingpractice.typing_practice_be.report.service.AdminReportService;
 import java.util.List;
 
@@ -33,13 +31,15 @@ public class AdminReportController {
   }
 
   @GetMapping("/admin/reports")
-  public ApiResponse<List<ReportResponse>> getReports(
-      @ModelAttribute @Valid ReportRequest request) {
+  public ApiResponse<AdminReportPaginationResponse> getReports(
+      @ModelAttribute @Valid ReportPaginationRequest request) {
     validateAdmin();
 
     List<Report> reports = adminReportService.findReports(request);
 
-    return ApiResponse.ok(reports.stream().map(ReportResponse::from).toList());
+    return ApiResponse.ok(
+        AdminReportPaginationResponse.from(
+            reports, request.getPage(), request.getSize(), reports.size() > request.getSize()));
   }
 
   @PostMapping("/admin/reports/{quoteId}/process")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/ReportController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/ReportController.java
@@ -3,11 +3,12 @@ package com.typingpractice.typing_practice_be.report.controller;
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.dto.ReportCreateRequest;
+import com.typingpractice.typing_practice_be.report.dto.ReportPaginationRequest;
+import com.typingpractice.typing_practice_be.report.dto.ReportPaginationResponse;
 import com.typingpractice.typing_practice_be.report.dto.ReportResponse;
 import com.typingpractice.typing_practice_be.report.service.ReportService;
-import java.util.List;
-
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
@@ -31,12 +32,15 @@ public class ReportController {
   }
 
   @GetMapping("/reports/my")
-  public ApiResponse<List<ReportResponse>> getMyReports() {
+  public ApiResponse<ReportPaginationResponse> getMyReports(
+      @ModelAttribute @Valid ReportPaginationRequest request) {
     Long memberId = getMemberId();
 
-    List<Report> myReports = reportService.findMyReports(memberId);
+    List<Report> myReports = reportService.findMyReports(memberId, request);
 
-    return ApiResponse.ok(myReports.stream().map(ReportResponse::from).toList());
+    return ApiResponse.ok(
+        ReportPaginationResponse.from(
+            myReports, request.getPage(), request.getSize(), myReports.size() > request.getSize()));
   }
 
   @DeleteMapping("/reports/{reportId}")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/domain/ReportOrderBy.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/domain/ReportOrderBy.java
@@ -1,0 +1,7 @@
+package com.typingpractice.typing_practice_be.report.domain;
+
+public enum ReportOrderBy {
+  id,
+  status,
+  createdAt,
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/AdminReportPaginationResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/AdminReportPaginationResponse.java
@@ -1,0 +1,36 @@
+package com.typingpractice.typing_practice_be.report.dto;
+
+import com.typingpractice.typing_practice_be.common.dto.PaginationResponse;
+import com.typingpractice.typing_practice_be.member.dto.MemberResponse;
+import com.typingpractice.typing_practice_be.report.domain.Report;
+import java.util.List;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class AdminReportPaginationResponse extends PaginationResponse {
+  private List<AdminReportResponse> content;
+
+  protected AdminReportPaginationResponse(int page, int size, boolean hasNext) {
+    super(page, size, hasNext);
+  }
+
+  public static AdminReportPaginationResponse from(
+      List<Report> reports, int page, int size, boolean hasNext) {
+    AdminReportPaginationResponse response = new AdminReportPaginationResponse(page, size, hasNext);
+
+    response.content =
+        reports.stream()
+            .limit(size)
+            .map(
+                r -> {
+                  MemberResponse member = MemberResponse.from(r.getMember());
+
+                  return AdminReportResponse.from(r, member);
+                })
+            .toList();
+
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/AdminReportResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/AdminReportResponse.java
@@ -1,15 +1,17 @@
 package com.typingpractice.typing_practice_be.report.dto;
 
+import com.typingpractice.typing_practice_be.member.dto.MemberResponse;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.domain.ReportReason;
 import com.typingpractice.typing_practice_be.report.domain.ReportStatus;
-import java.time.LocalDateTime;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.time.LocalDateTime;
+
 @Getter
 @ToString
-public class ReportResponse {
+public class AdminReportResponse {
   private Long id;
   private ReportReason reason;
   private ReportStatus status;
@@ -17,8 +19,11 @@ public class ReportResponse {
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
-  public static ReportResponse from(Report report) {
-    ReportResponse response = new ReportResponse();
+  private MemberResponse member;
+
+  public static AdminReportResponse from(Report report, MemberResponse member) {
+    AdminReportResponse response = new AdminReportResponse();
+
     response.id = report.getId();
     response.reason = report.getReason();
     response.status = report.getStatus();
@@ -26,6 +31,8 @@ public class ReportResponse {
 
     response.createdAt = report.getCreatedAt();
     response.updatedAt = report.getUpdatedAt();
+
+    response.member = member;
 
     return response;
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportPaginationRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportPaginationRequest.java
@@ -1,0 +1,39 @@
+package com.typingpractice.typing_practice_be.report.dto;
+
+import com.typingpractice.typing_practice_be.common.domain.SortDirection;
+import com.typingpractice.typing_practice_be.common.dto.PaginationRequest;
+import com.typingpractice.typing_practice_be.report.domain.ReportOrderBy;
+import com.typingpractice.typing_practice_be.report.domain.ReportStatus;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@ToString(callSuper = true)
+public class ReportPaginationRequest extends PaginationRequest {
+
+  private Long memberId;
+  private ReportStatus status;
+  private ReportOrderBy orderBy = ReportOrderBy.id;
+
+  protected ReportPaginationRequest(int page, int size, SortDirection sortDirection) {
+    super(page, size, sortDirection);
+  }
+
+  public static ReportPaginationRequest create(
+      int page,
+      int size,
+      SortDirection sortDirection,
+      ReportStatus status,
+      ReportOrderBy orderBy,
+      Long memberId) {
+    ReportPaginationRequest request = new ReportPaginationRequest(page, size, sortDirection);
+
+    request.status = status;
+    request.memberId = memberId;
+    request.orderBy = orderBy;
+
+    return request;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportPaginationResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/ReportPaginationResponse.java
@@ -1,0 +1,26 @@
+package com.typingpractice.typing_practice_be.report.dto;
+
+import com.typingpractice.typing_practice_be.common.dto.PaginationResponse;
+import com.typingpractice.typing_practice_be.report.domain.Report;
+import java.util.List;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ReportPaginationResponse extends PaginationResponse {
+  private List<ReportResponse> content;
+
+  protected ReportPaginationResponse(int page, int size, boolean hasNext) {
+    super(page, size, hasNext);
+  }
+
+  public static ReportPaginationResponse from(
+      List<Report> reports, int page, int size, boolean hasNext) {
+    ReportPaginationResponse response = new ReportPaginationResponse(page, size, hasNext);
+
+    response.content = reports.stream().limit(size).map(ReportResponse::from).toList();
+
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/service/AdminReportService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/service/AdminReportService.java
@@ -1,11 +1,13 @@
 package com.typingpractice.typing_practice_be.report.service;
 
+import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
+import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
 import com.typingpractice.typing_practice_be.report.domain.Report;
+import com.typingpractice.typing_practice_be.report.dto.ReportPaginationRequest;
 import com.typingpractice.typing_practice_be.report.dto.ReportProcessRequest;
-import com.typingpractice.typing_practice_be.report.dto.ReportRequest;
 import com.typingpractice.typing_practice_be.report.exception.ReportNotFoundException;
 import com.typingpractice.typing_practice_be.report.repository.ReportRepository;
 import java.util.List;
@@ -17,10 +19,16 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AdminReportService {
+  private final MemberRepository memberRepository;
   private final QuoteRepository quoteRepository;
   private final ReportRepository reportRepository;
 
-  public List<Report> findReports(ReportRequest request) {
+  public List<Report> findReports(ReportPaginationRequest request) {
+
+    if (request.getMemberId() != null) {
+      memberRepository.findById(request.getMemberId()).orElseThrow(MemberNotFoundException::new);
+    }
+
     List<Report> all = reportRepository.findAll(request);
 
     return all;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/service/ReportService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/service/ReportService.java
@@ -10,6 +10,7 @@ import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundExcept
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.dto.ReportCreateRequest;
+import com.typingpractice.typing_practice_be.report.dto.ReportPaginationRequest;
 import com.typingpractice.typing_practice_be.report.exception.DuplicateReportException;
 import com.typingpractice.typing_practice_be.report.exception.QuoteNotReportableException;
 import com.typingpractice.typing_practice_be.report.exception.ReportNotFoundException;
@@ -59,10 +60,10 @@ public class ReportService {
 
   // 내 신고 내역 조회
   // 페이징 추가 필요
-  public List<Report> findMyReports(Long memberId) {
+  public List<Report> findMyReports(Long memberId, ReportPaginationRequest request) {
     Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
-    return reportRepository.findMyReports(member);
+    return reportRepository.findMyReports(member, request);
   }
 
   // 본인 신고 내역 삭제(철회 or 처리된 신고 삭제)


### PR DESCRIPTION
## Report 페이징
- GET /reports/my: ReportPaginationRequest/Response 적용
- GET /admin/reports: AdminReportPaginationResponse 적용

## DTO 분리
- ReportResponse: 사용자용 (신고자 정보 없음)
- AdminReportResponse: 어드민용 (신고자 정보 포함)
- ReportPaginationResponse: 사용자용 페이징 응답
- AdminReportPaginationResponse: 어드민용 페이징 응답

## ReportPaginationRequest
- status, memberId 필터링
- ReportOrderBy enum (id, status, createdAt)

## ReportRepository
- findAll: 어드민용 (member fetch join)
- findMyReports: 사용자용 (member 조인 없음)