### PR TITLE
feat(security): Spring Security 기반 권한 설정 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -11,6 +11,7 @@ public enum ErrorCode {
 
   GOOGLE_AUTH_FAILED(HttpStatus.BAD_REQUEST, "Google 인증에 실패했습니다."),
   GOOGLE_SERVER_ERROR(HttpStatus.BAD_GATEWAY, "Google 서버 오류가 발생했습니다."),
+  UNAUTHORIZED_ERROR(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다."),
 
   AUTH_INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/CustomAccessDeniedHandler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,45 @@
+package com.typingpractice.typing_practice_be.common.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+import com.typingpractice.typing_practice_be.member.domain.MemberRole;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ProblemDetail;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public void handle(
+      HttpServletRequest request,
+      HttpServletResponse response,
+      AccessDeniedException accessDeniedException)
+      throws IOException {
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    response.setContentType("application/problem+json;charset=UTF-8");
+
+    Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+
+    boolean isBanned =
+        auth.getAuthorities().stream()
+            .anyMatch(a -> a.getAuthority().equals(MemberRole.BANNED.getAuthority()));
+
+    ErrorCode errorCode = isBanned ? ErrorCode.MEMBER_BANNED : ErrorCode.NOT_ADMIN;
+
+    ProblemDetail pd =
+        ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());
+    pd.setTitle("Forbidden");
+
+    response.getWriter().write(objectMapper.writeValueAsString(pd));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/CustomAuthenticationEntryPoint.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/security/CustomAuthenticationEntryPoint.java
@@ -1,10 +1,10 @@
 package com.typingpractice.typing_practice_be.common.security;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
@@ -28,8 +28,10 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
     response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     response.setContentType("application/problem+json;charset=UTF-8");
 
+    ErrorCode errorCode = ErrorCode.UNAUTHORIZED_ERROR;
+
     ProblemDetail problemDetail =
-        ProblemDetail.forStatusAndDetail(HttpStatus.UNAUTHORIZED, "로그인이 필요합니다.");
+        ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());
     problemDetail.setTitle("Unauthorized");
 
     response.getWriter().write(objectMapper.writeValueAsString(problemDetail));

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/AdminMemberController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/AdminMemberController.java
@@ -2,7 +2,6 @@ package com.typingpractice.typing_practice_be.member.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
-import com.typingpractice.typing_practice_be.common.security.admin.AdminOnly;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.dto.*;
 import com.typingpractice.typing_practice_be.member.dto.admin.MemberBanRequest;
@@ -18,7 +17,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@AdminOnly
+// @AdminOnly
 public class AdminMemberController {
   private final AdminMemberService adminMemberService;
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
@@ -2,7 +2,6 @@ package com.typingpractice.typing_practice_be.quote.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
-import com.typingpractice.typing_practice_be.common.security.admin.AdminOnly;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationResponse;
@@ -17,7 +16,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@AdminOnly
+// @AdminOnly
 public class AdminQuoteController {
   private final AdminQuoteService adminQuoteService;
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/QuoteController.java
@@ -2,7 +2,6 @@ package com.typingpractice.typing_practice_be.quote.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
-import com.typingpractice.typing_practice_be.common.security.banned.BannedNotAllowed;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.dto.*;
 import com.typingpractice.typing_practice_be.quote.exception.EmptyUpdateRequestException;
@@ -62,7 +61,7 @@ public class QuoteController {
   }
 
   // 공개 문장 업로드
-  @BannedNotAllowed
+  // @BannedNotAllowed
   @PostMapping("/quotes/public")
   public ApiResponse<QuoteResponse> createPublicQuote(
       @RequestBody @Valid QuoteCreateRequest request) {
@@ -115,7 +114,7 @@ public class QuoteController {
   }
 
   // 개인용 문장 공개 전환
-  @BannedNotAllowed
+  // @BannedNotAllowed
   @PostMapping("/quotes/{quoteId}/publish")
   public ApiResponse<QuoteResponse> publishQuote(@PathVariable Long quoteId) {
     Long memberId = getMemberId();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/AdminReportController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/AdminReportController.java
@@ -2,7 +2,6 @@ package com.typingpractice.typing_practice_be.report.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
-import com.typingpractice.typing_practice_be.common.security.admin.AdminOnly;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.dto.*;
 import com.typingpractice.typing_practice_be.report.query.ReportPaginationQuery;
@@ -14,7 +13,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@AdminOnly
+// @AdminOnly
 public class AdminReportController {
 
   private final AdminReportService adminReportService;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/ReportController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/report/controller/ReportController.java
@@ -2,7 +2,6 @@ package com.typingpractice.typing_practice_be.report.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
-import com.typingpractice.typing_practice_be.common.security.banned.BannedNotAllowed;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteResponse;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.dto.ReportCreateRequest;
@@ -26,7 +25,7 @@ public class ReportController {
     return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
   }
 
-  @BannedNotAllowed
+  // @BannedNotAllowed
   @PostMapping("/reports")
   public ApiResponse<ReportResponse> reportQuote(@RequestBody @Valid ReportCreateRequest request) {
     Long memberId = getMemberId();


### PR DESCRIPTION
## SecurityConfig
- 인증 불필요: /auth/**, /swagger-ui/**, GET /quotes
- 관리자 전용: /admin/** (hasRole ADMIN)
- BANNED 제외: POST /quotes/public, /quotes/*/publish, /reports

## 예외 처리
- CustomAccessDeniedHandler 구현 (403)
  - BANNED 유저: "활동이 제한된 계정입니다."
  - 권한 부족: "관리자 권한이 필요합니다."
- CustomAuthenticationEntryPoint ErrorCode 적용 (401)

## 기타
- ErrorCode.UNAUTHORIZED_ERROR 추가
- AOP 어노테이션(@AdminOnly, @BannedNotAllowed) 주석 처리 (참고용 유지)