### PR TITLE
refactor: Quote 도메인 DTO → Query 객체 분리

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/query/PaginationQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/query/PaginationQuery.java
@@ -1,0 +1,19 @@
+package com.typingpractice.typing_practice_be.common.query;
+
+import com.typingpractice.typing_practice_be.common.domain.SortDirection;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public abstract class PaginationQuery {
+  private final int page;
+  private final int size;
+  private final SortDirection sortDirection;
+
+  protected PaginationQuery(int page, int size, SortDirection sortDirection) {
+    this.page = page;
+    this.size = size;
+    this.sortDirection = sortDirection;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
@@ -10,6 +10,8 @@ import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationResponse;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteResponse;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteUpdateRequest;
+import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
+import com.typingpractice.typing_practice_be.quote.query.QuoteUpdateQuery;
 import com.typingpractice.typing_practice_be.quote.service.AdminQuoteService;
 import java.util.List;
 
@@ -38,7 +40,9 @@ public class AdminQuoteController {
       @ModelAttribute @Valid QuotePaginationRequest request) {
     validateAdmin();
 
-    List<Quote> quotes = adminQuoteService.findQuotes(request);
+    QuotePaginationQuery query = QuotePaginationQuery.from(request);
+
+    List<Quote> quotes = adminQuoteService.findQuotes(query);
 
     return ApiResponse.ok(
         QuotePaginationResponse.from(
@@ -81,7 +85,9 @@ public class AdminQuoteController {
       @PathVariable Long quoteId, @RequestBody QuoteUpdateRequest request) {
     validateAdmin();
 
-    Quote quote = adminQuoteService.updateQuote(quoteId, request);
+    QuoteUpdateQuery query = QuoteUpdateQuery.from(request);
+
+    Quote quote = adminQuoteService.updateQuote(quoteId, query);
 
     return ApiResponse.ok(QuoteResponse.from(quote));
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
@@ -4,6 +4,10 @@ import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.dto.*;
 import com.typingpractice.typing_practice_be.quote.exception.EmptyUpdateRequestException;
+import com.typingpractice.typing_practice_be.quote.query.PublicQuoteQuery;
+import com.typingpractice.typing_practice_be.quote.query.QuoteCreateQuery;
+import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
+import com.typingpractice.typing_practice_be.quote.query.QuoteUpdateQuery;
 import com.typingpractice.typing_practice_be.quote.service.QuoteService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -26,19 +30,23 @@ public class QuoteController {
   public ApiResponse<QuoteResponse> create(@RequestBody @Valid QuoteCreateRequest request) {
     Long memberId = getMemberId();
 
-    Quote quote = quoteService.create(memberId, request);
+    QuoteCreateQuery query = QuoteCreateQuery.from(request);
+
+    Quote quote = quoteService.create(memberId, query);
 
     return ApiResponse.ok(QuoteResponse.from(quote));
   }
 
-  // 공개 문장 조회
+  // 공개 문장 랜덤 조회
   @GetMapping("/quotes")
   public ApiResponse<List<QuoteResponse>> getPublicQuotes(
       @ModelAttribute @Valid PublicQuoteRequest request) {
 
     Long memberId = request.getOnlyMyQuotes() ? getMemberId() : null;
 
-    List<Quote> quotes = quoteService.findRandomPublicQuotes(memberId, request);
+    PublicQuoteQuery query = PublicQuoteQuery.from(memberId, request);
+
+    List<Quote> quotes = quoteService.findRandomPublicQuotes(query);
 
     return ApiResponse.ok(quotes.stream().map(QuoteResponse::from).toList());
   }
@@ -49,7 +57,9 @@ public class QuoteController {
       @ModelAttribute @Valid QuotePaginationRequest request) {
     Long memberId = getMemberId();
 
-    List<Quote> myQuotes = quoteService.getMyQuotes(memberId, request);
+    QuotePaginationQuery query = QuotePaginationQuery.from(request);
+
+    List<Quote> myQuotes = quoteService.getMyQuotes(memberId, query);
 
     return ApiResponse.ok(
         QuotePaginationResponse.from(
@@ -73,7 +83,9 @@ public class QuoteController {
     }
 
     Long memberId = getMemberId();
-    Quote quote = quoteService.updatePrivateQuote(memberId, quoteId, request);
+    QuoteUpdateQuery query = QuoteUpdateQuery.from(request);
+
+    Quote quote = quoteService.updatePrivateQuote(memberId, quoteId, query);
 
     return ApiResponse.ok(QuoteResponse.from(quote));
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -46,7 +46,7 @@ public class Quote extends BaseEntity {
     Quote quote = new Quote();
     quote.member = member;
     quote.sentence = sentence;
-    quote.author = StringUtils.hasText(author) ? author : DEFAULT_AUTHOR;
+    quote.author = author != null ? author : DEFAULT_AUTHOR;
     quote.type = type;
     quote.reportCount = 0;
     quote.status = quote.type == QuoteType.PUBLIC ? QuoteStatus.PENDING : QuoteStatus.ACTIVE;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/query/PublicQuoteQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/query/PublicQuoteQuery.java
@@ -1,0 +1,34 @@
+package com.typingpractice.typing_practice_be.quote.query;
+
+import com.typingpractice.typing_practice_be.quote.dto.PublicQuoteRequest;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class PublicQuoteQuery {
+  private final Integer page;
+  private final Integer count;
+  private final Boolean onlyMyQuotes;
+  private final Long memberId;
+  private final Float seed;
+
+  private PublicQuoteQuery(
+      Long memberId, Integer page, Integer count, Boolean onlyMyQuotes, Float seed) {
+    this.page = page;
+    this.count = count;
+    this.onlyMyQuotes = onlyMyQuotes;
+    this.memberId = memberId;
+    this.seed = seed;
+  }
+
+  public static PublicQuoteQuery from(Long memberId, PublicQuoteRequest request) {
+
+    return new PublicQuoteQuery(
+        memberId,
+        request.getPage(),
+        request.getCount(),
+        request.getOnlyMyQuotes(),
+        request.getSeed());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/query/QuoteCreateQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/query/QuoteCreateQuery.java
@@ -1,0 +1,26 @@
+package com.typingpractice.typing_practice_be.quote.query;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
+import com.typingpractice.typing_practice_be.quote.dto.QuoteCreateRequest;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class QuoteCreateQuery {
+
+  private final String sentence;
+  private final String author;
+  private final QuoteType type;
+
+  private QuoteCreateQuery(String sentence, String author, QuoteType type) {
+
+    this.sentence = sentence;
+    this.author = author;
+    this.type = type;
+  }
+
+  public static QuoteCreateQuery from(QuoteCreateRequest request) {
+    return new QuoteCreateQuery(request.getSentence(), request.getAuthor(), request.getType());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/query/QuotePaginationQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/query/QuotePaginationQuery.java
@@ -1,0 +1,43 @@
+package com.typingpractice.typing_practice_be.quote.query;
+
+import com.typingpractice.typing_practice_be.common.domain.SortDirection;
+import com.typingpractice.typing_practice_be.common.query.PaginationQuery;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteOrderBy;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
+import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationRequest;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true)
+public class QuotePaginationQuery extends PaginationQuery {
+
+  private final QuoteStatus status;
+  private final QuoteType type;
+  private final QuoteOrderBy orderBy;
+
+  private QuotePaginationQuery(
+      int page,
+      int size,
+      SortDirection sortDirection,
+      QuoteStatus status,
+      QuoteType type,
+      QuoteOrderBy orderBy) {
+    super(page, size, sortDirection);
+
+    this.status = status;
+    this.type = type;
+    this.orderBy = orderBy;
+  }
+
+  public static QuotePaginationQuery from(QuotePaginationRequest request) {
+    return new QuotePaginationQuery(
+        request.getPage(),
+        request.getSize(),
+        request.getSortDirection(),
+        request.getStatus(),
+        request.getType(),
+        request.getOrderBy());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/query/QuoteUpdateQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/query/QuoteUpdateQuery.java
@@ -1,0 +1,21 @@
+package com.typingpractice.typing_practice_be.quote.query;
+
+import com.typingpractice.typing_practice_be.quote.dto.QuoteUpdateRequest;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class QuoteUpdateQuery {
+  private final String sentence;
+  private final String author;
+
+  private QuoteUpdateQuery(String sentence, String author) {
+    this.sentence = sentence;
+    this.author = author;
+  }
+
+  public static QuoteUpdateQuery from(QuoteUpdateRequest request) {
+    return new QuoteUpdateQuery(request.getSentence(), request.getAuthor());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
@@ -3,12 +3,11 @@ package com.typingpractice.typing_practice_be.quote.service;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
-import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationRequest;
-import com.typingpractice.typing_practice_be.quote.dto.QuoteUpdateRequest;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotProcessableException;
+import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
+import com.typingpractice.typing_practice_be.quote.query.QuoteUpdateQuery;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
-import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -59,14 +58,14 @@ public class AdminQuoteService {
   }
 
   @Transactional
-  public Quote updateQuote(Long quoteId, QuoteUpdateRequest request) {
+  public Quote updateQuote(Long quoteId, QuoteUpdateQuery query) {
     Quote quote = findQuoteById(quoteId);
 
     if (quote.getType() != QuoteType.PUBLIC) {
       throw new QuoteNotProcessableException();
     }
 
-    quote.update(request.getSentence(), request.getAuthor());
+    quote.update(query.getSentence(), query.getAuthor());
 
     return quote;
   }
@@ -93,7 +92,7 @@ public class AdminQuoteService {
     return quote;
   }
 
-  public List<Quote> findQuotes(@Valid QuotePaginationRequest request) {
-    return quoteRepository.findAll(request);
+  public List<Quote> findQuotes(QuotePaginationQuery query) {
+    return quoteRepository.findAll(query);
   }
 }


### PR DESCRIPTION
## Query 객체
- PaginationQuery: 페이징 공통 추상 클래스
- PublicQuoteQuery: 공개 문장 랜덤 조회
- QuotePaginationQuery: 문장 페이징 조회
- QuoteCreateQuery: 문장 생성
- QuoteUpdateQuery: 문장 수정

## 레이어 역할
- Controller: DTO 수신 → Query 변환
- Service/Repository: Query 객체만 의존

## 구조
- private 생성자 + from() 정적 팩토리 메서드
- final 필드로 불변성 보장