### PR TITLE
feat: 공개 문장 랜덤 조회 (시드 기반 페이징)

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
@@ -35,7 +35,8 @@ public class QuoteController {
   @GetMapping("/quotes")
   public ApiResponse<List<QuoteResponse>> getPublicQuotes(
       @ModelAttribute @Valid PublicQuoteRequest request) {
-    Long memberId = getMemberId();
+
+    Long memberId = request.getOnlyMyQuotes() ? getMemberId() : null;
 
     List<Quote> quotes = quoteService.findRandomPublicQuotes(memberId, request);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/PublicQuoteRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/PublicQuoteRequest.java
@@ -1,5 +1,9 @@
 package com.typingpractice.typing_practice_be.quote.dto;
 
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.ToString;
 import org.hibernate.validator.constraints.Range;
@@ -7,13 +11,24 @@ import org.hibernate.validator.constraints.Range;
 @Getter
 @ToString
 public class PublicQuoteRequest {
+  @Min(value = 1)
+  private final Integer page;
+
   @Range(min = 100, max = 300)
   private final Integer count;
 
   private final Boolean onlyMyQuotes;
 
-  public PublicQuoteRequest(Integer count, Boolean onlyMyQuotes) {
+  @NotNull
+  @DecimalMin("-1.0")
+  @DecimalMax("1.0")
+  private final Float seed;
+
+  public PublicQuoteRequest(Integer page, Integer count, Boolean onlyMyQuotes, Float seed) {
+    this.page = page != null ? page : 1;
     this.count = count != null ? count : 100;
     this.onlyMyQuotes = onlyMyQuotes != null ? onlyMyQuotes : false;
+    this.seed = seed;
+    // this.seed = seed != null ? seed : (float) (Math.random() * 2 - 1);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
@@ -62,10 +62,14 @@ public class QuoteRepository {
     return query.getResultList();
   }
 
-  public List<Quote> findPublicQuotes(long memberId, int count, boolean onlyMyQuotes) {
+  public List<Quote> findPublicQuotes(
+      Long memberId, Float seed, Integer page, Integer count, Boolean onlyMyQuotes) {
+    // 랜덤 순서
+    em.createNativeQuery("SELECT SETSEED(:seed)").setParameter("seed", seed).getSingleResult();
+
     String jpql = "select q from Quote q where q.status = :status and q.type = :type";
 
-    if (onlyMyQuotes) {
+    if (onlyMyQuotes && memberId != null) {
       jpql += " and q.member.id = :memberId";
     }
 
@@ -75,9 +79,10 @@ public class QuoteRepository {
         em.createQuery(jpql, Quote.class)
             .setParameter("status", QuoteStatus.ACTIVE)
             .setParameter("type", QuoteType.PUBLIC)
+            .setFirstResult((page - 1) * count)
             .setMaxResults(count);
 
-    if (onlyMyQuotes) {
+    if (onlyMyQuotes && memberId != null) {
       query.setParameter("memberId", memberId);
     }
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
@@ -32,7 +32,12 @@ public class QuoteService {
 
   public List<Quote> findRandomPublicQuotes(Long memberId, PublicQuoteRequest request) {
     List<Quote> all =
-        quoteRepository.findPublicQuotes(memberId, request.getCount(), request.getOnlyMyQuotes());
+        quoteRepository.findPublicQuotes(
+            memberId,
+            request.getSeed(),
+            request.getPage(),
+            request.getCount(),
+            request.getOnlyMyQuotes());
 
     return all;
   }


### PR DESCRIPTION
## API
- GET /quotes?page=1&count=100&seed=0.5&onlyMyQuotes=false

## PublicQuoteRequest
- page: 페이지 번호 (기본값 1)
- count: 조회 개수 (100~300)
- seed: 랜덤 시드 (-1.0~1.0, 필수)
- onlyMyQuotes: 내 문장만 조회 (기본값 false)

## 시드 기반 페이징
- SETSEED로 세션 랜덤 시드 설정
- 같은 시드 → 같은 순서 보장
- 페이지별 중복 없이 조회

## QuoteRepository
- findPublicQuotes: PUBLIC + ACTIVE 문장 랜덤 조회
- ORDER BY RANDOM() + OFFSET 페이징