### PR TITLE
feat(member): 닉네임 중복 확인 기능 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -7,6 +7,8 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum ErrorCode {
+  DATA_INTEGRITY_VIOLATION(HttpStatus.BAD_REQUEST, "데이터 중복 오류"),
+
   GOOGLE_AUTH_FAILED(HttpStatus.BAD_REQUEST, "Google 인증에 실패했습니다."),
   GOOGLE_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "Google 서버 오류가 발생했습니다."),
 
@@ -14,6 +16,7 @@ public enum ErrorCode {
 
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
   MEMBER_NOT_PROCESSABLE(HttpStatus.BAD_REQUEST, "처리할 수 없는 회원입니다."),
+  MEMBER_DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다."),
 
   NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
   QUOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예문을 찾을 수 없습니다."),

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
@@ -25,6 +25,15 @@ public class MemberController {
     return ApiResponse.ok(MemberResponse.from(member));
   }
 
+  @GetMapping("/check-nickname")
+  public ApiResponse<Boolean> checkNicknameDuplicated(
+      @ModelAttribute CheckNicknameRequest request) {
+
+    boolean isExist = memberService.checkNicknameDuplicated(request.getNickname());
+
+    return ApiResponse.ok(isExist);
+  }
+
   @PatchMapping("/me")
   public ApiResponse<MemberResponse> updateNickname(
       @RequestBody UpdateNicknameRequest updateNicknameRequest) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/Member.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/domain/Member.java
@@ -25,6 +25,7 @@ public class Member extends BaseEntity {
 
   private String email;
 
+  @Column(unique = true)
   private String nickname;
 
   @Enumerated(EnumType.STRING)

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/CheckNicknameRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/dto/CheckNicknameRequest.java
@@ -1,0 +1,21 @@
+package com.typingpractice.typing_practice_be.member.dto;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+
+@Getter
+@Setter
+public class CheckNicknameRequest {
+  @NotNull
+  @Length(min = 2, max = 10)
+  private String nickname;
+
+  public static CheckNicknameRequest create(String nickname) {
+    CheckNicknameRequest request = new CheckNicknameRequest();
+    request.nickname = nickname;
+
+    return request;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/DuplicateNicknameException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/DuplicateNicknameException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.member.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class DuplicateNicknameException extends BusinessException {
+  public DuplicateNicknameException() {
+    super(ErrorCode.MEMBER_DUPLICATE_NICKNAME);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/MemberExceptionHandler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/MemberExceptionHandler.java
@@ -3,6 +3,7 @@ package com.typingpractice.typing_practice_be.member.exception;
 import com.typingpractice.typing_practice_be.common.exception.BusinessException;
 import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ProblemDetail;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -10,6 +11,26 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @RestControllerAdvice(basePackages = "com.typingpractice.typing_practice_be.member")
 public class MemberExceptionHandler {
+  private ProblemDetail createProblemDetail(ErrorCode errorCode) {
+    ProblemDetail pd =
+        ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());
+
+    pd.setTitle("Member Domain Error");
+
+    return pd;
+  }
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ProblemDetail handleDuplicateNicknameException(DataIntegrityViolationException e) {
+    String message = e.getMessage();
+
+    if (message != null && message.contains("nickname")) {
+      return createProblemDetail(ErrorCode.MEMBER_DUPLICATE_NICKNAME);
+    }
+
+    return createProblemDetail(ErrorCode.DATA_INTEGRITY_VIOLATION);
+  }
+
   @ExceptionHandler(BusinessException.class)
   public ProblemDetail handleMemberException(BusinessException e) {
     log.warn("[Member] {}: {}", e.getClass().getSimpleName(), e.getMessage());

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepository.java
@@ -15,4 +15,6 @@ public interface MemberRepository {
   Long save(Member member);
 
   void deleteMember(Member member);
+
+  boolean existByNickname(String nickname);
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepositoryImpl.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepositoryImpl.java
@@ -15,6 +15,16 @@ public class MemberRepositoryImpl implements MemberRepository {
   private final EntityManager em;
 
   @Override
+  public boolean existByNickname(String nickname) {
+    return em.createQuery("select m from Member m where m.nickname = :nickname", Member.class)
+        .setParameter("nickname", nickname)
+        .setMaxResults(1)
+        .getResultStream()
+        .findAny()
+        .isPresent();
+  }
+
+  @Override
   public List<Member> findAll(MemberPaginationQuery query) {
     int page = query.getPage();
     int size = query.getSize();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/MemberService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/MemberService.java
@@ -4,6 +4,7 @@ import com.typingpractice.typing_practice_be.auth.dto.google.GoogleUserInfo;
 import com.typingpractice.typing_practice_be.auth.repository.RefreshTokenRepository;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.dto.LoginResult;
+import com.typingpractice.typing_practice_be.member.exception.DuplicateNicknameException;
 import com.typingpractice.typing_practice_be.member.query.MemberCreateQuery;
 import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
 import com.typingpractice.typing_practice_be.member.query.MemberUpdateQuery;
@@ -57,6 +58,10 @@ public class MemberService {
     return member;
   }
 
+  public boolean checkNicknameDuplicated(String nickname) {
+    return memberRepository.existByNickname(nickname);
+  }
+
   @Transactional
   public Member updateNickname(Long memberId, MemberUpdateQuery query) {
     Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
@@ -66,6 +71,10 @@ public class MemberService {
     // 변경하지 않은 경우 그냥 반환
     if (member.getNickname().equals(nickname)) {
       return member;
+    }
+
+    if (memberRepository.existByNickname(nickname)) {
+      throw new DuplicateNicknameException();
     }
 
     member.updateNickName(nickname);


### PR DESCRIPTION
## API
- GET /members/check-nickname: 닉네임 중복 확인 (편의 기능)

## DB 제약
- Member.nickname에 unique 제약 추가

## 닉네임 변경 시 중복 체크
- 서버에서 먼저 중복 확인 후 DuplicateNicknameException 발생
- DB 제약 위반 시 DataIntegrityViolationException 처리

## 예외 처리
- DuplicateNicknameException 추가
- MemberExceptionHandler에서 DataIntegrityViolationException 처리
- ErrorCode: MEMBER_DUPLICATE_NICKNAME, DATA_INTEGRITY_VIOLATION 추가