### PR TITLE
feat: 일일 제한 구현 (신고 20회, 업로드 50회)

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -21,7 +21,10 @@ public enum ErrorCode {
   REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "신고 내역을 찾을 수 없습니다."),
   DUPLICATE_REPORT(HttpStatus.BAD_REQUEST, "중복된 신고 내역이 존재합니다."),
   QUOTE_NOT_REPORTABLE(HttpStatus.BAD_REQUEST, "신고 불가능한 문장입니다."),
-  REPORT_NOT_PROCESSABLE(HttpStatus.BAD_REQUEST, "처리할 수 없는 신고 내역입니다.");
+  REPORT_NOT_PROCESSABLE(HttpStatus.BAD_REQUEST, "처리할 수 없는 신고 내역입니다."),
+
+  DAILY_REPORT_LIMIT(HttpStatus.BAD_REQUEST, "하루 신고 제한 횟수에 도달했습니다."),
+  DAILY_QUOTE_UPLOAD_LIMIT(HttpStatus.BAD_REQUEST, "하루 업로드 제한 횟수에 도달했습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/DailyLimitService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/DailyLimitService.java
@@ -4,4 +4,8 @@ public interface DailyLimitService {
   boolean canReport(Long memberId);
 
   void incrementReportCount(Long memberId);
+
+  boolean canUploadQuote(Long memberId);
+
+  void incrementQuoteUploadCount(Long memberId);
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/MemberFieldDailyLimitService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/MemberFieldDailyLimitService.java
@@ -13,15 +13,31 @@ import org.springframework.stereotype.Service;
 public class MemberFieldDailyLimitService implements DailyLimitService {
   private final MemberRepository memberRepository;
 
+  private Member findMemberById(Long memberId) {
+    return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+  }
+
   @Override
   public boolean canReport(Long memberId) {
-    Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    Member member = findMemberById(memberId);
     return member.canReportToday(DailyLimitPolicy.MAX_REPORT);
   }
 
   @Override
   public void incrementReportCount(Long memberId) {
-    Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+    Member member = findMemberById(memberId);
     member.incrementReportCount();
+  }
+
+  @Override
+  public boolean canUploadQuote(Long memberId) {
+    Member member = findMemberById(memberId);
+    return member.canUploadQuote(DailyLimitPolicy.MAX_QUOTE_UPLOAD);
+  }
+
+  @Override
+  public void incrementQuoteUploadCount(Long memberId) {
+    Member member = findMemberById(memberId);
+    member.incrementQuoteUploadCount();
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/exception/DailyQuoteUploadLimitException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/exception/DailyQuoteUploadLimitException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.dailylimit.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class DailyQuoteUploadLimitException extends BusinessException {
+  public DailyQuoteUploadLimitException() {
+    super(ErrorCode.DAILY_QUOTE_UPLOAD_LIMIT);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/exception/DailyReportLimitException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/dailylimit/exception/DailyReportLimitException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.dailylimit.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class DailyReportLimitException extends BusinessException {
+  public DailyReportLimitException() {
+    super(ErrorCode.DAILY_REPORT_LIMIT);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/Member.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/Member.java
@@ -34,6 +34,9 @@ public class Member extends BaseEntity {
   private int reportCount = 0;
   private LocalDate lastReportDate = LocalDate.now();
 
+  private int dailyQuoteUploadCount = 0;
+  private LocalDate lastQuoteUploadDate = LocalDate.now();
+
   @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
   private List<Report> reports = new ArrayList<>();
 
@@ -43,8 +46,11 @@ public class Member extends BaseEntity {
     member.password = password;
     member.nickname = nickname;
     member.role = MemberRole.USER;
+
     member.reportCount = 0;
     member.lastReportDate = LocalDate.now();
+    member.dailyQuoteUploadCount = 0;
+    member.lastQuoteUploadDate = LocalDate.now();
 
     return member;
   }
@@ -66,6 +72,14 @@ public class Member extends BaseEntity {
     return this.reportCount < limit;
   }
 
+  public boolean canUploadQuote(int limit) {
+    if (LocalDate.now().isAfter(lastQuoteUploadDate)) {
+      return true;
+    }
+
+    return this.dailyQuoteUploadCount < limit;
+  }
+
   public void incrementReportCount() {
     LocalDate today = LocalDate.now();
     if (today.isAfter(this.lastReportDate)) {
@@ -74,6 +88,16 @@ public class Member extends BaseEntity {
     }
 
     this.reportCount++;
+  }
+
+  public void incrementQuoteUploadCount() {
+    LocalDate today = LocalDate.now();
+    if (today.isAfter(this.lastQuoteUploadDate)) {
+      this.dailyQuoteUploadCount = 0;
+      this.lastQuoteUploadDate = today;
+    }
+
+    this.dailyQuoteUploadCount++;
   }
 
   public void ban(String reason) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
@@ -43,7 +43,7 @@ public class QuoteController {
   @GetMapping("/quotes/my")
   public ApiResponse<QuotePaginationResponse> getMyQuotes(
       @ModelAttribute @Valid QuotePaginationRequest request) {
-    Long memberId = 2L; // getMemberId();
+    Long memberId = getMemberId();
 
     List<Quote> myQuotes = quoteService.getMyQuotes(memberId, request);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
@@ -8,9 +8,8 @@ import com.typingpractice.typing_practice_be.quote.dto.QuoteUpdateRequest;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotProcessableException;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
-import java.util.List;
-
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -38,7 +37,7 @@ public class AdminQuoteService {
     Quote quote = findQuoteById(quoteId);
 
     if (quote.getStatus() != QuoteStatus.PENDING || quote.getType() != QuoteType.PUBLIC) {
-      throw new QuoteNotProcessableException(); // IllegalStateException("공개 신청한 문장이 아닙니다.");
+      throw new QuoteNotProcessableException();
     }
 
     quote.approvePublish();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/service/ReportService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/service/ReportService.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.report.service;
 
 import com.typingpractice.typing_practice_be.dailylimit.DailyLimitService;
+import com.typingpractice.typing_practice_be.dailylimit.exception.DailyReportLimitException;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
@@ -47,7 +48,7 @@ public class ReportService {
 
     // 신고 횟수 가능 검증
     if (!dailyLimitService.canReport(memberId)) {
-      throw new IllegalStateException("하루 최대 신고 횟수 초과");
+      throw new DailyReportLimitException();
     }
 
     // 중복 신고 검증


### PR DESCRIPTION
## dailylimit 패키지
- DailyLimitPolicy: 상수 (MAX_REPORT=20, MAX_QUOTE_UPLOAD=50)
- DailyLimitService: 인터페이스 (Redis 전환 대비)
- MemberFieldDailyLimitService: Member 필드 기반 구현체

## Member 엔티티
- reportCount, lastReportDate 추가
- dailyQuoteUploadCount, lastQuoteUploadDate 추가
- canReportToday(), incrementReportCount()
- canUploadQuote(), incrementQuoteUploadCount()

## 예외 처리
- DailyReportLimitException
- DailyQuoteUploadLimitException
- ErrorCode 추가 (DAILY_REPORT_LIMIT, DAILY_QUOTE_UPLOAD_LIMIT)

## 적용
- ReportService: 신고 생성 시 제한 검증
- QuoteService: 문장 업로드 시 제한 검증