### PR TITLE
feat: 공개 문장 랜덤 조회 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
@@ -33,8 +33,11 @@ public class QuoteController {
 
   // 공개 문장 조회
   @GetMapping("/quotes")
-  public ApiResponse<List<QuoteResponse>> getPublicQuotes() {
-    List<Quote> quotes = quoteService.findPublicQuotes();
+  public ApiResponse<List<QuoteResponse>> getPublicQuotes(
+      @ModelAttribute @Valid PublicQuoteRequest request) {
+    Long memberId = getMemberId();
+
+    List<Quote> quotes = quoteService.findRandomPublicQuotes(memberId, request);
 
     return ApiResponse.ok(quotes.stream().map(QuoteResponse::from).toList());
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/PublicQuoteRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/PublicQuoteRequest.java
@@ -1,0 +1,19 @@
+package com.typingpractice.typing_practice_be.quote.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+import org.hibernate.validator.constraints.Range;
+
+@Getter
+@ToString
+public class PublicQuoteRequest {
+  @Range(min = 100, max = 300)
+  private final Integer count;
+
+  private final Boolean onlyMyQuotes;
+
+  public PublicQuoteRequest(Integer count, Boolean onlyMyQuotes) {
+    this.count = count != null ? count : 100;
+    this.onlyMyQuotes = onlyMyQuotes != null ? onlyMyQuotes : false;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
@@ -7,11 +7,10 @@ import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
 import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationRequest;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor
@@ -63,12 +62,26 @@ public class QuoteRepository {
     return query.getResultList();
   }
 
-  public List<Quote> findPublicQuotes() {
-    return em.createQuery(
-            "select q from Quote q where q.status = :status and q.type = :type", Quote.class)
-        .setParameter("status", QuoteStatus.ACTIVE)
-        .setParameter("type", QuoteType.PUBLIC)
-        .getResultList();
+  public List<Quote> findPublicQuotes(long memberId, int count, boolean onlyMyQuotes) {
+    String jpql = "select q from Quote q where q.status = :status and q.type = :type";
+
+    if (onlyMyQuotes) {
+      jpql += " and q.member.id = :memberId";
+    }
+
+    jpql += " order by function('RANDOM')";
+
+    TypedQuery<Quote> query =
+        em.createQuery(jpql, Quote.class)
+            .setParameter("status", QuoteStatus.ACTIVE)
+            .setParameter("type", QuoteType.PUBLIC)
+            .setMaxResults(count);
+
+    if (onlyMyQuotes) {
+      query.setParameter("memberId", memberId);
+    }
+
+    return query.getResultList();
   }
 
   public List<Quote> findByStatus(QuoteStatus quoteStatus) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
@@ -8,6 +8,7 @@ import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
+import com.typingpractice.typing_practice_be.quote.dto.PublicQuoteRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteCreateRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteUpdateRequest;
@@ -29,13 +30,9 @@ public class QuoteService {
 
   private final DailyLimitService dailyLimitService;
 
-  /**
-   * 추후 랜덤 조회로 변경할 예정
-   *
-   * @return List<Quote>
-   */
-  public List<Quote> findPublicQuotes() {
-    List<Quote> all = quoteRepository.findPublicQuotes();
+  public List<Quote> findRandomPublicQuotes(Long memberId, PublicQuoteRequest request) {
+    List<Quote> all =
+        quoteRepository.findPublicQuotes(memberId, request.getCount(), request.getOnlyMyQuotes());
 
     return all;
   }


### PR DESCRIPTION
## API
- GET /quotes?count=100&onlyMyQuotes=false

## PublicQuoteRequest
- count: 조회 개수 (기본값 100, 범위 100~300)
- onlyMyQuotes: 내 문장만 조회 (기본값 false)

## QuoteRepository
- findPublicQuotes: ORDER BY RANDOM() 적용
- PUBLIC + ACTIVE 문장만 조회