### PR TITLE
feat: Refresh Token rotation 구현 및 설정 외부화

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/TypingPracticeBeApplication.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/TypingPracticeBeApplication.java
@@ -2,12 +2,14 @@ package com.typingpractice.typing_practice_be;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
+@ConfigurationPropertiesScan
 public class TypingPracticeBeApplication {
 
   public static void main(String[] args) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/GoogleOAuthProperties.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/GoogleOAuthProperties.java
@@ -1,0 +1,23 @@
+package com.typingpractice.typing_practice_be.auth;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "google")
+@Getter
+public class GoogleOAuthProperties {
+  private final String clientId;
+  private final String clientSecret;
+  private final String redirectUri;
+  private final String tokenUri;
+  private final String grantType;
+
+  public GoogleOAuthProperties(
+      String clientId, String clientSecret, String redirectUri, String tokenUri) {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.redirectUri = redirectUri;
+    this.tokenUri = tokenUri;
+    this.grantType = "authorization_code";
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/JwtProperties.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/JwtProperties.java
@@ -1,0 +1,14 @@
+package com.typingpractice.typing_practice_be.auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "jwt")
+@Getter
+@AllArgsConstructor
+public class JwtProperties {
+  private String secret;
+  private long accessTokenExpirationMs;
+  private long refreshTokenExpirationDays;
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/AuthController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/AuthController.java
@@ -33,8 +33,9 @@ public class AuthController {
     Member member = loginResult.getMember();
 
     String token = jwtTokenProvider.createToken(member.getId(), member.getRole());
+    String refreshToken = authService.createRefreshToken(member);
 
-    return ApiResponse.ok(LoginResponse.from(loginResult, token));
+    return ApiResponse.ok(LoginResponse.from(loginResult, token, refreshToken));
   }
 
   @PostMapping("/google")
@@ -48,8 +49,9 @@ public class AuthController {
 
     Member member = loginResult.getMember();
     String token = jwtTokenProvider.createToken(member.getId(), member.getRole());
+    String refreshToken = authService.createRefreshToken(member);
 
-    return ApiResponse.ok(LoginResponse.from(loginResult, token));
+    return ApiResponse.ok(LoginResponse.from(loginResult, token, refreshToken));
   }
 
   @PostMapping("/logout")
@@ -61,5 +63,16 @@ public class AuthController {
     authService.logout(token);
 
     return ApiResponse.ok(null);
+  }
+
+  @PostMapping("/refresh")
+  public ApiResponse<AuthTokenRefreshResponse> refresh(
+      @RequestBody AuthTokenRefreshRequest request) {
+
+    TokenRotation tokenRotation = authService.rotateToken(request.getRefreshToken());
+
+    return ApiResponse.ok(
+        AuthTokenRefreshResponse.from(
+            tokenRotation.getAccessToken(), tokenRotation.getRefreshToken()));
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/domain/RefreshToken.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/domain/RefreshToken.java
@@ -1,0 +1,37 @@
+package com.typingpractice.typing_practice_be.auth.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "refresh_token_id")
+  private Long id;
+
+  private Long memberId;
+
+  private String token;
+
+  private LocalDateTime expiresIn;
+
+  public static RefreshToken create(Long memberId, String token, LocalDateTime expiresIn) {
+    RefreshToken refreshToken = new RefreshToken();
+    refreshToken.memberId = memberId;
+    refreshToken.token = token;
+    refreshToken.expiresIn = expiresIn;
+
+    return refreshToken;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/AuthTokenRefreshRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/AuthTokenRefreshRequest.java
@@ -1,0 +1,17 @@
+package com.typingpractice.typing_practice_be.auth.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class AuthTokenRefreshRequest {
+  private String refreshToken;
+
+  public static AuthTokenRefreshRequest create(String refreshToken) {
+    AuthTokenRefreshRequest request = new AuthTokenRefreshRequest();
+    request.refreshToken = refreshToken;
+
+    return request;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/AuthTokenRefreshResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/AuthTokenRefreshResponse.java
@@ -1,0 +1,19 @@
+package com.typingpractice.typing_practice_be.auth.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class AuthTokenRefreshResponse {
+  private String accessToken;
+  private String refreshToken;
+
+  public static AuthTokenRefreshResponse from(String accessToken, String refreshToken) {
+    AuthTokenRefreshResponse response = new AuthTokenRefreshResponse();
+    response.accessToken = accessToken;
+    response.refreshToken = refreshToken;
+
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/LoginResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/LoginResponse.java
@@ -20,9 +20,10 @@ public class LoginResponse {
 
   private boolean isNewMember;
 
-  private String token;
+  private String accessToken;
+  private String refreshToken;
 
-  public static LoginResponse from(LoginResult result, String token) {
+  public static LoginResponse from(LoginResult result, String accessToken, String refreshToken) {
     Member member = result.getMember();
     return new LoginResponse(
         member.getId(),
@@ -31,6 +32,7 @@ public class LoginResponse {
         member.getRole(),
         member.getCreatedAt(),
         result.isNewMember(),
-        token);
+        accessToken,
+        refreshToken);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/TokenRotation.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/dto/TokenRotation.java
@@ -1,0 +1,22 @@
+package com.typingpractice.typing_practice_be.auth.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class TokenRotation {
+  private String accessToken;
+  private String refreshToken;
+
+  public static TokenRotation create(String accessToken, String refreshToken) {
+    TokenRotation tokenRotation = new TokenRotation();
+    tokenRotation.accessToken = accessToken;
+    tokenRotation.refreshToken = refreshToken;
+
+    return tokenRotation;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/exception/AuthInvalidRefreshTokenException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/exception/AuthInvalidRefreshTokenException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.auth.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class AuthInvalidRefreshTokenException extends BusinessException {
+  public AuthInvalidRefreshTokenException() {
+    super(ErrorCode.AUTH_INVALID_REFRESH_TOKEN);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/repository/RefreshTokenRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,47 @@
+package com.typingpractice.typing_practice_be.auth.repository;
+
+import com.typingpractice.typing_practice_be.auth.domain.RefreshToken;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RefreshTokenRepository {
+  private final EntityManager em;
+
+  public Long save(RefreshToken refreshToken) {
+    em.persist(refreshToken);
+
+    return refreshToken.getId();
+  }
+
+  public Optional<RefreshToken> findByToken(String token) {
+    return em.createQuery("select t from RefreshToken t where t.token = :token", RefreshToken.class)
+        .setParameter("token", token)
+        .setMaxResults(1)
+        .getResultStream()
+        .findFirst();
+  }
+
+  public void deleteByToken(String token) {
+    em.createQuery("delete from RefreshToken t where t.token = :token")
+        .setParameter("token", token)
+        .executeUpdate();
+  }
+
+  public void deleteByMemberId(Long memberId) {
+    em.createQuery("delete from RefreshToken t where t.memberId = :memberId")
+        .setParameter("memberId", memberId)
+        .executeUpdate();
+  }
+
+  public void deleteExpiredTokens(LocalDateTime now) {
+    em.createQuery("delete from RefreshToken t where t.expiresIn < :now")
+        .setParameter("now", now)
+        .executeUpdate();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/service/AuthService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/service/AuthService.java
@@ -1,15 +1,25 @@
 package com.typingpractice.typing_practice_be.auth.service;
 
+import com.typingpractice.typing_practice_be.auth.GoogleOAuthProperties;
+import com.typingpractice.typing_practice_be.auth.JwtProperties;
 import com.typingpractice.typing_practice_be.auth.domain.JwtBlackList;
+import com.typingpractice.typing_practice_be.auth.domain.RefreshToken;
+import com.typingpractice.typing_practice_be.auth.dto.TokenRotation;
 import com.typingpractice.typing_practice_be.auth.dto.google.GoogleTokenResponse;
 import com.typingpractice.typing_practice_be.auth.dto.google.GoogleUserInfo;
-import com.typingpractice.typing_practice_be.common.jwt.JwtPayload;
+import com.typingpractice.typing_practice_be.auth.exception.AuthInvalidRefreshTokenException;
 import com.typingpractice.typing_practice_be.auth.exception.GoogleAuthException;
 import com.typingpractice.typing_practice_be.auth.exception.GoogleServerException;
 import com.typingpractice.typing_practice_be.auth.repository.JwtBlackListRepository;
+import com.typingpractice.typing_practice_be.auth.repository.RefreshTokenRepository;
+import com.typingpractice.typing_practice_be.common.jwt.JwtPayload;
 import com.typingpractice.typing_practice_be.common.jwt.JwtTokenProvider;
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
+import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,34 +33,29 @@ import org.springframework.web.client.RestClient;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class AuthService {
-  @Value("${google.client-id}")
-  private String clientId;
-
-  @Value("${google.client-secret}")
-  private String clientSecret;
-
-  @Value("${google.redirect-uri}")
-  private String redirectUri;
-
-  @Value("${google.token-uri}")
-  private String tokenUri;
 
   private final RestClient restClient = RestClient.create();
   private final JwtTokenProvider jwtTokenProvider;
   private final JwtBlackListRepository jwtBlackListRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
+
+  private final GoogleOAuthProperties googleOAuthProperties;
+  private final JwtProperties jwtProperties;
+
+  private final MemberRepository memberRepository;
 
   public GoogleTokenResponse getAccessToken(String code) {
     try {
       MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
       params.add("code", code);
-      params.add("client_id", clientId);
-      params.add("client_secret", clientSecret);
-      params.add("redirect_uri", redirectUri);
-      params.add("grant_type", "authorization_code");
+      params.add("client_id", googleOAuthProperties.getClientId());
+      params.add("client_secret", googleOAuthProperties.getClientSecret());
+      params.add("redirect_uri", googleOAuthProperties.getRedirectUri());
+      params.add("grant_type", googleOAuthProperties.getGrantType());
 
       return restClient
           .post()
-          .uri(tokenUri)
+          .uri(googleOAuthProperties.getTokenUri())
           .contentType(MediaType.APPLICATION_FORM_URLENCODED)
           .body(params)
           .retrieve()
@@ -85,10 +90,53 @@ public class AuthService {
     JwtBlackList jwtBlackList =
         JwtBlackList.create(jwtPayload.getJwtId(), jwtPayload.getExpiresIn());
 
+    refreshTokenRepository.deleteByMemberId(jwtPayload.getMemberId());
+
     jwtBlackListRepository.save(jwtBlackList);
   }
 
   public boolean isBlacklistedJwt(String jwtId) {
     return jwtBlackListRepository.existByJwtId(jwtId);
+  }
+
+  @Transactional
+  public TokenRotation rotateToken(String refreshToken) {
+    RefreshToken refreshTokenInfo =
+        refreshTokenRepository
+            .findByToken(refreshToken)
+            .orElseThrow(AuthInvalidRefreshTokenException::new);
+
+    if (refreshTokenInfo.getExpiresIn().isBefore(LocalDateTime.now())) {
+      throw new AuthInvalidRefreshTokenException();
+    }
+
+    Long memberId = refreshTokenInfo.getMemberId();
+
+    Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+
+    String newAccessToken = jwtTokenProvider.createToken(memberId, member.getRole());
+    String newRefreshToken = UUID.randomUUID().toString();
+
+    RefreshToken newRefreshTokenInfo =
+        RefreshToken.create(
+            memberId,
+            newRefreshToken,
+            LocalDateTime.now().plusDays(jwtProperties.getRefreshTokenExpirationDays()));
+
+    refreshTokenRepository.deleteByToken(refreshToken); // 기존 토큰 삭제
+    refreshTokenRepository.save(newRefreshTokenInfo);
+
+    return TokenRotation.create(newAccessToken, newRefreshToken);
+  }
+
+  @Transactional
+  public String createRefreshToken(Member member) {
+    RefreshToken refreshToken =
+        RefreshToken.create(
+            member.getId(),
+            UUID.randomUUID().toString(),
+            LocalDateTime.now().plusDays(jwtProperties.getRefreshTokenExpirationDays()));
+    refreshTokenRepository.save(refreshToken);
+    return refreshToken.getToken();
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/service/AuthTokenCleanupScheduler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/service/AuthTokenCleanupScheduler.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.auth.service;
 
 import com.typingpractice.typing_practice_be.auth.repository.JwtBlackListRepository;
+import com.typingpractice.typing_practice_be.auth.repository.RefreshTokenRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -11,12 +12,19 @@ import java.time.ZoneOffset;
 
 @Component
 @RequiredArgsConstructor
-public class BlackListCleanupScheduler {
+public class AuthTokenCleanupScheduler {
   private final JwtBlackListRepository jwtBlackListRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
 
   @Scheduled(cron = "0 0 3 * * *")
   @Transactional
   public void cleanupExpiredTokens() {
+    refreshTokenRepository.deleteExpiredTokens(LocalDateTime.now(ZoneOffset.UTC));
+  }
+
+  @Scheduled(cron = "0 0 4 * * *")
+  @Transactional
+  public void cleanupBlackListTokens() {
     jwtBlackListRepository.deleteExpiredTokens(LocalDateTime.now(ZoneOffset.UTC));
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -10,8 +10,9 @@ public enum ErrorCode {
   GOOGLE_AUTH_FAILED(HttpStatus.BAD_REQUEST, "Google 인증에 실패했습니다."),
   GOOGLE_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "Google 서버 오류가 발생했습니다."),
 
+  AUTH_INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
-  DUPLICATE_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
   MEMBER_NOT_PROCESSABLE(HttpStatus.BAD_REQUEST, "처리할 수 없는 회원입니다."),
 
   NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtPayload.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtPayload.java
@@ -21,6 +21,14 @@ public class JwtPayload {
 
   private JwtPayload() {}
 
+  public static JwtPayload create(Long memberId, String jwtId, LocalDateTime expiresIn) {
+    JwtPayload jwtPayload = new JwtPayload();
+    jwtPayload.memberId = memberId;
+    jwtPayload.jwtId = jwtId;
+    jwtPayload.expiresIn = expiresIn;
+    return jwtPayload;
+  }
+
   public static JwtPayload create(Claims jwtClaims) {
     JwtPayload jwtPayload = new JwtPayload();
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtTokenProvider.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtTokenProvider.java
@@ -1,31 +1,29 @@
 package com.typingpractice.typing_practice_be.common.jwt;
 
+import com.typingpractice.typing_practice_be.auth.JwtProperties;
 import com.typingpractice.typing_practice_be.member.domain.MemberRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Component;
-
-import javax.crypto.SecretKey;
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.UUID;
+import javax.crypto.SecretKey;
+import org.springframework.stereotype.Component;
 
 @Component
 public class JwtTokenProvider {
   private final SecretKey secretKey;
-  private final long expiration;
+  private final long accessTokenExpiration;
 
-  public JwtTokenProvider(
-      @Value("${jwt.secret}") String secret, @Value("${jwt.expiration}") long expiration) {
-    this.secretKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
-    this.expiration = expiration;
+  public JwtTokenProvider(JwtProperties jwtProperties) {
+    this.secretKey = Keys.hmacShaKeyFor(jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8));
+    this.accessTokenExpiration = jwtProperties.getAccessTokenExpirationMs();
   }
 
   public String createToken(Long memberId, MemberRole role) {
     Date now = new Date();
-    Date expiryDate = new Date(now.getTime() + expiration); // 만료 시간
+    Date expiryDate = new Date(now.getTime() + accessTokenExpiration); // 만료 시간
 
     return Jwts.builder()
         .subject(String.valueOf(memberId))

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/auth/service/AuthServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/auth/service/AuthServiceTest.java
@@ -1,0 +1,71 @@
+package com.typingpractice.typing_practice_be.auth.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.typingpractice.typing_practice_be.auth.domain.JwtBlackList;
+import com.typingpractice.typing_practice_be.auth.repository.JwtBlackListRepository;
+import com.typingpractice.typing_practice_be.common.jwt.JwtPayload;
+import com.typingpractice.typing_practice_be.common.jwt.JwtTokenProvider;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+  @Mock private JwtBlackListRepository jwtBlackListRepository;
+  @Mock private JwtTokenProvider jwtTokenProvider;
+
+  @InjectMocks private AuthService authService;
+
+  @Nested
+  @DisplayName("logout")
+  class Logout {
+    @Test
+    @DisplayName("로그아웃 성공 - 토큰이 블랙리스트에 저장됨")
+    void success() {
+      // given
+      String token = "test-token";
+      JwtPayload jwtPayload = JwtPayload.create(1L, "jwt-id-123", LocalDateTime.now().plusHours(1));
+
+      when(jwtTokenProvider.getJwtPayload(token)).thenReturn(jwtPayload);
+
+      // when
+      authService.logout(token);
+
+      // then
+      verify(jwtBlackListRepository).save(any(JwtBlackList.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("isBlacklistedJwt")
+  class IsBlacklistedJwt {
+    @Test
+    @DisplayName("블랙리스트에 없는 토큰 - false 반환")
+    void notBlacklisted() {
+      // given
+      String jwtId = "not-exist-jwt-id";
+      when(jwtBlackListRepository.existByJwtId(jwtId)).thenReturn(false);
+
+      // when & then
+      assertThat(authService.isBlacklistedJwt(jwtId)).isFalse();
+    }
+
+    @Test
+    @DisplayName("블랙리스트에 있는 토큰 - true 반환")
+    void blacklisted() {
+      // given
+      String jwtId = "exist-jwt-id";
+      when(jwtBlackListRepository.existByJwtId(jwtId)).thenReturn(true);
+
+      // when & then
+      assertThat(authService.isBlacklistedJwt(jwtId)).isTrue();
+    }
+  }
+}


### PR DESCRIPTION
## Refresh Token
- RefreshToken 엔티티 (memberId, token, expiresIn)
- RefreshTokenRepository: save(), findByToken(), deleteByToken(), deleteByMemberId(), deleteExpiredTokens()
- AuthController: POST /auth/refresh 엔드포인트
- AuthService: rotateToken(), createRefreshToken()
- LoginResponse에 refreshToken 필드 추가

## 설정 외부화 (@ConfigurationProperties)
- JwtProperties: secret, accessTokenExpirationMs, refreshTokenExpirationDays
- GoogleOAuthProperties: clientId, clientSecret, redirectUri, tokenUri, grantType
- @ConfigurationPropertiesScan 적용
- JwtTokenProvider, AuthService에서 Properties 클래스 사용

## 토큰 정리 스케줄러 통합
- BlackListCleanupScheduler → AuthTokenCleanupScheduler 이름 변경
- 매일 새벽 3시: 만료된 RefreshToken 삭제
- 매일 새벽 4시: 만료된 JwtBlackList 삭제

## 로그아웃 개선
- logout 시 해당 회원의 RefreshToken도 함께 삭제