### PR TITLE
feat: JWT 블랙리스트 구현 및 auth 패키지 구조 개선

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/TypingPracticeBeApplication.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/TypingPracticeBeApplication.java
@@ -3,9 +3,11 @@ package com.typingpractice.typing_practice_be;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class TypingPracticeBeApplication {
 
   public static void main(String[] args) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/AuthController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/AuthController.java
@@ -1,16 +1,18 @@
-package com.typingpractice.typing_practice_be.auth;
+package com.typingpractice.typing_practice_be.auth.controller;
 
+import com.typingpractice.typing_practice_be.auth.dto.google.GoogleLoginRequest;
+import com.typingpractice.typing_practice_be.auth.dto.google.GoogleTokenResponse;
+import com.typingpractice.typing_practice_be.auth.dto.google.GoogleUserInfo;
+import com.typingpractice.typing_practice_be.auth.service.AuthService;
 import com.typingpractice.typing_practice_be.auth.dto.*;
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.jwt.JwtTokenProvider;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.dto.LoginResult;
 import com.typingpractice.typing_practice_be.member.service.MemberService;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/auth")
@@ -30,8 +32,7 @@ public class AuthController {
 
     Member member = loginResult.getMember();
 
-    String token =
-        jwtTokenProvider.createToken(member.getId(), member.getEmail(), member.getRole());
+    String token = jwtTokenProvider.createToken(member.getId(), member.getRole());
 
     return ApiResponse.ok(LoginResponse.from(loginResult, token));
   }
@@ -46,9 +47,19 @@ public class AuthController {
     LoginResult loginResult = memberService.loginOrSignIn(userInfo);
 
     Member member = loginResult.getMember();
-    String token =
-        jwtTokenProvider.createToken(member.getId(), member.getEmail(), member.getRole());
+    String token = jwtTokenProvider.createToken(member.getId(), member.getRole());
 
     return ApiResponse.ok(LoginResponse.from(loginResult, token));
+  }
+
+  @PostMapping("/logout")
+  public ApiResponse<Void> logout(
+      @Parameter(hidden = true) @RequestHeader("Authorization") String authHeader) {
+
+    String token = authHeader.substring("Bearer ".length());
+
+    authService.logout(token);
+
+    return ApiResponse.ok(null);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/domain/JwtBlackList.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/domain/JwtBlackList.java
@@ -1,0 +1,34 @@
+package com.typingpractice.typing_practice_be.auth.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class JwtBlackList extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "token_blacklist_id")
+  private Long id;
+
+  private String jwtId;
+
+  private LocalDateTime expiresIn;
+
+  public static JwtBlackList create(String jwtId, LocalDateTime expiresIn) {
+    JwtBlackList jwtBlackList = new JwtBlackList();
+    jwtBlackList.jwtId = jwtId;
+    jwtBlackList.expiresIn = expiresIn;
+
+    return jwtBlackList;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/google/GoogleLoginRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/google/GoogleLoginRequest.java
@@ -1,4 +1,4 @@
-package com.typingpractice.typing_practice_be.auth.dto;
+package com.typingpractice.typing_practice_be.auth.dto.google;
 
 import lombok.Getter;
 import lombok.ToString;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/google/GoogleTokenResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/google/GoogleTokenResponse.java
@@ -1,4 +1,4 @@
-package com.typingpractice.typing_practice_be.auth.dto;
+package com.typingpractice.typing_practice_be.auth.dto.google;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/google/GoogleUserInfo.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/google/GoogleUserInfo.java
@@ -1,4 +1,4 @@
-package com.typingpractice.typing_practice_be.auth.dto;
+package com.typingpractice.typing_practice_be.auth.dto.google;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.*;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/repository/JwtBlackListRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/repository/JwtBlackListRepository.java
@@ -1,0 +1,34 @@
+package com.typingpractice.typing_practice_be.auth.repository;
+
+import com.typingpractice.typing_practice_be.auth.domain.JwtBlackList;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+
+@Repository
+@RequiredArgsConstructor
+public class JwtBlackListRepository {
+  private final EntityManager em;
+
+  public Long save(JwtBlackList jwtBlackList) {
+    em.persist(jwtBlackList);
+
+    return jwtBlackList.getId();
+  }
+
+  public boolean existByJwtId(String jwtId) {
+
+    return !em.createQuery("select j from JwtBlackList j where jwtId = :jwtId", JwtBlackList.class)
+        .setParameter("jwtId", jwtId)
+        .getResultList()
+        .isEmpty();
+  }
+
+  public void deleteExpiredTokens(LocalDateTime now) {
+    em.createQuery("delete from JwtBlackList j where j.expiresIn < :now")
+        .setParameter("now", now)
+        .executeUpdate();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/service/BlackListCleanupScheduler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/service/BlackListCleanupScheduler.java
@@ -1,0 +1,22 @@
+package com.typingpractice.typing_practice_be.auth.service;
+
+import com.typingpractice.typing_practice_be.auth.repository.JwtBlackListRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+
+@Component
+@RequiredArgsConstructor
+public class BlackListCleanupScheduler {
+  private final JwtBlackListRepository jwtBlackListRepository;
+
+  @Scheduled(cron = "0 0 3 * * *")
+  @Transactional
+  public void cleanupExpiredTokens() {
+    jwtBlackListRepository.deleteExpiredTokens(LocalDateTime.now(ZoneOffset.UTC));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtPayload.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtPayload.java
@@ -1,0 +1,39 @@
+package com.typingpractice.typing_practice_be.common.jwt;
+
+import com.typingpractice.typing_practice_be.member.domain.MemberRole;
+import io.jsonwebtoken.Claims;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class JwtPayload {
+  private Long memberId;
+
+  private MemberRole role;
+
+  private String jwtId;
+
+  private LocalDateTime issuedAt;
+  private LocalDateTime expiresIn;
+
+  private JwtPayload() {}
+
+  public static JwtPayload create(Claims jwtClaims) {
+    JwtPayload jwtPayload = new JwtPayload();
+
+    jwtPayload.memberId = Long.valueOf(jwtClaims.getSubject());
+    jwtPayload.role = MemberRole.valueOf(jwtClaims.get("role", String.class));
+
+    jwtPayload.jwtId = jwtClaims.get("jwtId", String.class);
+
+    jwtPayload.issuedAt =
+        LocalDateTime.ofInstant(jwtClaims.getIssuedAt().toInstant(), ZoneOffset.UTC);
+    jwtPayload.expiresIn =
+        LocalDateTime.ofInstant(jwtClaims.getExpiration().toInstant(), ZoneOffset.UTC);
+
+    return jwtPayload;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtTokenProvider.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtTokenProvider.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Component;
 import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
+import java.util.UUID;
 
 @Component
 public class JwtTokenProvider {
@@ -22,14 +23,14 @@ public class JwtTokenProvider {
     this.expiration = expiration;
   }
 
-  public String createToken(Long memberId, String email, MemberRole role) {
+  public String createToken(Long memberId, MemberRole role) {
     Date now = new Date();
     Date expiryDate = new Date(now.getTime() + expiration); // 만료 시간
 
     return Jwts.builder()
         .subject(String.valueOf(memberId))
-        .claim("email", email)
         .claim("role", role.name())
+        .claim("jwtId", UUID.randomUUID().toString())
         .issuedAt(now)
         .expiration(expiryDate)
         .signWith(secretKey)
@@ -44,6 +45,11 @@ public class JwtTokenProvider {
   public String getRole(String token) {
     Claims claims = parseClaims(token);
     return claims.get("role", String.class);
+  }
+
+  public JwtPayload getJwtPayload(String token) {
+    Claims claims = parseClaims(token);
+    return JwtPayload.create(claims);
   }
 
   public boolean validateToken(String token) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/MemberService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/MemberService.java
@@ -1,6 +1,6 @@
 package com.typingpractice.typing_practice_be.member.service;
 
-import com.typingpractice.typing_practice_be.auth.dto.GoogleUserInfo;
+import com.typingpractice.typing_practice_be.auth.dto.google.GoogleUserInfo;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.dto.LoginResult;
 import com.typingpractice.typing_practice_be.member.query.MemberCreateQuery;

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/member/service/MemberServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/member/service/MemberServiceTest.java
@@ -2,7 +2,7 @@ package com.typingpractice.typing_practice_be.member.service;
 
 import static org.assertj.core.api.Assertions.*;
 
-import com.typingpractice.typing_practice_be.auth.dto.GoogleUserInfo;
+import com.typingpractice.typing_practice_be.auth.dto.google.GoogleUserInfo;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.dto.LoginResult;
 import com.typingpractice.typing_practice_be.member.dto.UpdateNicknameRequest;


### PR DESCRIPTION
## JWT 블랙리스트
- JwtBlackList 엔티티 (jwtId, expiresIn)
- JwtBlackListRepository: save(), existByJwtId(), deleteExpiredTokens()
- AuthController: POST /auth/logout 엔드포인트
- AuthService: logout(), isBlacklistedJwt()
- JwtAuthenticationFilter: AuthService를 통해 블랙리스트 체크

## 만료 토큰 정리
- BlackListCleanupScheduler: 매일 새벽 3시 만료된 토큰 삭제
- @EnableScheduling 적용

## auth 패키지 구조 분리
- controller, service 폴더 분리
- dto/google 폴더로 Google 관련 DTO 분리

## JWT 토큰 수정
- JwtPayload를 common/jwt로 이동
- createToken에서 email 파라미터 제거 (개인정보 보호)
- jwtId claim 추가