### PR TITLE
feat: 문장 업로드 UI 프로토타입 추가

### DIFF
--- a/tp-react/prototype.css
+++ b/tp-react/prototype.css
@@ -947,3 +947,523 @@ body.dark {
     background-color: #9ca3af;
     cursor: not-allowed;
 }
+
+/* 문장 업로드 팝업 */
+.upload-popup-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2500;
+}
+
+.upload-popup {
+    background-color: white;
+    border-radius: 1rem;
+    padding: 2rem;
+    width: 80%;
+    max-width: 1000px;
+    min-width: 600px;
+    max-height: 85vh;
+    overflow-y: auto;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+}
+
+.upload-popup.dark {
+    background-color: #1f1f1f;
+    color: #e5e7eb;
+}
+
+.upload-popup-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+.upload-popup-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: #6d28d9;
+}
+
+.upload-popup-close-btn {
+    border: none;
+    background: none;
+    color: #999;
+    font-size: 1.25rem;
+    cursor: pointer;
+    padding: 0.25rem;
+    transition: color 0.2s;
+}
+
+.upload-popup-close-btn:hover {
+    color: #666;
+}
+
+.upload-popup-close-btn.dark {
+    color: #666;
+}
+
+.upload-popup-close-btn.dark:hover {
+    color: #999;
+}
+
+/* 공개/비공개 안내 */
+.upload-type-toggle {
+    margin-bottom: 1rem;
+}
+
+.upload-type-hint {
+    font-size: 0.85rem;
+    color: #666;
+}
+
+.upload-type-hint.dark {
+    color: #999;
+}
+
+.upload-type-info {
+    position: relative;
+    cursor: help;
+}
+
+.upload-type-info i {
+    margin-left: 0.25rem;
+    color: #999;
+}
+
+.upload-type-info.dark i {
+    color: #666;
+}
+
+.upload-type-tooltip {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-top: 0.5rem;
+    padding: 0.75rem 1rem;
+    background-color: #333;
+    color: white;
+    border-radius: 0.5rem;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    z-index: 10;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    width: max-content;
+    max-width: 350px;
+}
+
+.upload-type-tooltip p {
+    margin: 0;
+}
+
+.upload-type-tooltip p + p {
+    margin-top: 0.5rem;
+}
+
+.upload-type-tooltip.dark {
+    background-color: #3f3f46;
+}
+
+.upload-type-info:hover .upload-type-tooltip {
+    display: block;
+}
+
+/* 입력 영역들 */
+.upload-entries {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+}
+
+.upload-entry {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    background-color: #fafafa;
+}
+
+.upload-entry.dark {
+    border-color: #3f3f46;
+    background-color: #27272a;
+}
+
+.upload-entry.success {
+    border-color: #16a34a;
+    background-color: #f0fdf4;
+}
+
+.upload-entry.success.dark {
+    border-color: #22c55e;
+    background-color: #14532d20;
+}
+
+.upload-entry.error {
+    border-color: #dc2626;
+}
+
+.upload-entry-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+
+.upload-entry-number {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #6d28d9;
+}
+
+.upload-entry-delete-btn {
+    border: none;
+    background: none;
+    color: #999;
+    font-size: 0.9rem;
+    cursor: pointer;
+    padding: 0.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.2s;
+}
+
+.upload-entry-delete-btn:hover {
+    color: #dc2626;
+}
+
+.upload-entry-delete-btn.dark {
+    color: #666;
+}
+
+.upload-entry-delete-btn.dark:hover {
+    color: #dc2626;
+}
+
+/* 각 entry의 공개/비공개 토글 */
+.upload-entry-type-toggle {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.upload-entry-type-btn {
+    padding: 0.25rem 0.5rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.25rem;
+    background-color: transparent;
+    color: #999;
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.upload-entry-type-btn:hover {
+    border-color: #6d28d9;
+    color: #6d28d9;
+}
+
+.upload-entry-type-btn.active {
+    border-color: #6d28d9;
+    background-color: #6d28d9;
+    color: white;
+}
+
+.upload-entry-type-btn.dark {
+    border-color: #3f3f46;
+    color: #666;
+}
+
+.upload-entry-type-btn.dark:hover {
+    border-color: #8b5cf6;
+    color: #8b5cf6;
+}
+
+.upload-entry-type-btn.dark.active {
+    border-color: #8b5cf6;
+    background-color: #8b5cf6;
+    color: white;
+}
+
+.upload-entry-inputs {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-start;
+}
+
+.upload-sentence-wrapper {
+    flex: 1;
+}
+
+.upload-author-wrapper {
+    width: 150px;
+}
+
+.upload-input {
+    width: 100%;
+    padding: 0.5rem 0;
+    border: none;
+    border-bottom: 1px solid #e5e7eb;
+    background-color: transparent;
+    font-size: 1rem;
+    color: #333;
+    outline: none;
+    transition: border-color 0.2s;
+}
+
+.upload-input:focus {
+    border-bottom-color: #6d28d9;
+}
+
+.upload-input.dark {
+    border-bottom-color: #3f3f46;
+    color: #e5e7eb;
+}
+
+.upload-input.dark:focus {
+    border-bottom-color: #8b5cf6;
+}
+
+.upload-input::placeholder {
+    color: #999;
+}
+
+.upload-input.dark::placeholder {
+    color: #666;
+}
+
+.upload-entry-message {
+    font-size: 0.85rem;
+    min-height: 1.25rem;
+}
+
+.upload-entry-message.error {
+    color: #dc2626;
+}
+
+.upload-entry-message.success {
+    color: #16a34a;
+}
+
+.upload-entry-message.success.dark {
+    color: #22c55e;
+}
+
+/* 문장 추가 버튼 */
+.upload-add-btn {
+    width: 100%;
+    padding: 0.75rem;
+    margin-bottom: 1.5rem;
+    border: 2px dashed #e5e7eb;
+    border-radius: 0.5rem;
+    background-color: transparent;
+    color: #999;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.upload-add-btn:hover {
+    border-color: #6d28d9;
+    color: #6d28d9;
+}
+
+.upload-add-btn.dark {
+    border-color: #3f3f46;
+    color: #666;
+}
+
+.upload-add-btn.dark:hover {
+    border-color: #8b5cf6;
+    color: #8b5cf6;
+}
+
+.upload-add-btn:disabled {
+    border-color: #e5e7eb;
+    color: #ccc;
+    cursor: not-allowed;
+}
+
+.upload-add-btn.dark:disabled {
+    border-color: #3f3f46;
+    color: #555;
+}
+
+/* 하단 버튼 */
+.upload-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+}
+
+.upload-cancel-btn {
+    padding: 0.75rem 1.5rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    background-color: transparent;
+    color: #666;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.upload-cancel-btn:hover {
+    background-color: #f5f5f5;
+    color: #333;
+}
+
+.upload-cancel-btn.dark {
+    border-color: #3f3f46;
+    color: #999;
+}
+
+.upload-cancel-btn.dark:hover {
+    background-color: #27272a;
+    color: #e5e7eb;
+}
+
+.upload-submit-btn {
+    padding: 0.75rem 1.5rem;
+    border: none;
+    border-radius: 0.5rem;
+    background-color: #6d28d9;
+    color: white;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.upload-submit-btn:hover {
+    background-color: #5b21b6;
+}
+
+.upload-submit-btn:disabled {
+    background-color: #9ca3af;
+    cursor: not-allowed;
+}
+
+.upload-submit-btn.dark {
+    background-color: #8b5cf6;
+}
+
+.upload-submit-btn.dark:hover {
+    background-color: #7c3aed;
+}
+
+/* 확인 팝업 */
+.confirm-popup-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 3000;
+}
+
+.confirm-popup {
+    background-color: white;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    max-width: 400px;
+    width: 90%;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+}
+
+.confirm-popup.dark {
+    background-color: #1f1f1f;
+    color: #e5e7eb;
+}
+
+.confirm-popup-message {
+    font-size: 1rem;
+    color: #333;
+    margin-bottom: 1.5rem;
+    text-align: center;
+    line-height: 1.5;
+}
+
+.confirm-popup-message.dark {
+    color: #e5e7eb;
+}
+
+.confirm-popup-actions {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.confirm-popup-cancel-btn {
+    flex: 1;
+    padding: 0.75rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    background-color: transparent;
+    color: #666;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.confirm-popup-cancel-btn:hover {
+    background-color: #f5f5f5;
+    color: #333;
+}
+
+.confirm-popup-cancel-btn.dark {
+    border-color: #3f3f46;
+    color: #999;
+}
+
+.confirm-popup-cancel-btn.dark:hover {
+    background-color: #27272a;
+    color: #e5e7eb;
+}
+
+.confirm-popup-ok-btn {
+    flex: 1;
+    padding: 0.75rem;
+    border: none;
+    border-radius: 0.5rem;
+    background-color: #6d28d9;
+    color: white;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.confirm-popup-ok-btn:hover {
+    background-color: #5b21b6;
+}
+
+.confirm-popup-ok-btn.dark {
+    background-color: #8b5cf6;
+}
+
+.confirm-popup-ok-btn.dark:hover {
+    background-color: #7c3aed;
+}

--- a/tp-react/prototype.js
+++ b/tp-react/prototype.js
@@ -46,7 +46,7 @@ function toggleTheme() {
     document.getElementById('body').classList.toggle('dark');
     document.getElementById('iconSun').classList.toggle('display-none');
     document.getElementById('iconMoon').classList.toggle('display-none');
-    document.querySelectorAll('.font-size-label, .font-size-slider, .mode-toggle-label, .mode-toggle, .notice-icon, .title-title, .header-btn, .profile-btn, .dropdown-menu, .dropdown-item, .dropdown-divider, .dark-mode-icon, .result-period-btn, .result-period-value, .CPM-text, .CPM-value, .info-averages, .average-label, .average-value, .averages-toggle-btn, .author-text, .character, .input-char-correct, .input, .contact').forEach(el => el.classList.toggle('dark'));
+    document.querySelectorAll('.font-size-label, .font-size-slider, .mode-toggle-label, .mode-toggle, .notice-icon, .title-title, .header-btn, .profile-btn, .dropdown-menu, .dropdown-item, .dropdown-divider, .dark-mode-icon, .result-period-btn, .result-period-value, .CPM-text, .CPM-value, .info-averages, .average-label, .average-value, .averages-toggle-btn, .author-text, .character, .input-char-correct, .input, .contact, .upload-popup, .upload-popup-close-btn, .upload-type-hint, .upload-type-info, .upload-type-tooltip, .upload-entry, .upload-input, .upload-entry-delete-btn, .upload-entry-type-btn, .upload-entry-message.success, .upload-add-btn, .upload-cancel-btn, .upload-submit-btn, .confirm-popup, .confirm-popup-message, .confirm-popup-cancel-btn, .confirm-popup-ok-btn').forEach(el => el.classList.toggle('dark'));
     localStorage.setItem('Typing-Practice-darkMode', document.getElementById('body').classList.contains('dark'));
 }
 
@@ -414,8 +414,341 @@ document.getElementById('logoutBtn').addEventListener('click', () => {
 
 // 드롭다운 메뉴 아이템들
 document.getElementById('uploadBtn').addEventListener('click', () => {
-    alert('문장 업로드 기능 (준비 중)');
+    openUploadPopup();
 });
+
+// ============ 문장 업로드 ============
+
+const MAX_UPLOAD_ENTRIES = 5;
+let currentEntryCount = 0;
+
+const uploadPopupOverlay = document.getElementById('uploadPopupOverlay');
+const uploadPopup = document.getElementById('uploadPopup');
+const uploadEntries = document.getElementById('uploadEntries');
+const uploadAddBtn = document.getElementById('uploadAddBtn');
+
+// 단일 입력 필드 생성
+function createUploadEntry(index) {
+    const entry = document.createElement('div');
+    entry.className = 'upload-entry';
+    entry.id = `uploadEntry${index}`;
+    entry.dataset.index = index;
+    entry.dataset.type = 'public'; // 기본값: 공개
+    
+    const isDark = document.getElementById('body').classList.contains('dark');
+    if (isDark) entry.classList.add('dark');
+    
+    entry.innerHTML = `
+        <div class="upload-entry-header">
+            <span class="upload-entry-number">${index + 1}</span>
+            <button class="upload-entry-delete-btn${isDark ? ' dark' : ''}" title="삭제">
+                <i class="fa-solid fa-xmark"></i>
+            </button>
+        </div>
+        <div class="upload-entry-type-toggle">
+            <button class="upload-entry-type-btn${isDark ? ' dark' : ''} active" data-type="public">
+                <i class="fa-solid fa-globe"></i>
+                <span>공개</span>
+            </button>
+            <button class="upload-entry-type-btn${isDark ? ' dark' : ''}" data-type="private">
+                <i class="fa-solid fa-lock"></i>
+                <span>비공개</span>
+            </button>
+        </div>
+        <div class="upload-entry-inputs">
+            <div class="upload-sentence-wrapper">
+                <input 
+                    type="text" 
+                    class="upload-input${isDark ? ' dark' : ''}" 
+                    id="uploadSentence${index}"
+                    placeholder="문장을 입력하세요 (5-100자)"
+                    maxlength="100"
+                />
+            </div>
+            <div class="upload-author-wrapper">
+                <input 
+                    type="text" 
+                    class="upload-input${isDark ? ' dark' : ''}" 
+                    id="uploadAuthor${index}"
+                    placeholder="출처 (선택)"
+                    maxlength="20"
+                />
+            </div>
+        </div>
+        <div class="upload-entry-message" id="uploadMessage${index}"></div>
+    `;
+    
+    // 삭제 버튼 이벤트
+    entry.querySelector('.upload-entry-delete-btn').addEventListener('click', () => {
+        removeUploadEntry(entry);
+    });
+    
+    // 공개/비공개 토글 이벤트
+    entry.querySelectorAll('.upload-entry-type-btn').forEach(btn => {
+        btn.addEventListener('click', () => {
+            entry.querySelectorAll('.upload-entry-type-btn').forEach(b => b.classList.remove('active'));
+            btn.classList.add('active');
+            entry.dataset.type = btn.dataset.type;
+        });
+    });
+    
+    return entry;
+}
+
+// 입력 영역 추가
+function addUploadEntry() {
+    if (currentEntryCount >= MAX_UPLOAD_ENTRIES) return;
+    
+    const entry = createUploadEntry(currentEntryCount);
+    uploadEntries.appendChild(entry);
+    currentEntryCount++;
+    
+    updateAddButton();
+    updateDeleteButtons();
+}
+
+// 입력 영역 삭제
+function removeUploadEntry(entry) {
+    if (currentEntryCount <= 1) return;
+    
+    entry.remove();
+    currentEntryCount--;
+    
+    // 번호 재정렬
+    renumberEntries();
+    updateAddButton();
+    updateDeleteButtons();
+}
+
+// 번호 재정렬
+function renumberEntries() {
+    const entries = uploadEntries.querySelectorAll('.upload-entry');
+    entries.forEach((entry, index) => {
+        entry.id = `uploadEntry${index}`;
+        entry.dataset.index = index;
+        entry.querySelector('.upload-entry-number').textContent = index + 1;
+        
+        const sentenceInput = entry.querySelector('input[id^="uploadSentence"]');
+        const authorInput = entry.querySelector('input[id^="uploadAuthor"]');
+        const messageEl = entry.querySelector('div[id^="uploadMessage"]');
+        
+        sentenceInput.id = `uploadSentence${index}`;
+        authorInput.id = `uploadAuthor${index}`;
+        messageEl.id = `uploadMessage${index}`;
+    });
+}
+
+// 삭제 버튼 표시/숨김
+function updateDeleteButtons() {
+    const deleteButtons = uploadEntries.querySelectorAll('.upload-entry-delete-btn');
+    deleteButtons.forEach(btn => {
+        btn.style.display = currentEntryCount <= 1 ? 'none' : 'flex';
+    });
+}
+
+// + 버튼 상태 업데이트
+function updateAddButton() {
+    if (currentEntryCount >= MAX_UPLOAD_ENTRIES) {
+        uploadAddBtn.disabled = true;
+        uploadAddBtn.querySelector('span').textContent = `최대 ${MAX_UPLOAD_ENTRIES}개`;
+    } else {
+        uploadAddBtn.disabled = false;
+        uploadAddBtn.querySelector('span').textContent = `문장 추가 (${currentEntryCount}/${MAX_UPLOAD_ENTRIES})`;
+    }
+}
+
+// 팝업 열기
+function openUploadPopup() {
+    uploadPopupOverlay.classList.remove('display-none');
+    
+    const isDark = document.getElementById('body').classList.contains('dark');
+    if (isDark) {
+        uploadPopup.classList.add('dark');
+        document.getElementById('uploadPopupCloseBtn').classList.add('dark');
+        document.querySelector('.upload-type-hint').classList.add('dark');
+        document.querySelector('.upload-type-info').classList.add('dark');
+        document.querySelector('.upload-type-tooltip').classList.add('dark');
+        uploadAddBtn.classList.add('dark');
+        document.getElementById('uploadCancelBtn').classList.add('dark');
+        document.getElementById('uploadSubmitBtn').classList.add('dark');
+    }
+    
+    // 초기화: 입력 영역 비우고 1개만 생성
+    uploadEntries.innerHTML = '';
+    currentEntryCount = 0;
+    addUploadEntry();
+    updateDeleteButtons();
+}
+
+// 팝업 닫기
+function closeUploadPopup() {
+    uploadPopupOverlay.classList.add('display-none');
+}
+
+// + 버튼 이벤트
+uploadAddBtn.addEventListener('click', addUploadEntry);
+
+// 닫기 버튼
+document.getElementById('uploadPopupCloseBtn').addEventListener('click', closeUploadPopup);
+document.getElementById('uploadCancelBtn').addEventListener('click', closeUploadPopup);
+
+// 확인 팝업
+const uploadConfirmOverlay = document.getElementById('uploadConfirmOverlay');
+const uploadConfirmPopup = document.getElementById('uploadConfirmPopup');
+const uploadConfirmMessage = document.getElementById('uploadConfirmMessage');
+let pendingUploadEntries = [];
+
+function showUploadConfirm(entries) {
+    pendingUploadEntries = entries;
+    
+    const publicCount = entries.filter(e => e.type === 'public').length;
+    const privateCount = entries.filter(e => e.type === 'private').length;
+    
+    let message = '';
+    if (publicCount > 0 && privateCount > 0) {
+        message = `공개 ${publicCount}개, 비공개 ${privateCount}개의 문장을 업로드합니다.`;
+    } else if (publicCount > 0) {
+        message = `${publicCount}개의 문장을 공개로 업로드합니다.`;
+    } else {
+        message = `${privateCount}개의 문장을 비공개로 업로드합니다.`;
+    }
+    uploadConfirmMessage.textContent = message;
+    
+    const isDark = document.getElementById('body').classList.contains('dark');
+    if (isDark) {
+        uploadConfirmPopup.classList.add('dark');
+        uploadConfirmMessage.classList.add('dark');
+        document.getElementById('uploadConfirmCancelBtn').classList.add('dark');
+        document.getElementById('uploadConfirmOkBtn').classList.add('dark');
+    } else {
+        uploadConfirmPopup.classList.remove('dark');
+        uploadConfirmMessage.classList.remove('dark');
+        document.getElementById('uploadConfirmCancelBtn').classList.remove('dark');
+        document.getElementById('uploadConfirmOkBtn').classList.remove('dark');
+    }
+    
+    uploadConfirmOverlay.classList.remove('display-none');
+}
+
+function hideUploadConfirm() {
+    uploadConfirmOverlay.classList.add('display-none');
+    pendingUploadEntries = [];
+}
+
+document.getElementById('uploadConfirmCancelBtn').addEventListener('click', hideUploadConfirm);
+document.getElementById('uploadConfirmOkBtn').addEventListener('click', () => {
+    hideUploadConfirm();
+    executeUpload(pendingUploadEntries);
+});
+
+// 업로드 버튼 클릭 - 확인 팝업 표시
+document.getElementById('uploadSubmitBtn').addEventListener('click', () => {
+    const entries = [];
+    
+    // 입력된 문장들 수집
+    for (let i = 0; i < currentEntryCount; i++) {
+        const entryEl = document.getElementById(`uploadEntry${i}`);
+        const sentenceEl = document.getElementById(`uploadSentence${i}`);
+        const authorEl = document.getElementById(`uploadAuthor${i}`);
+        
+        if (!entryEl || !sentenceEl || !authorEl) continue;
+        
+        const sentence = sentenceEl.value.trim();
+        const author = authorEl.value.trim();
+        const type = entryEl.dataset.type || 'public';
+        const messageEl = document.getElementById(`uploadMessage${i}`);
+        
+        // 메시지 초기화
+        if (messageEl) {
+            messageEl.textContent = '';
+            messageEl.className = 'upload-entry-message';
+        }
+        entryEl.classList.remove('error', 'success');
+        
+        if (sentence) {
+            entries.push({ index: i, sentence, author, type });
+        }
+    }
+    
+    if (entries.length === 0) {
+        alert('최소 1개의 문장을 입력해주세요.');
+        return;
+    }
+    
+    showUploadConfirm(entries);
+});
+
+// 실제 업로드 실행
+async function executeUpload(entries) {
+    const submitBtn = document.getElementById('uploadSubmitBtn');
+    submitBtn.disabled = true;
+    submitBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i><span>업로드 중...</span>';
+    
+    // 각 문장 업로드 시뮬레이션
+    let successCount = 0;
+    
+    for (const entry of entries) {
+        const { index, sentence, author, type } = entry;
+        const messageEl = document.getElementById(`uploadMessage${index}`);
+        const entryEl = document.getElementById(`uploadEntry${index}`);
+        const sentenceInput = document.getElementById(`uploadSentence${index}`);
+        const authorInput = document.getElementById(`uploadAuthor${index}`);
+        
+        // 유효성 검증
+        if (sentence.length < 5 || sentence.length > 100) {
+            messageEl.textContent = '문장은 5-100자여야 합니다.';
+            messageEl.classList.add('error');
+            entryEl.classList.add('error');
+            continue;
+        }
+        
+        // API 호출 시뮬레이션
+        try {
+            // 실제로는 fetch 호출
+            // const response = await fetch(`/quotes/${type}`, {
+            //     method: 'POST',
+            //     headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
+            //     body: JSON.stringify({ sentence, author: author || undefined })
+            // });
+            
+            // 시뮬레이션: 랜덤하게 성공/실패
+            await new Promise(resolve => setTimeout(resolve, 500));
+            const isSuccess = Math.random() > 0.3; // 70% 성공률
+            
+            if (isSuccess) {
+                messageEl.textContent = '업로드 성공!';
+                messageEl.classList.add('success');
+                if (document.getElementById('body').classList.contains('dark')) {
+                    messageEl.classList.add('dark');
+                }
+                entryEl.classList.add('success');
+                
+                // 성공한 입력 필드 비우기
+                sentenceInput.value = '';
+                authorInput.value = '';
+                successCount++;
+            } else {
+                // 실패 시뮬레이션
+                throw new Error('서버 오류가 발생했습니다.');
+            }
+        } catch (error) {
+            messageEl.textContent = error.message || '업로드에 실패했습니다.';
+            messageEl.classList.add('error');
+            entryEl.classList.add('error');
+        }
+    }
+    
+    submitBtn.disabled = false;
+    submitBtn.innerHTML = '<i class="fa-solid fa-upload"></i><span>업로드</span>';
+    
+    // 결과 알림
+    if (successCount === entries.length) {
+        alert(`${successCount}개의 문장이 모두 업로드되었습니다!`);
+        closeUploadPopup();
+    } else if (successCount > 0) {
+        alert(`${entries.length}개 중 ${successCount}개 업로드 성공, ${entries.length - successCount}개 실패`);
+    }
+}
 
 document.getElementById('mysentencesBtn').addEventListener('click', () => {
     alert('내 문장 기능 (준비 중)');

--- a/tp-react/typing-practice-prototype.html
+++ b/tp-react/typing-practice-prototype.html
@@ -187,6 +187,53 @@
     </div>
 </div>
 
+<!-- 문장 업로드 팝업 -->
+<div class="upload-popup-overlay display-none" id="uploadPopupOverlay">
+    <div class="upload-popup" id="uploadPopup">
+        <div class="upload-popup-header">
+            <h2 class="upload-popup-title">문장 업로드</h2>
+            <button class="upload-popup-close-btn" id="uploadPopupCloseBtn">
+                <i class="fa-solid fa-xmark"></i>
+            </button>
+        </div>
+
+        <div class="upload-type-toggle">
+            <span class="upload-type-hint">각 문장마다 공개/비공개를 선택할 수 있습니다. <span class="upload-type-info"><i class="fa-solid fa-circle-info"></i><span class="upload-type-tooltip">
+                    <p><strong>공개</strong>: 관리자 승인 후 모든 사용자에게 노출됩니다.</p>
+                    <p><strong>비공개</strong>: 본인만 사용할 수 있습니다.</p>
+                </span></span></span>
+        </div>
+
+        <div class="upload-entries" id="uploadEntries">
+            <!-- 입력 필드가 여기에 동적으로 생성됨 -->
+        </div>
+
+        <button class="upload-add-btn" id="uploadAddBtn">
+            <i class="fa-solid fa-plus"></i>
+            <span>문장 추가</span>
+        </button>
+
+        <div class="upload-actions">
+            <button class="upload-cancel-btn" id="uploadCancelBtn">취소</button>
+            <button class="upload-submit-btn" id="uploadSubmitBtn">
+                <i class="fa-solid fa-upload"></i>
+                <span>업로드</span>
+            </button>
+        </div>
+    </div>
+</div>
+
+<!-- 업로드 확인 팝업 -->
+<div class="confirm-popup-overlay display-none" id="uploadConfirmOverlay">
+    <div class="confirm-popup" id="uploadConfirmPopup">
+        <p class="confirm-popup-message" id="uploadConfirmMessage"></p>
+        <div class="confirm-popup-actions">
+            <button class="confirm-popup-cancel-btn" id="uploadConfirmCancelBtn">취소</button>
+            <button class="confirm-popup-ok-btn" id="uploadConfirmOkBtn">확인</button>
+        </div>
+    </div>
+</div>
+
 <script src="prototype.js"></script>
 </body>
 </html>


### PR DESCRIPTION
- 문장 업로드 팝업 구현
  - 최대 5개 문장 동적 추가/삭제
  - 각 문장마다 공개/비공개 선택 (기본값: 공개)
  - 업로드 전 확인 팝업 (공개 n개, 비공개 n개 표시)

- UI 구성
  - + 버튼으로 문장 추가, X 버튼으로 삭제
  - 1개일 때 삭제 버튼 숨김
  - 공개/비공개 설명 툴팁 (ℹ️ 아이콘 hover)
  - 다크모드 지원

- 업로드 흐름 시뮬레이션
  - 성공: 입력칸 비우기 + 녹색 테두리
  - 실패: 입력칸 유지 + 에러 메시지