### PR TITLE
feat: JWT에 role 추가 및 인증/인가 개선

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtTokenProvider.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.common.jwt;
 
+import com.typingpractice.typing_practice_be.member.domain.MemberRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -21,13 +22,14 @@ public class JwtTokenProvider {
     this.expiration = expiration;
   }
 
-  public String createToken(Long memberId, String email) {
+  public String createToken(Long memberId, String email, MemberRole role) {
     Date now = new Date();
     Date expiryDate = new Date(now.getTime() + expiration); // 만료 시간
 
     return Jwts.builder()
         .subject(String.valueOf(memberId))
         .claim("email", email)
+        .claim("role", role.name())
         .issuedAt(now)
         .expiration(expiryDate)
         .signWith(secretKey)
@@ -37,6 +39,11 @@ public class JwtTokenProvider {
   public Long getMemberId(String token) {
     Claims claims = parseClaims(token);
     return Long.valueOf(claims.getSubject());
+  }
+
+  public String getRole(String token) {
+    Claims claims = parseClaims(token);
+    return claims.get("role", String.class);
   }
 
   public boolean validateToken(String token) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/AdminCheckAspect.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/AdminCheckAspect.java
@@ -1,0 +1,25 @@
+package com.typingpractice.typing_practice_be.common.security;
+
+import com.typingpractice.typing_practice_be.member.domain.MemberRole;
+import com.typingpractice.typing_practice_be.member.exception.NotAdminException;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class AdminCheckAspect {
+  @Before("@within(AdminOnly) || @annotation(AdminOnly)")
+  public void checkAdmin() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    boolean isAdmin =
+        auth.getAuthorities().stream()
+            .anyMatch(a -> a.getAuthority().equals(MemberRole.ADMIN.getAuthority()));
+
+    if (!isAdmin) {
+      throw new NotAdminException();
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/AdminOnly.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/AdminOnly.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.common.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AdminOnly {}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/CustomAuthenticationEntryPoint.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.typingpractice.typing_practice_be.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+  private final ObjectMapper objectMapper;
+
+  public CustomAuthenticationEntryPoint(ObjectMapper objectMapper) {
+    this.objectMapper = objectMapper;
+  }
+
+  @Override
+  public void commence(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AuthenticationException authException)
+      throws IOException {
+
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    response.setContentType("application/problem+json;charset=UTF-8");
+
+    ProblemDetail problemDetail =
+        ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+    problemDetail.setTitle("Unauthorized");
+
+    response.getWriter().write(objectMapper.writeValueAsString(problemDetail));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.config;
 
 import com.typingpractice.typing_practice_be.common.jwt.JwtAuthenticationFilter;
+import com.typingpractice.typing_practice_be.common.security.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,6 +18,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
 
   private final JwtAuthenticationFilter jwtAuthenticationFilter;
+  private final CustomAuthenticationEntryPoint authenticationEntryPoint;
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -40,6 +42,7 @@ public class SecurityConfig {
             //                    .anyRequest()
             //                    .authenticated() // 나머지는 인증 필요
             )
+        .exceptionHandling(ex -> ex.authenticationEntryPoint(authenticationEntryPoint))
         .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
     return http.build();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/AdminMemberController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/AdminMemberController.java
@@ -2,43 +2,29 @@ package com.typingpractice.typing_practice_be.member.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
+import com.typingpractice.typing_practice_be.common.security.AdminOnly;
 import com.typingpractice.typing_practice_be.member.domain.Member;
-import com.typingpractice.typing_practice_be.member.domain.MemberRole;
 import com.typingpractice.typing_practice_be.member.dto.*;
 import com.typingpractice.typing_practice_be.member.dto.admin.MemberBanRequest;
 import com.typingpractice.typing_practice_be.member.dto.admin.MemberPaginationRequest;
 import com.typingpractice.typing_practice_be.member.dto.admin.MemberPaginationResponse;
 import com.typingpractice.typing_practice_be.member.dto.admin.MemberUpdateRoleRequest;
-import com.typingpractice.typing_practice_be.member.exception.NotAdminException;
 import com.typingpractice.typing_practice_be.member.query.MemberBanQuery;
 import com.typingpractice.typing_practice_be.member.query.MemberPaginationQuery;
 import com.typingpractice.typing_practice_be.member.service.AdminMemberService;
-import com.typingpractice.typing_practice_be.member.service.MemberService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@AdminOnly
 public class AdminMemberController {
-  private final MemberService memberService;
   private final AdminMemberService adminMemberService;
-
-  private void validateAdmin() {
-    Long memberId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-
-    Member admin = memberService.findMemberById(memberId);
-
-    if (admin.getRole() != MemberRole.ADMIN) {
-      throw new NotAdminException();
-    }
-  }
 
   @GetMapping("/admin/members")
   public ApiResponse<MemberPaginationResponse> getMemberList(
       @ModelAttribute @Valid MemberPaginationRequest request) {
-    validateAdmin();
 
     MemberPaginationQuery query = MemberPaginationQuery.from(request);
 
@@ -49,7 +35,6 @@ public class AdminMemberController {
 
   @GetMapping("/admin/members/{memberId}")
   public ApiResponse<MemberResponse> findMemberById(@PathVariable Long memberId) {
-    validateAdmin();
 
     Member member = adminMemberService.findMemberById(memberId);
 
@@ -59,7 +44,6 @@ public class AdminMemberController {
   @PatchMapping("/admin/members/{memberId}/role")
   public ApiResponse<MemberResponse> updateMemberRole(
       @PathVariable Long memberId, @RequestBody MemberUpdateRoleRequest request) {
-    validateAdmin();
 
     Member member = adminMemberService.updateRole(memberId, request.getRole());
 
@@ -69,7 +53,6 @@ public class AdminMemberController {
   @PostMapping("/admin/members/{memberId}/ban")
   public ApiResponse<MemberResponse> banMember(
       @PathVariable Long memberId, @RequestBody MemberBanRequest request) {
-    validateAdmin();
 
     MemberBanQuery query = MemberBanQuery.from(request);
 
@@ -80,7 +63,6 @@ public class AdminMemberController {
 
   @PostMapping("/admin/members/{memberId}/unban")
   public ApiResponse<MemberResponse> unbanMember(@PathVariable Long memberId) {
-    validateAdmin();
 
     Member member = adminMemberService.unbanMember(memberId);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
@@ -31,7 +31,8 @@ public class MemberController {
 
     Member member = this.memberService.loginOrSignIn(query);
 
-    String token = jwtTokenProvider.createToken(member.getId(), member.getEmail());
+    String token =
+        jwtTokenProvider.createToken(member.getId(), member.getEmail(), member.getRole());
 
     return ApiResponse.ok(LoginResponse.of(member, token));
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/MemberRole.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/MemberRole.java
@@ -1,7 +1,16 @@
 package com.typingpractice.typing_practice_be.member.domain;
 
+import lombok.Getter;
+
+@Getter
 public enum MemberRole {
-  USER,
-  ADMIN,
-  BANNED
+  USER("ROLE_USER"),
+  ADMIN("ROLE_ADMIN"),
+  BANNED("ROLE_BANNED");
+
+  private final String authority;
+
+  MemberRole(String authority) {
+    this.authority = authority;
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
@@ -2,10 +2,7 @@ package com.typingpractice.typing_practice_be.quote.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
-import com.typingpractice.typing_practice_be.member.domain.Member;
-import com.typingpractice.typing_practice_be.member.domain.MemberRole;
-import com.typingpractice.typing_practice_be.member.exception.NotAdminException;
-import com.typingpractice.typing_practice_be.member.service.MemberService;
+import com.typingpractice.typing_practice_be.common.security.AdminOnly;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationResponse;
@@ -16,28 +13,17 @@ import com.typingpractice.typing_practice_be.quote.query.QuoteUpdateQuery;
 import com.typingpractice.typing_practice_be.quote.service.AdminQuoteService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@AdminOnly
 public class AdminQuoteController {
-  private final MemberService memberService;
   private final AdminQuoteService adminQuoteService;
-
-  private void validateAdmin() {
-    Long memberId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-    Member member = memberService.findMemberById(memberId);
-
-    if (member.getRole() != MemberRole.ADMIN) {
-      throw new NotAdminException();
-    }
-  }
 
   @GetMapping("/admin/quotes")
   public ApiResponse<QuotePaginationResponse> getQuotes(
       @ModelAttribute @Valid QuotePaginationRequest request) {
-    validateAdmin();
 
     QuotePaginationQuery query = QuotePaginationQuery.from(request);
 
@@ -46,20 +32,9 @@ public class AdminQuoteController {
     return ApiResponse.ok(QuotePaginationResponse.from(result));
   }
 
-  //  // 승인 대기 목록 조회
-  //  @GetMapping("/admin/quotes/pending")
-  //  public ApiResponse<List<QuoteResponse>> getPendingQuotes() {
-  //    validateAdmin();
-  //
-  //    List<Quote> pendingQuotes = adminQuoteService.findPendingQuotes();
-  //
-  //    return ApiResponse.ok(pendingQuotes.stream().map(QuoteResponse::from).toList());
-  //  }
-
   // 승인
   @PostMapping("/admin/quotes/{quoteId}/approve")
   public ApiResponse<QuoteResponse> approvePendingQuote(@PathVariable Long quoteId) {
-    validateAdmin();
 
     Quote quote = adminQuoteService.approvePublish(quoteId);
 
@@ -69,7 +44,6 @@ public class AdminQuoteController {
   // 거부
   @PostMapping("/admin/quotes/{quoteId}/reject")
   public ApiResponse<QuoteResponse> rejectPendingQuote(@PathVariable Long quoteId) {
-    validateAdmin();
 
     Quote quote = adminQuoteService.rejectPublish(quoteId);
 
@@ -80,7 +54,6 @@ public class AdminQuoteController {
   @PatchMapping("/admin/quotes/{quoteId}")
   public ApiResponse<QuoteResponse> patchQuote(
       @PathVariable Long quoteId, @RequestBody QuoteUpdateRequest request) {
-    validateAdmin();
 
     QuoteUpdateQuery query = QuoteUpdateQuery.from(request);
 
@@ -92,27 +65,15 @@ public class AdminQuoteController {
   // 삭제
   @DeleteMapping("/admin/quotes/{quoteId}")
   public ApiResponse<Void> deleteQuote(@PathVariable Long quoteId) {
-    validateAdmin();
 
     adminQuoteService.deleteQuote(quoteId);
 
     return ApiResponse.ok(null);
   }
 
-  //  // 숨김 목록
-  //  @GetMapping("/admin/quotes/hidden")
-  //  public ApiResponse<List<QuoteResponse>> getHiddenQuotes() {
-  //    validateAdmin();
-  //
-  //    List<Quote> hiddenQuotes = adminQuoteService.findHiddenQuotes();
-  //
-  //    return ApiResponse.ok(hiddenQuotes.stream().map(QuoteResponse::from).toList());
-  //  }
-
   // 숨김 해제
   @PostMapping("/admin/quotes/{quoteId}/restore")
   public ApiResponse<QuoteResponse> restoreHiddenQuotes(@PathVariable Long quoteId) {
-    validateAdmin();
 
     Quote quote = adminQuoteService.cancelHidden(quoteId);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/AdminReportController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/AdminReportController.java
@@ -2,10 +2,7 @@ package com.typingpractice.typing_practice_be.report.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
-import com.typingpractice.typing_practice_be.member.domain.Member;
-import com.typingpractice.typing_practice_be.member.domain.MemberRole;
-import com.typingpractice.typing_practice_be.member.exception.NotAdminException;
-import com.typingpractice.typing_practice_be.member.service.MemberService;
+import com.typingpractice.typing_practice_be.common.security.AdminOnly;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.dto.*;
 import com.typingpractice.typing_practice_be.report.query.ReportPaginationQuery;
@@ -13,28 +10,18 @@ import com.typingpractice.typing_practice_be.report.query.ReportProcessQuery;
 import com.typingpractice.typing_practice_be.report.service.AdminReportService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
+@AdminOnly
 public class AdminReportController {
-  private final MemberService memberService;
+
   private final AdminReportService adminReportService;
-
-  private void validateAdmin() {
-    Long memberId = (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-    Member member = memberService.findMemberById(memberId);
-
-    if (member.getRole() != MemberRole.ADMIN) {
-      throw new NotAdminException();
-    }
-  }
 
   @GetMapping("/admin/reports")
   public ApiResponse<AdminReportPaginationResponse> getReports(
       @ModelAttribute @Valid ReportPaginationRequest request) {
-    validateAdmin();
 
     ReportPaginationQuery query = ReportPaginationQuery.from(request);
 
@@ -46,7 +33,6 @@ public class AdminReportController {
   @PostMapping("/admin/reports/{quoteId}/process")
   public ApiResponse<Void> processReport(
       @PathVariable Long quoteId, @RequestBody @Valid ReportProcessRequest request) {
-    validateAdmin();
 
     ReportProcessQuery query = ReportProcessQuery.from(request);
 
@@ -57,7 +43,6 @@ public class AdminReportController {
 
   @DeleteMapping("/admin/reports/{reportId}")
   public ApiResponse<Void> deleteReport(@PathVariable Long reportId) {
-    validateAdmin();
 
     adminReportService.deleteReport(reportId);
 


### PR DESCRIPTION
## JWT
- JwtTokenProvider: role claim 추가, getRole() 메서드 추가
- JwtAuthenticationFilter: role을 authorities로 설정
- BANNED 유저 필터에서 차단
- payload 파싱 실패 시 예외 처리 (clearContext)

## 관리자 권한 체크
- MemberRole: authority 필드 추가 (ROLE_ 접두사 관리)
- @AdminOnly 어노테이션 + AOP로 공통화
- Admin 컨트롤러에서 validateAdmin() 제거

## 인증 실패 응답
- CustomAuthenticationEntryPoint: 401 응답 커스터마이징
- ProblemDetail 형식으로 일관성 유지