### PR TITLE
fix: 인증 플로우 보안 개선

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/service/AuthService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/service/AuthService.java
@@ -107,6 +107,7 @@ public class AuthService {
             .orElseThrow(AuthInvalidRefreshTokenException::new);
 
     if (refreshTokenInfo.getExpiresIn().isBefore(LocalDateTime.now())) {
+      refreshTokenRepository.deleteByToken(refreshToken);
       throw new AuthInvalidRefreshTokenException();
     }
 
@@ -131,6 +132,9 @@ public class AuthService {
 
   @Transactional
   public String createRefreshToken(Member member) {
+    // 기존 refresh token 삭제
+    refreshTokenRepository.deleteByMemberId(member.getId());
+
     RefreshToken refreshToken =
         RefreshToken.create(
             member.getId(),

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtAuthenticationFilter.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtAuthenticationFilter.java
@@ -53,7 +53,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (authService.isBlacklistedJwt(jwtId)) {
           SecurityContextHolder.clearContext();
         } else if (memberRole == MemberRole.BANNED) {
-          SecurityContextHolder.clearContext();
+          // TODO
+          // Banned 사용자 처리 방식 결정 필요
+          // SecurityContextHolder.clearContext();
         } else {
           List<SimpleGrantedAuthority> authorities =
               List.of(new SimpleGrantedAuthority(memberRole.getAuthority()));

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/MemberService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.member.service;
 
 import com.typingpractice.typing_practice_be.auth.dto.google.GoogleUserInfo;
+import com.typingpractice.typing_practice_be.auth.repository.RefreshTokenRepository;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.dto.LoginResult;
 import com.typingpractice.typing_practice_be.member.query.MemberCreateQuery;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberService {
   private final MemberRepository memberRepository;
+  private final RefreshTokenRepository refreshTokenRepository;
 
   public Member findMemberById(Long memberId) {
     return memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
@@ -74,6 +76,8 @@ public class MemberService {
   @Transactional
   public void deleteMember(Long memberId) {
     Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
+
+    refreshTokenRepository.deleteByMemberId(memberId);
 
     memberRepository.deleteMember(member);
   }


### PR DESCRIPTION
## RefreshToken 정리
- 로그인 시 기존 RefreshToken 삭제 (단일 세션 정책)
- 회원 탈퇴 시 RefreshToken 삭제
- rotateToken 시 만료된 토큰 즉시 삭제

## BANNED 유저 처리
- JwtAuthenticationFilter에서 BANNED 처리 로직 임시 비활성화 (TODO)
- 별도 브랜치에서 작업 예정