### PR TITLE
refactor: Report 도메인 DTO → Query 객체 분리

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuotePaginationRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuotePaginationRequest.java
@@ -27,24 +27,4 @@ public class QuotePaginationRequest extends PaginationRequest {
     this.type = type;
     this.orderBy = orderBy != null ? orderBy : QuoteOrderBy.id;
   }
-
-  /*protected QuotePaginationRequest(int page, int size, SortDirection sortDirection) {
-    super(page, size, sortDirection);
-  }
-
-  public static QuotePaginationRequest create(
-      int page,
-      int size,
-      SortDirection sortDirection,
-      QuoteStatus status,
-      QuoteType type,
-      QuoteOrderBy orderBy) {
-    QuotePaginationRequest request = new QuotePaginationRequest(page, size, sortDirection);
-
-    request.status = status;
-    request.type = type;
-    request.orderBy = orderBy;
-
-    return request;
-  }*/
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/AdminReportController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/AdminReportController.java
@@ -7,6 +7,8 @@ import com.typingpractice.typing_practice_be.member.exception.NotAdminException;
 import com.typingpractice.typing_practice_be.member.service.MemberService;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.dto.*;
+import com.typingpractice.typing_practice_be.report.query.ReportPaginationQuery;
+import com.typingpractice.typing_practice_be.report.query.ReportProcessQuery;
 import com.typingpractice.typing_practice_be.report.service.AdminReportService;
 import java.util.List;
 
@@ -35,9 +37,9 @@ public class AdminReportController {
       @ModelAttribute @Valid ReportPaginationRequest request) {
     validateAdmin();
 
-    List<Report> reports = adminReportService.findReports(request);
+    ReportPaginationQuery query = ReportPaginationQuery.from(request);
 
-    System.out.println("request = " + request);
+    List<Report> reports = adminReportService.findReports(query);
 
     return ApiResponse.ok(
         AdminReportPaginationResponse.from(
@@ -49,7 +51,9 @@ public class AdminReportController {
       @PathVariable Long quoteId, @RequestBody @Valid ReportProcessRequest request) {
     validateAdmin();
 
-    adminReportService.processReport(quoteId, request);
+    ReportProcessQuery query = ReportProcessQuery.from(request);
+
+    adminReportService.processReport(quoteId, query);
 
     return ApiResponse.ok(null);
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/ReportController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/ReportController.java
@@ -7,6 +7,8 @@ import com.typingpractice.typing_practice_be.report.dto.ReportCreateRequest;
 import com.typingpractice.typing_practice_be.report.dto.ReportPaginationRequest;
 import com.typingpractice.typing_practice_be.report.dto.ReportPaginationResponse;
 import com.typingpractice.typing_practice_be.report.dto.ReportResponse;
+import com.typingpractice.typing_practice_be.report.query.ReportCreateQuery;
+import com.typingpractice.typing_practice_be.report.query.ReportPaginationQuery;
 import com.typingpractice.typing_practice_be.report.service.ReportService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -27,7 +29,9 @@ public class ReportController {
   public ApiResponse<ReportResponse> reportQuote(@RequestBody @Valid ReportCreateRequest request) {
     Long memberId = getMemberId();
 
-    Report report = reportService.createReport(memberId, request.getQuoteId(), request);
+    ReportCreateQuery query = ReportCreateQuery.from(request);
+
+    Report report = reportService.createReport(memberId, request.getQuoteId(), query);
 
     QuoteResponse quote = QuoteResponse.from(report.getQuote());
 
@@ -39,7 +43,9 @@ public class ReportController {
       @ModelAttribute @Valid ReportPaginationRequest request) {
     Long memberId = getMemberId();
 
-    List<Report> myReports = reportService.findMyReports(memberId, request);
+    ReportPaginationQuery query = ReportPaginationQuery.from(request);
+
+    List<Report> myReports = reportService.findMyReports(memberId, query);
 
     return ApiResponse.ok(
         ReportPaginationResponse.from(

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/AdminReportPaginationResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/dto/AdminReportPaginationResponse.java
@@ -29,7 +29,6 @@ public class AdminReportPaginationResponse extends PaginationResponse {
                   MemberResponse member = MemberResponse.from(r.getMember());
                   QuoteResponse quote =
                       r.getQuote() != null ? QuoteResponse.from(r.getQuote()) : null;
-                  // System.out.println(r.getQuote());
 
                   return AdminReportResponse.from(r, member, quote);
                 })

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/query/ReportCreateQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/query/ReportCreateQuery.java
@@ -1,0 +1,22 @@
+package com.typingpractice.typing_practice_be.report.query;
+
+import com.typingpractice.typing_practice_be.report.domain.ReportReason;
+import com.typingpractice.typing_practice_be.report.dto.ReportCreateRequest;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ReportCreateQuery {
+  private final ReportReason reason;
+  private final String detail;
+
+  private ReportCreateQuery(ReportReason reason, String detail) {
+    this.reason = reason;
+    this.detail = detail;
+  }
+
+  public static ReportCreateQuery from(ReportCreateRequest request) {
+    return new ReportCreateQuery(request.getReason(), request.getDetail());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/query/ReportPaginationQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/query/ReportPaginationQuery.java
@@ -1,0 +1,41 @@
+package com.typingpractice.typing_practice_be.report.query;
+
+import com.typingpractice.typing_practice_be.common.domain.SortDirection;
+import com.typingpractice.typing_practice_be.common.query.PaginationQuery;
+import com.typingpractice.typing_practice_be.report.domain.ReportOrderBy;
+import com.typingpractice.typing_practice_be.report.domain.ReportStatus;
+import com.typingpractice.typing_practice_be.report.dto.ReportPaginationRequest;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ReportPaginationQuery extends PaginationQuery {
+  private final Long memberId;
+  private final ReportStatus status;
+  private final ReportOrderBy orderBy;
+
+  private ReportPaginationQuery(
+      int page,
+      int size,
+      SortDirection sortDirection,
+      Long memberId,
+      ReportStatus status,
+      ReportOrderBy orderBy) {
+    super(page, size, sortDirection);
+
+    this.memberId = memberId;
+    this.status = status;
+    this.orderBy = orderBy;
+  }
+
+  public static ReportPaginationQuery from(ReportPaginationRequest request) {
+    return new ReportPaginationQuery(
+        request.getPage(),
+        request.getSize(),
+        request.getSortDirection(),
+        request.getMemberId(),
+        request.getStatus(),
+        request.getOrderBy());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/query/ReportProcessQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/query/ReportProcessQuery.java
@@ -1,0 +1,21 @@
+package com.typingpractice.typing_practice_be.report.query;
+
+import com.typingpractice.typing_practice_be.report.dto.ReportProcessRequest;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class ReportProcessQuery {
+  private final String sentence;
+  private final String author;
+
+  private ReportProcessQuery(String sentence, String author) {
+    this.sentence = sentence;
+    this.author = author;
+  }
+
+  public static ReportProcessQuery from(ReportProcessRequest request) {
+    return new ReportProcessQuery(request.getSentence(), request.getAuthor());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/repository/ReportRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/repository/ReportRepository.java
@@ -4,7 +4,7 @@ import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.domain.ReportStatus;
-import com.typingpractice.typing_practice_be.report.dto.ReportPaginationRequest;
+import com.typingpractice.typing_practice_be.report.query.ReportPaginationQuery;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import java.time.LocalDateTime;
@@ -24,65 +24,65 @@ public class ReportRepository {
     return report;
   }
 
-  public List<Report> findAll(ReportPaginationRequest request) {
-    int page = request.getPage();
-    int size = request.getSize();
+  public List<Report> findAll(ReportPaginationQuery query) {
+    int page = query.getPage();
+    int size = query.getSize();
 
     String jpql = "select r from Report r join fetch r.member m left join fetch r.quote q";
 
-    if (request.getStatus() != null && request.getMemberId() != null) {
+    if (query.getStatus() != null && query.getMemberId() != null) {
       jpql += " where r.status = :status and m.id = :memberId";
-    } else if (request.getStatus() == null && request.getMemberId() != null) {
+    } else if (query.getStatus() == null && query.getMemberId() != null) {
       jpql += " where m.id = :memberId";
-    } else if (request.getStatus() != null) {
+    } else if (query.getStatus() != null) {
       jpql += " where r.status = :status";
     }
 
-    jpql += " order by r." + request.getOrderBy() + " " + request.getSortDirection();
+    jpql += " order by r." + query.getOrderBy() + " " + query.getSortDirection();
 
-    TypedQuery<Report> query =
+    TypedQuery<Report> typedQuery =
         em.createQuery(jpql, Report.class)
             .setFirstResult((page - 1) * size)
             .setMaxResults(size + 1);
 
-    if (request.getStatus() != null) {
-      query.setParameter("status", request.getStatus());
+    if (query.getStatus() != null) {
+      typedQuery.setParameter("status", query.getStatus());
     }
 
-    if (request.getMemberId() != null) {
-      query.setParameter("memberId", request.getMemberId());
+    if (query.getMemberId() != null) {
+      typedQuery.setParameter("memberId", query.getMemberId());
     }
 
-    return query.getResultList();
+    return typedQuery.getResultList();
   }
 
   public Optional<Report> findById(Long reportId) {
     return Optional.ofNullable(em.find(Report.class, reportId));
   }
 
-  public List<Report> findMyReports(Member member, ReportPaginationRequest request) {
-    int page = request.getPage();
-    int size = request.getSize();
+  public List<Report> findMyReports(Member member, ReportPaginationQuery query) {
+    int page = query.getPage();
+    int size = query.getSize();
 
     String jpql = "select r from Report r left join fetch r.quote where r.member.id = :memberId";
 
-    if (request.getStatus() != null) {
+    if (query.getStatus() != null) {
       jpql += " and r.status = :status";
     }
 
-    jpql += " order by r." + request.getOrderBy() + " " + request.getSortDirection();
+    jpql += " order by r." + query.getOrderBy() + " " + query.getSortDirection();
 
-    TypedQuery<Report> query = em.createQuery(jpql, Report.class);
+    TypedQuery<Report> typedQuery = em.createQuery(jpql, Report.class);
 
-    query.setFirstResult((page - 1) * size).setMaxResults(size + 1);
+    typedQuery.setFirstResult((page - 1) * size).setMaxResults(size + 1);
 
-    query.setParameter("memberId", member.getId());
+    typedQuery.setParameter("memberId", member.getId());
 
-    if (request.getStatus() != null) {
-      query.setParameter("status", request.getStatus());
+    if (query.getStatus() != null) {
+      typedQuery.setParameter("status", query.getStatus());
     }
 
-    return query.getResultList();
+    return typedQuery.getResultList();
   }
 
   public List<Report> findByQuote(Quote quote) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/service/AdminReportService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/service/AdminReportService.java
@@ -6,9 +6,9 @@ import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
 import com.typingpractice.typing_practice_be.report.domain.Report;
-import com.typingpractice.typing_practice_be.report.dto.ReportPaginationRequest;
-import com.typingpractice.typing_practice_be.report.dto.ReportProcessRequest;
 import com.typingpractice.typing_practice_be.report.exception.ReportNotFoundException;
+import com.typingpractice.typing_practice_be.report.query.ReportPaginationQuery;
+import com.typingpractice.typing_practice_be.report.query.ReportProcessQuery;
 import com.typingpractice.typing_practice_be.report.repository.ReportRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -23,30 +23,30 @@ public class AdminReportService {
   private final QuoteRepository quoteRepository;
   private final ReportRepository reportRepository;
 
-  public List<Report> findReports(ReportPaginationRequest request) {
+  public List<Report> findReports(ReportPaginationQuery query) {
 
-    if (request.getMemberId() != null) {
-      memberRepository.findById(request.getMemberId()).orElseThrow(MemberNotFoundException::new);
+    if (query.getMemberId() != null) {
+      memberRepository.findById(query.getMemberId()).orElseThrow(MemberNotFoundException::new);
     }
 
-    List<Report> all = reportRepository.findAll(request);
+    List<Report> all = reportRepository.findAll(query);
 
     return all;
   }
 
   @Transactional
-  public void processReport(Long quoteId, ReportProcessRequest request) {
+  public void processReport(Long quoteId, ReportProcessQuery query) {
     Quote targetQuote = quoteRepository.findById(quoteId).orElseThrow(QuoteNotFoundException::new);
 
     // DTO 에 값이 없으면 삭제
-    if (request.getSentence() == null && request.getAuthor() == null) {
+    if (query.getSentence() == null && query.getAuthor() == null) {
       quoteRepository.deleteQuote(targetQuote);
 
       // 신고 내역 처리
       reportRepository.processReportByQuote(targetQuote, true);
     } else {
       // DTO 에 값이 있으면 수정
-      targetQuote.update(request.getSentence(), request.getAuthor());
+      targetQuote.update(query.getSentence(), query.getAuthor());
       targetQuote.resetReportCount();
 
       // 신고 내역 처리

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/service/ReportService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/service/ReportService.java
@@ -11,16 +11,15 @@ import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
 import com.typingpractice.typing_practice_be.report.domain.Report;
-import com.typingpractice.typing_practice_be.report.dto.ReportCreateRequest;
-import com.typingpractice.typing_practice_be.report.dto.ReportPaginationRequest;
 import com.typingpractice.typing_practice_be.report.exception.DuplicateReportException;
 import com.typingpractice.typing_practice_be.report.exception.QuoteNotReportableException;
 import com.typingpractice.typing_practice_be.report.exception.ReportNotFoundException;
 import com.typingpractice.typing_practice_be.report.exception.ReportNotProcessableException;
+import com.typingpractice.typing_practice_be.report.query.ReportCreateQuery;
+import com.typingpractice.typing_practice_be.report.query.ReportPaginationQuery;
 import com.typingpractice.typing_practice_be.report.repository.ReportRepository;
 import java.util.List;
 import java.util.Objects;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,7 +36,7 @@ public class ReportService {
 
   // 신고 생성
   @Transactional
-  public Report createReport(Long memberId, Long quoteId, ReportCreateRequest request) {
+  public Report createReport(Long memberId, Long quoteId, ReportCreateQuery query) {
     Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
     Quote quote = quoteRepository.findById(quoteId).orElseThrow(QuoteNotFoundException::new);
 
@@ -57,7 +56,7 @@ public class ReportService {
     }
 
     // 신고 생성
-    Report report = Report.create(member, quote, request.getReason(), request.getDetail());
+    Report report = Report.create(member, quote, query.getReason(), query.getDetail());
 
     reportRepository.save(report);
 
@@ -74,10 +73,10 @@ public class ReportService {
 
   // 내 신고 내역 조회
   // 페이징 추가 필요
-  public List<Report> findMyReports(Long memberId, ReportPaginationRequest request) {
+  public List<Report> findMyReports(Long memberId, ReportPaginationQuery query) {
     Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
-    return reportRepository.findMyReports(member, request);
+    return reportRepository.findMyReports(member, query);
   }
 
   // 본인 신고 내역 삭제(철회 or 처리된 신고 삭제)


### PR DESCRIPTION
## Query 객체
- ReportCreateQuery: 신고 생성
- ReportPaginationQuery: 신고 페이징 조회
- ReportProcessQuery: 신고 처리

## 레이어 역할
- Controller: DTO 수신 → Query 변환
- Service/Repository: Query 객체만 의존

## 구조
- private 생성자 + from() 정적 팩토리 메서드
- final 필드로 불변성 보장