### PR TITLE
feat: BANNED 유저 기능 제한 및 문장 업로드 엔드포인트 분리

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -17,6 +17,7 @@ public enum ErrorCode {
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
   MEMBER_NOT_PROCESSABLE(HttpStatus.BAD_REQUEST, "처리할 수 없는 회원입니다."),
   MEMBER_DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다."),
+  MEMBER_BANNED(HttpStatus.FORBIDDEN, "활동이 제한된 계정입니다."),
 
   NOT_ADMIN(HttpStatus.FORBIDDEN, "관리자 권한이 필요합니다."),
   QUOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예문을 찾을 수 없습니다."),

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtAuthenticationFilter.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/jwt/JwtAuthenticationFilter.java
@@ -22,7 +22,6 @@ import org.springframework.web.filter.OncePerRequestFilter;
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
   private final JwtTokenProvider jwtTokenProvider;
-  // private final JwtBlackListRepository jwtBlackListRepository;
   private final AuthService authService;
 
   //  @Override
@@ -52,11 +51,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         if (authService.isBlacklistedJwt(jwtId)) {
           SecurityContextHolder.clearContext();
-        } else if (memberRole == MemberRole.BANNED) {
-          // TODO
-          // Banned 사용자 처리 방식 결정 필요
-          // SecurityContextHolder.clearContext();
         } else {
+          // BANNED 포함 모든 Role 인증 설정
           List<SimpleGrantedAuthority> authorities =
               List.of(new SimpleGrantedAuthority(memberRole.getAuthority()));
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/admin/AdminCheckAspect.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/admin/AdminCheckAspect.java
@@ -1,4 +1,4 @@
-package com.typingpractice.typing_practice_be.common.security;
+package com.typingpractice.typing_practice_be.common.security.admin;
 
 import com.typingpractice.typing_practice_be.member.domain.MemberRole;
 import com.typingpractice.typing_practice_be.member.exception.NotAdminException;
@@ -11,7 +11,8 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 public class AdminCheckAspect {
-  @Before("@within(AdminOnly) || @annotation(AdminOnly)")
+  @Before(
+      "@within(com.typingpractice.typing_practice_be.common.security.admin.AdminOnly) || @annotation(com.typingpractice.typing_practice_be.common.security.admin.AdminOnly)")
   public void checkAdmin() {
     Authentication auth = SecurityContextHolder.getContext().getAuthentication();
     boolean isAdmin =

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/admin/AdminOnly.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/admin/AdminOnly.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.common.security.admin;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AdminOnly {}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/banned/BannedCheckAspect.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/banned/BannedCheckAspect.java
@@ -1,0 +1,25 @@
+package com.typingpractice.typing_practice_be.common.security.banned;
+
+import com.typingpractice.typing_practice_be.member.domain.MemberRole;
+import com.typingpractice.typing_practice_be.member.exception.BannedMemberException;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class BannedCheckAspect {
+  @Before("@annotation(BannedNotAllowed)")
+  public void checkBanned() {
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+    boolean isBanned =
+        auth.getAuthorities().stream()
+            .anyMatch(a -> a.getAuthority().equals(MemberRole.BANNED.getAuthority()));
+
+    if (isBanned) {
+      throw new BannedMemberException();
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/banned/BannedNotAllowed.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/banned/BannedNotAllowed.java
@@ -1,10 +1,10 @@
-package com.typingpractice.typing_practice_be.common.security;
+package com.typingpractice.typing_practice_be.common.security.banned;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.TYPE, ElementType.METHOD})
+@Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface AdminOnly {}
+public @interface BannedNotAllowed {}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/AdminMemberController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/AdminMemberController.java
@@ -2,7 +2,7 @@ package com.typingpractice.typing_practice_be.member.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
-import com.typingpractice.typing_practice_be.common.security.AdminOnly;
+import com.typingpractice.typing_practice_be.common.security.admin.AdminOnly;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.dto.*;
 import com.typingpractice.typing_practice_be.member.dto.admin.MemberBanRequest;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
@@ -5,6 +5,7 @@ import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.dto.*;
 import com.typingpractice.typing_practice_be.member.query.MemberUpdateQuery;
 import com.typingpractice.typing_practice_be.member.service.MemberService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -27,7 +28,7 @@ public class MemberController {
 
   @GetMapping("/check-nickname")
   public ApiResponse<Boolean> checkNicknameDuplicated(
-      @ModelAttribute CheckNicknameRequest request) {
+      @ModelAttribute @Valid CheckNicknameRequest request) {
 
     boolean isExist = memberService.checkNicknameDuplicated(request.getNickname());
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/BannedMemberException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/exception/BannedMemberException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.member.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class BannedMemberException extends BusinessException {
+  public BannedMemberException() {
+    super(ErrorCode.MEMBER_BANNED);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
@@ -2,7 +2,7 @@ package com.typingpractice.typing_practice_be.quote.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
-import com.typingpractice.typing_practice_be.common.security.AdminOnly;
+import com.typingpractice.typing_practice_be.common.security.admin.AdminOnly;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationResponse;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.quote.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
+import com.typingpractice.typing_practice_be.common.security.banned.BannedNotAllowed;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.dto.*;
 import com.typingpractice.typing_practice_be.quote.exception.EmptyUpdateRequestException;
@@ -23,18 +24,6 @@ public class QuoteController {
 
   private Long getMemberId() {
     return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
-  }
-
-  // 문장 업로드
-  @PostMapping("/quotes")
-  public ApiResponse<QuoteResponse> create(@RequestBody @Valid QuoteCreateRequest request) {
-    Long memberId = getMemberId();
-
-    QuoteCreateQuery query = QuoteCreateQuery.from(request);
-
-    Quote quote = quoteService.create(memberId, query);
-
-    return ApiResponse.ok(QuoteResponse.from(quote));
   }
 
   // 공개 문장 랜덤 조회
@@ -72,6 +61,33 @@ public class QuoteController {
     return ApiResponse.ok(QuoteResponse.from(quote));
   }
 
+  // 공개 문장 업로드
+  @BannedNotAllowed
+  @PostMapping("/quotes/public")
+  public ApiResponse<QuoteResponse> createPublicQuote(
+      @RequestBody @Valid QuoteCreateRequest request) {
+    Long memberId = getMemberId();
+
+    QuoteCreateQuery query = QuoteCreateQuery.ofPublic(request);
+
+    Quote quote = quoteService.create(memberId, query);
+
+    return ApiResponse.ok(QuoteResponse.from(quote));
+  }
+
+  // 비공개 문장 업로드
+  @PostMapping("/quotes/private")
+  public ApiResponse<QuoteResponse> createPrivateQuote(
+      @RequestBody @Valid QuoteCreateRequest request) {
+    Long memberId = getMemberId();
+
+    QuoteCreateQuery query = QuoteCreateQuery.ofPrivate(request);
+
+    Quote quote = quoteService.create(memberId, query);
+
+    return ApiResponse.ok(QuoteResponse.from(quote));
+  }
+
   // 비공개 문장 수정
   @PatchMapping("/quotes/{quoteId}")
   public ApiResponse<QuoteResponse> updatePrivateQuote(
@@ -99,6 +115,7 @@ public class QuoteController {
   }
 
   // 개인용 문장 공개 전환
+  @BannedNotAllowed
   @PostMapping("/quotes/{quoteId}/publish")
   public ApiResponse<QuoteResponse> publishQuote(@PathVariable Long quoteId) {
     Long memberId = getMemberId();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteCreateRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteCreateRequest.java
@@ -1,6 +1,5 @@
 package com.typingpractice.typing_practice_be.quote.dto;
 
-import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 import lombok.ToString;
@@ -16,13 +15,10 @@ public class QuoteCreateRequest {
   @Length(min = 1, max = 20)
   private String author;
 
-  private QuoteType type = QuoteType.PUBLIC;
-
-  public static QuoteCreateRequest create(String sentence, String author, QuoteType type) {
+  public static QuoteCreateRequest create(String sentence, String author) {
     QuoteCreateRequest request = new QuoteCreateRequest();
     request.sentence = sentence;
     request.author = author;
-    request.type = type;
 
     return request;
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/query/QuoteCreateQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/query/QuoteCreateQuery.java
@@ -20,7 +20,15 @@ public class QuoteCreateQuery {
     this.type = type;
   }
 
-  public static QuoteCreateQuery from(QuoteCreateRequest request) {
-    return new QuoteCreateQuery(request.getSentence(), request.getAuthor(), request.getType());
+  public static QuoteCreateQuery from(QuoteCreateRequest request, QuoteType type) {
+    return new QuoteCreateQuery(request.getSentence(), request.getAuthor(), type);
+  }
+
+  public static QuoteCreateQuery ofPublic(QuoteCreateRequest request) {
+    return new QuoteCreateQuery(request.getSentence(), request.getAuthor(), QuoteType.PUBLIC);
+  }
+
+  public static QuoteCreateQuery ofPrivate(QuoteCreateRequest request) {
+    return new QuoteCreateQuery(request.getSentence(), request.getAuthor(), QuoteType.PRIVATE);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/AdminReportController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/AdminReportController.java
@@ -2,7 +2,7 @@ package com.typingpractice.typing_practice_be.report.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
-import com.typingpractice.typing_practice_be.common.security.AdminOnly;
+import com.typingpractice.typing_practice_be.common.security.admin.AdminOnly;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.dto.*;
 import com.typingpractice.typing_practice_be.report.query.ReportPaginationQuery;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/ReportController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/ReportController.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.report.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
+import com.typingpractice.typing_practice_be.common.security.banned.BannedNotAllowed;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteResponse;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.dto.ReportCreateRequest;
@@ -25,6 +26,7 @@ public class ReportController {
     return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
   }
 
+  @BannedNotAllowed
   @PostMapping("/reports")
   public ApiResponse<ReportResponse> reportQuote(@RequestBody @Valid ReportCreateRequest request) {
     Long memberId = getMemberId();

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteServiceTest.java
@@ -71,8 +71,8 @@ class QuoteServiceTest {
   }
 
   private QuoteCreateQuery createCreateQuery(QuoteType type) {
-    QuoteCreateRequest request = QuoteCreateRequest.create("테스트 문장입니다.", "저자", type);
-    return QuoteCreateQuery.from(request);
+    QuoteCreateRequest request = QuoteCreateRequest.create("테스트 문장입니다.", "저자");
+    return QuoteCreateQuery.from(request, type);
   }
 
   private QuoteUpdateQuery createUpdateQuery(String sentence, String author) {


### PR DESCRIPTION
## BANNED 유저 처리
- @BannedNotAllowed 어노테이션 및 BannedCheckAspect 구현
- BannedMemberException, ErrorCode.MEMBER_BANNED 추가
- JwtAuthenticationFilter: BANNED 유저도 인증 통과 (기능만 제한)
- 적용 대상: POST /quotes/public, /quotes/{id}/publish, /reports

## 문장 업로드 엔드포인트 분리
- POST /quotes → POST /quotes/public, POST /quotes/private
- QuoteCreateRequest에서 type 필드 제거
- QuoteCreateQuery에 ofPublic(), ofPrivate() 팩토리 메서드 추가

## 패키지 정리
- AdminOnly, AdminCheckAspect → common/security/admin으로 이동