### PR TITLE
feat: 신고 일일 제한 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/DailyLimitPolicy.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/DailyLimitPolicy.java
@@ -1,0 +1,8 @@
+package com.typingpractice.typing_practice_be.dailylimit;
+
+public final class DailyLimitPolicy {
+  public static final int MAX_REPORT = 20;
+  public static final int MAX_QUOTE_UPLOAD = 50;
+
+  private DailyLimitPolicy() {}
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/DailyLimitService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/DailyLimitService.java
@@ -1,0 +1,7 @@
+package com.typingpractice.typing_practice_be.dailylimit;
+
+public interface DailyLimitService {
+  boolean canReport(Long memberId);
+
+  void incrementReportCount(Long memberId);
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/MemberFieldDailyLimitService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/MemberFieldDailyLimitService.java
@@ -1,0 +1,27 @@
+package com.typingpractice.typing_practice_be.dailylimit;
+
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
+import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Service;
+
+@Service
+@Primary
+@RequiredArgsConstructor
+public class MemberFieldDailyLimitService implements DailyLimitService {
+  private final MemberRepository memberRepository;
+
+  @Override
+  public boolean canReport(Long memberId) {
+    Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    return member.canReportToday(DailyLimitPolicy.MAX_REPORT);
+  }
+
+  @Override
+  public void incrementReportCount(Long memberId) {
+    Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    member.incrementReportCount();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/Member.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/Member.java
@@ -3,6 +3,8 @@ package com.typingpractice.typing_practice_be.member.domain;
 import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import jakarta.persistence.*;
+
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -29,6 +31,9 @@ public class Member extends BaseEntity {
 
   private String banReason = "";
 
+  private int reportCount = 0;
+  private LocalDate lastReportDate = LocalDate.now();
+
   @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
   private List<Report> reports = new ArrayList<>();
 
@@ -38,6 +43,8 @@ public class Member extends BaseEntity {
     member.password = password;
     member.nickname = nickname;
     member.role = MemberRole.USER;
+    member.reportCount = 0;
+    member.lastReportDate = LocalDate.now();
 
     return member;
   }
@@ -48,6 +55,25 @@ public class Member extends BaseEntity {
 
   public void updateRole(MemberRole role) {
     this.role = role;
+  }
+
+  public boolean canReportToday(int limit) {
+    // 날짜 변경됨.
+    if (LocalDate.now().isAfter(lastReportDate)) {
+      return true;
+    }
+
+    return this.reportCount < limit;
+  }
+
+  public void incrementReportCount() {
+    LocalDate today = LocalDate.now();
+    if (today.isAfter(this.lastReportDate)) {
+      this.reportCount = 0;
+      this.lastReportDate = today;
+    }
+
+    this.reportCount++;
   }
 
   public void ban(String reason) {


### PR DESCRIPTION
## dailylimit 패키지
- DailyLimitPolicy: 일일 제한 상수 (MAX_REPORT=20, MAX_QUOTE_UPLOAD=50)
- DailyLimitService: 인터페이스 (Redis 전환 대비)
- MemberFieldDailyLimitService: Member 필드 기반 구현체

## Member 엔티티
- reportCount, lastReportDate 필드 추가
- canReportToday(): 오늘 신고 가능 여부 확인
- incrementReportCount(): 신고 횟수 증가 (날짜 변경 시 초기화)

## ReportService
- 신고 생성 시 일일 제한 검증 추가