### PR TITLE
refactor: AdminMember 도메인 DTO → Query 객체 분리

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/AdminMemberController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/AdminMemberController.java
@@ -4,11 +4,13 @@ import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.domain.MemberRole;
 import com.typingpractice.typing_practice_be.member.dto.*;
-import com.typingpractice.typing_practice_be.member.dto.admin.BanMemberRequest;
+import com.typingpractice.typing_practice_be.member.dto.admin.MemberBanRequest;
 import com.typingpractice.typing_practice_be.member.dto.admin.MemberPaginationRequest;
 import com.typingpractice.typing_practice_be.member.dto.admin.MemberPaginationResponse;
-import com.typingpractice.typing_practice_be.member.dto.admin.UpdateMemberRoleRequest;
+import com.typingpractice.typing_practice_be.member.dto.admin.MemberUpdateRoleRequest;
 import com.typingpractice.typing_practice_be.member.exception.NotAdminException;
+import com.typingpractice.typing_practice_be.member.query.MemberBanQuery;
+import com.typingpractice.typing_practice_be.member.query.MemberPaginationQuery;
 import com.typingpractice.typing_practice_be.member.service.AdminMemberService;
 import com.typingpractice.typing_practice_be.member.service.MemberService;
 import jakarta.validation.Valid;
@@ -38,7 +40,9 @@ public class AdminMemberController {
       @ModelAttribute @Valid MemberPaginationRequest request) {
     validateAdmin();
 
-    List<Member> allMembers = adminMemberService.findAllMembers(request);
+    MemberPaginationQuery query = MemberPaginationQuery.from(request);
+
+    List<Member> allMembers = adminMemberService.findAllMembers(query);
 
     boolean hasNext = allMembers.size() > request.getSize();
 
@@ -57,7 +61,7 @@ public class AdminMemberController {
 
   @PatchMapping("/admin/members/{memberId}/role")
   public ApiResponse<MemberResponse> updateMemberRole(
-      @PathVariable Long memberId, @RequestBody UpdateMemberRoleRequest request) {
+      @PathVariable Long memberId, @RequestBody MemberUpdateRoleRequest request) {
     validateAdmin();
 
     Member member = adminMemberService.updateRole(memberId, request.getRole());
@@ -67,10 +71,12 @@ public class AdminMemberController {
 
   @PostMapping("/admin/members/{memberId}/ban")
   public ApiResponse<MemberResponse> banMember(
-      @PathVariable Long memberId, @RequestBody BanMemberRequest request) {
+      @PathVariable Long memberId, @RequestBody MemberBanRequest request) {
     validateAdmin();
 
-    Member member = adminMemberService.banMember(memberId, request);
+    MemberBanQuery query = MemberBanQuery.from(request);
+
+    Member member = adminMemberService.banMember(memberId, query);
 
     return ApiResponse.ok(MemberResponse.from(member));
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/admin/MemberBanRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/admin/MemberBanRequest.java
@@ -5,6 +5,6 @@ import lombok.ToString;
 
 @Getter
 @ToString
-public class BanMemberRequest {
+public class MemberBanRequest {
   private String banReason;
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/admin/MemberUpdateRoleRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/admin/MemberUpdateRoleRequest.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 
 @Getter
 @ToString
-public class UpdateMemberRoleRequest {
+public class MemberUpdateRoleRequest {
   @NotNull(message = "필수값 누락")
   private MemberRole role;
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/query/MemberBanQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/query/MemberBanQuery.java
@@ -1,0 +1,19 @@
+package com.typingpractice.typing_practice_be.member.query;
+
+import com.typingpractice.typing_practice_be.member.dto.admin.MemberBanRequest;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class MemberBanQuery {
+  private final String banReason;
+
+  private MemberBanQuery(String banReason) {
+    this.banReason = banReason;
+  }
+
+  public static MemberBanQuery from(MemberBanRequest request) {
+    return new MemberBanQuery(request.getBanReason());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/query/MemberPaginationQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/query/MemberPaginationQuery.java
@@ -1,0 +1,33 @@
+package com.typingpractice.typing_practice_be.member.query;
+
+import com.typingpractice.typing_practice_be.common.domain.SortDirection;
+import com.typingpractice.typing_practice_be.common.query.PaginationQuery;
+import com.typingpractice.typing_practice_be.member.domain.MemberOrderBy;
+import com.typingpractice.typing_practice_be.member.domain.MemberRole;
+import com.typingpractice.typing_practice_be.member.dto.admin.MemberPaginationRequest;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true)
+public class MemberPaginationQuery extends PaginationQuery {
+  private final MemberRole role;
+  private final MemberOrderBy orderBy;
+
+  private MemberPaginationQuery(
+      int page, int size, SortDirection sortDirection, MemberRole role, MemberOrderBy orderBy) {
+    super(page, size, sortDirection);
+
+    this.role = role;
+    this.orderBy = orderBy;
+  }
+
+  public static MemberPaginationQuery from(MemberPaginationRequest request) {
+    return new MemberPaginationQuery(
+        request.getPage(),
+        request.getSize(),
+        request.getSortDirection(),
+        request.getRole(),
+        request.getOrderBy());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepository.java
@@ -1,13 +1,12 @@
 package com.typingpractice.typing_practice_be.member.repository;
 
 import com.typingpractice.typing_practice_be.member.domain.Member;
-import com.typingpractice.typing_practice_be.member.dto.admin.MemberPaginationRequest;
-
+import com.typingpractice.typing_practice_be.member.query.MemberPaginationQuery;
 import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository {
-  List<Member> findAll(MemberPaginationRequest request);
+  List<Member> findAll(MemberPaginationQuery query);
 
   Optional<Member> findById(Long memberId);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepositoryImpl.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepositoryImpl.java
@@ -1,7 +1,7 @@
 package com.typingpractice.typing_practice_be.member.repository;
 
 import com.typingpractice.typing_practice_be.member.domain.Member;
-import com.typingpractice.typing_practice_be.member.dto.admin.MemberPaginationRequest;
+import com.typingpractice.typing_practice_be.member.query.MemberPaginationQuery;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 import java.util.List;
@@ -15,23 +15,25 @@ public class MemberRepositoryImpl implements MemberRepository {
   private final EntityManager em;
 
   @Override
-  public List<Member> findAll(MemberPaginationRequest request) {
-    int page = request.getPage();
-    int size = request.getSize();
+  public List<Member> findAll(MemberPaginationQuery query) {
+    int page = query.getPage();
+    int size = query.getSize();
 
     String jpql = "select m from Member m";
 
-    if (request.getRole() != null) {
+    if (query.getRole() != null) {
       jpql += " where m.role = :role";
     }
-    jpql += (" order by m." + request.getOrderBy() + " " + request.getSortDirection());
 
-    TypedQuery<Member> query = em.createQuery(jpql, Member.class);
-    if (request.getRole() != null) {
-      query.setParameter("role", request.getRole());
+    jpql += (" order by m." + query.getOrderBy() + " " + query.getSortDirection());
+
+    TypedQuery<Member> typedQuery = em.createQuery(jpql, Member.class);
+
+    if (query.getRole() != null) {
+      typedQuery.setParameter("role", query.getRole());
     }
 
-    return query.setFirstResult((page - 1) * size).setMaxResults(size + 1).getResultList();
+    return typedQuery.setFirstResult((page - 1) * size).setMaxResults(size + 1).getResultList();
   }
 
   @Override

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MockMemberRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MockMemberRepository.java
@@ -1,8 +1,7 @@
 package com.typingpractice.typing_practice_be.member.repository;
 
 import com.typingpractice.typing_practice_be.member.domain.Member;
-import com.typingpractice.typing_practice_be.member.dto.admin.MemberPaginationRequest;
-
+import com.typingpractice.typing_practice_be.member.query.MemberPaginationQuery;
 import java.util.*;
 
 public class MockMemberRepository implements MemberRepository {
@@ -10,7 +9,7 @@ public class MockMemberRepository implements MemberRepository {
   private Long sequence = 1L;
 
   @Override
-  public List<Member> findAll(MemberPaginationRequest request) {
+  public List<Member> findAll(MemberPaginationQuery request) {
     return new ArrayList<>(store.values());
   }
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/AdminMemberService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/AdminMemberService.java
@@ -2,10 +2,10 @@ package com.typingpractice.typing_practice_be.member.service;
 
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.domain.MemberRole;
-import com.typingpractice.typing_practice_be.member.dto.admin.BanMemberRequest;
-import com.typingpractice.typing_practice_be.member.dto.admin.MemberPaginationRequest;
 import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
 import com.typingpractice.typing_practice_be.member.exception.MemberNotProcessableException;
+import com.typingpractice.typing_practice_be.member.query.MemberBanQuery;
+import com.typingpractice.typing_practice_be.member.query.MemberPaginationQuery;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,8 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminMemberService {
   private final MemberRepository memberRepository;
 
-  public List<Member> findAllMembers(MemberPaginationRequest request) {
-    List<Member> members = memberRepository.findAll(request);
+  public List<Member> findAllMembers(MemberPaginationQuery query) {
+    List<Member> members = memberRepository.findAll(query);
 
     return members;
   }
@@ -42,14 +42,14 @@ public class AdminMemberService {
   }
 
   @Transactional
-  public Member banMember(Long memberId, BanMemberRequest request) {
+  public Member banMember(Long memberId, MemberBanQuery query) {
     Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
 
     if (member.getRole() == MemberRole.ADMIN) {
       throw new MemberNotProcessableException();
     }
 
-    member.ban(request.getBanReason());
+    member.ban(query.getBanReason());
 
     return member;
   }


### PR DESCRIPTION
## Query 객체
- MemberPaginationQuery: 회원 목록 조회
- MemberBanQuery: 회원 밴

## DTO 네이밍 통일
- BanMemberRequest → MemberBanRequest
- UpdateMemberRoleRequest → MemberUpdateRoleRequest

## 레이어 역할
- Controller: DTO 수신 → Query 변환
- Service/Repository: Query 객체만 의존