### PR TITLE
feat: 문장 업로드 기능 구현

### DIFF
--- a/tp-react/package-lock.json
+++ b/tp-react/package-lock.json
@@ -17,6 +17,7 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.3.0",
+        "react-router-dom": "^7.13.0",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
       },
@@ -15102,6 +15103,57 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
+      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
+      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.13.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -16044,6 +16096,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/tp-react/package.json
+++ b/tp-react/package.json
@@ -12,6 +12,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
+    "react-router-dom": "^7.13.0",
     "react-scripts": "5.0.1",
     "web-vitals": "^2.1.4"
   },

--- a/tp-react/prototype.js
+++ b/tp-react/prototype.js
@@ -597,9 +597,11 @@ const uploadConfirmOverlay = document.getElementById('uploadConfirmOverlay');
 const uploadConfirmPopup = document.getElementById('uploadConfirmPopup');
 const uploadConfirmMessage = document.getElementById('uploadConfirmMessage');
 let pendingUploadEntries = [];
+let isResultPopup = false;
 
 function showUploadConfirm(entries) {
     pendingUploadEntries = entries;
+    isResultPopup = false;
     
     const publicCount = entries.filter(e => e.type === 'public').length;
     const privateCount = entries.filter(e => e.type === 'private').length;
@@ -637,9 +639,44 @@ function hideUploadConfirm() {
 
 document.getElementById('uploadConfirmCancelBtn').addEventListener('click', hideUploadConfirm);
 document.getElementById('uploadConfirmOkBtn').addEventListener('click', () => {
-    hideUploadConfirm();
-    executeUpload(pendingUploadEntries);
+    if (isResultPopup) {
+        hideResultPopup();
+    } else {
+        const entriesToUpload = [...pendingUploadEntries];
+        hideUploadConfirm();
+        executeUpload(entriesToUpload);
+    }
 });
+
+// 결과 팝업 (확인 버튼만)
+function showResultPopup(message) {
+    isResultPopup = true;
+    uploadConfirmMessage.textContent = message;
+    
+    const isDark = document.getElementById('body').classList.contains('dark');
+    if (isDark) {
+        uploadConfirmPopup.classList.add('dark');
+        uploadConfirmMessage.classList.add('dark');
+        document.getElementById('uploadConfirmCancelBtn').classList.add('dark');
+        document.getElementById('uploadConfirmOkBtn').classList.add('dark');
+    } else {
+        uploadConfirmPopup.classList.remove('dark');
+        uploadConfirmMessage.classList.remove('dark');
+        document.getElementById('uploadConfirmCancelBtn').classList.remove('dark');
+        document.getElementById('uploadConfirmOkBtn').classList.remove('dark');
+    }
+    
+    // 취소 버튼 숨김
+    document.getElementById('uploadConfirmCancelBtn').classList.add('display-none');
+    
+    uploadConfirmOverlay.classList.remove('display-none');
+}
+
+function hideResultPopup() {
+    uploadConfirmOverlay.classList.add('display-none');
+    // 취소 버튼 다시 표시
+    document.getElementById('uploadConfirmCancelBtn').classList.remove('display-none');
+}
 
 // 업로드 버튼 클릭 - 확인 팝업 표시
 document.getElementById('uploadSubmitBtn').addEventListener('click', () => {
@@ -686,8 +723,10 @@ async function executeUpload(entries) {
     
     // 각 문장 업로드 시뮬레이션
     let successCount = 0;
+    const successIndices = [];
     
-    for (const entry of entries) {
+    for (let i = 0; i < entries.length; i++) {
+        const entry = entries[i];
         const { index, sentence, author, type } = entry;
         const messageEl = document.getElementById(`uploadMessage${index}`);
         const entryEl = document.getElementById(`uploadEntry${index}`);
@@ -711,22 +750,13 @@ async function executeUpload(entries) {
             //     body: JSON.stringify({ sentence, author: author || undefined })
             // });
             
-            // 시뮬레이션: 랜덤하게 성공/실패
+            // 시뮬레이션: 2, 4번째 문장은 실패 (i는 0부터 시작하므로 i=1, i=3이 실패)
             await new Promise(resolve => setTimeout(resolve, 500));
-            const isSuccess = Math.random() > 0.3; // 70% 성공률
+            const isSuccess = i % 2 === 0; // 1, 3, 5번째 성공 / 2, 4번째 실패
             
             if (isSuccess) {
-                messageEl.textContent = '업로드 성공!';
-                messageEl.classList.add('success');
-                if (document.getElementById('body').classList.contains('dark')) {
-                    messageEl.classList.add('dark');
-                }
-                entryEl.classList.add('success');
-                
-                // 성공한 입력 필드 비우기
-                sentenceInput.value = '';
-                authorInput.value = '';
                 successCount++;
+                successIndices.push(index);
             } else {
                 // 실패 시뮬레이션
                 throw new Error('서버 오류가 발생했습니다.');
@@ -741,12 +771,26 @@ async function executeUpload(entries) {
     submitBtn.disabled = false;
     submitBtn.innerHTML = '<i class="fa-solid fa-upload"></i><span>업로드</span>';
     
-    // 결과 알림
-    if (successCount === entries.length) {
-        alert(`${successCount}개의 문장이 모두 업로드되었습니다!`);
-        closeUploadPopup();
-    } else if (successCount > 0) {
-        alert(`${entries.length}개 중 ${successCount}개 업로드 성공, ${entries.length - successCount}개 실패`);
+    // 성공한 entry 제거 및 결과 팝업
+    if (successCount > 0) {
+        // 성공한 entry 제거
+        successIndices.forEach(index => {
+            const entryEl = document.getElementById(`uploadEntry${index}`);
+            if (entryEl) entryEl.remove();
+        });
+        currentEntryCount -= successCount;
+        
+        // entry가 0개면 1개 추가
+        if (currentEntryCount === 0) {
+            addUploadEntry();
+        } else {
+            renumberEntries();
+            updateAddButton();
+            updateDeleteButtons();
+        }
+        
+        // 결과 팝업 표시
+        showResultPopup(`${successCount}개의 문장 업로드에 성공했습니다.`);
     }
 }
 

--- a/tp-react/src/App.js
+++ b/tp-react/src/App.js
@@ -1,50 +1,35 @@
 import "./App.css";
 
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import { ThemeContextProvider } from "./Context/ThemeContext";
 import { AuthProvider } from "./Context/AuthContext";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import Head from "./components/Head/Head";
 import AppDiv from "./components/AppDiv/AppDiv";
-import Info from "./components/Info/Info";
-import { SettingContextProvider } from "./Context/SettingContext";
-import { ScoreContextProvider } from "./Context/ScoreContext";
-import Quote from "./components/Quote/Quote";
 import Contact from "./components/Contact/Contact";
-import { QuoteContextProvider } from "./Context/QuoteContext";
-import AverageScorePopUp from "./components/AverageScorePopUp/AverageScorePopUp";
-import FontSizeSlider from "./components/FontSizeSlider/FontSizeSlider";
-import ModeToggle from "./components/ModeToggle/ModeToggle";
-import UpdatePopup from "./components/UpdatePopup/UpdatePopup";
+import Home from "./pages/Home/Home";
+import QuoteUpload from "./pages/QuoteUpload/QuoteUpload";
 import {Analytics} from "@vercel/analytics/react";
 
 function App() {
   return (
     <GoogleOAuthProvider clientId={process.env.REACT_APP_GOOGLE_CLIENT_ID}>
-      <ThemeContextProvider>
-        <AuthProvider>
-          <AppDiv>
-            <Head />
-            <SettingContextProvider>
-              <div className="top-left-controls">
-                <FontSizeSlider />
-                <ModeToggle />
-              </div>
-              <UpdatePopup />
-              <ScoreContextProvider>
-                <AverageScorePopUp />
-                <Info />
-                <QuoteContextProvider>
-                  <Quote />
-                </QuoteContextProvider>
-              </ScoreContextProvider>
-            </SettingContextProvider>
-            <Contact />
+      <BrowserRouter>
+        <ThemeContextProvider>
+          <AuthProvider>
+            <AppDiv>
+              <Head />
+              <Routes>
+                <Route path="/" element={<Home />} />
+                <Route path="/quote/upload" element={<QuoteUpload />} />
+              </Routes>
+              <Contact />
               <Analytics/>
-          </AppDiv>
-        </AuthProvider>
-      </ThemeContextProvider>
+            </AppDiv>
+          </AuthProvider>
+        </ThemeContextProvider>
+      </BrowserRouter>
     </GoogleOAuthProvider>
-
   );
 }
 

--- a/tp-react/src/components/Head/Head.css
+++ b/tp-react/src/components/Head/Head.css
@@ -14,3 +14,22 @@
     align-items: center;
     gap: 1rem;
 }
+
+.header-btn {
+    padding: 0.5rem 1rem;
+    border: none;
+    background-color: transparent;
+    color: var(--color-text-muted);
+    border-radius: 0.375rem;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.header-btn:hover {
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text);
+}

--- a/tp-react/src/components/Head/Head.jsx
+++ b/tp-react/src/components/Head/Head.jsx
@@ -1,4 +1,5 @@
 import React, {useState, useEffect} from "react";
+import {useNavigate} from "react-router-dom";
 import Title from "./title/Title";
 import DarkModeButton from "./themeButton/DarkModeButton";
 import LoginButton from "../LoginButton/LoginButton";
@@ -6,8 +7,10 @@ import ProfileDropdown from "../ProfileDropdown/ProfileDropdown";
 import LoadingSpinner from "../LoadingSpinner/LoadingSpinner";
 import NicknamePopup from "../NicknamePopup/NicknamePopup";
 import {useAuth} from "../../Context/AuthContext";
+import {useTheme} from "../../Context/ThemeContext";
 import {useGoogleLogin} from "@react-oauth/google";
 import {loginWithGoogle} from "../../utils/authApi";
+import {FaPlus} from "react-icons/fa";
 import "./Head.css";
 
 // UUID 형식 체크 함수
@@ -18,6 +21,8 @@ const isUuidFormat = (str) => {
 };
 
 const Head = () => {
+    const navigate = useNavigate();
+    const {isDark} = useTheme();
     const {user, accessToken, refreshToken, isLoading, setIsLoading, login} = useAuth();
     const [showNicknamePopup, setShowNicknamePopup] = useState(false);
 
@@ -85,6 +90,19 @@ const Head = () => {
             <div className="head">
                 <Title/>
                 <div className="head-right">
+                    <button 
+                        className={`header-btn ${isDark ? 'dark' : ''}`}
+                        onClick={() => {
+                            if (user) {
+                                navigate('/quote/upload');
+                            } else {
+                                alert('로그인이 필요한 기능입니다.');
+                            }
+                        }}
+                    >
+                        <FaPlus/>
+                        <span>문장 업로드</span>
+                    </button>
                     {user ? <ProfileDropdown/> : <LoginButton onClick={handleLogin}/>}
                     <DarkModeButton/>
                 </div>

--- a/tp-react/src/components/Head/title/Title.css
+++ b/tp-react/src/components/Head/title/Title.css
@@ -3,4 +3,5 @@
     color: var(--color-text);
     font-weight: 600;
     letter-spacing: -0.5px;
+    cursor: pointer;
 }

--- a/tp-react/src/components/Head/title/Title.jsx
+++ b/tp-react/src/components/Head/title/Title.jsx
@@ -1,9 +1,18 @@
-import "./Title.css";
+import { useNavigate } from "react-router-dom";
 import { useTheme } from "../../../Context/ThemeContext";
+import "./Title.css";
 
 const Title = () => {
+  const navigate = useNavigate();
   const { isDark } = useTheme();
-  return <h1 className={`title ${isDark ? "dark" : ""}`}>Typing Practice</h1>;
+  return (
+    <h1 
+      className={`title ${isDark ? "dark" : ""}`}
+      onClick={() => navigate("/")}
+    >
+      Typing Practice
+    </h1>
+  );
 };
 
 export default Title;

--- a/tp-react/src/components/ProfilePopup/ProfilePopup.css
+++ b/tp-react/src/components/ProfilePopup/ProfilePopup.css
@@ -135,7 +135,7 @@
 .profile-btn {
     flex: 1;
     padding: 0.75rem;
-    border: none;
+    border: 1px solid transparent;
     border-radius: 0.5rem;
     font-size: 1rem;
     cursor: pointer;
@@ -143,11 +143,16 @@
 }
 
 .profile-btn-save {
+    background-color: var(--color-border);
+    color: var(--color-text-placeholder);
+}
+
+.profile-btn-save:enabled {
     background-color: var(--color-primary);
     color: var(--color-white);
 }
 
-.profile-btn-save:hover:not(:disabled) {
+.profile-btn-save:enabled:hover {
     background-color: var(--color-primary-dark);
     color: var(--color-white);
 }
@@ -163,12 +168,13 @@
     color: var(--color-text-placeholder);
 }
 
-.profile-btn-close {
-    background-color: var(--color-bg-secondary);
-    color: var(--color-text);
+.profile-btn.profile-btn-close {
+    background-color: transparent;
+    border: 1px solid var(--color-border);
+    color: var(--color-text-muted);
 }
 
-.profile-btn-close:hover {
-    background-color: var(--color-border);
+.profile-btn.profile-btn-close:hover {
+    background-color: var(--color-bg-secondary);
     color: var(--color-text);
 }

--- a/tp-react/src/pages/Home/Home.jsx
+++ b/tp-react/src/pages/Home/Home.jsx
@@ -1,0 +1,30 @@
+import FontSizeSlider from '../../components/FontSizeSlider/FontSizeSlider';
+import ModeToggle from '../../components/ModeToggle/ModeToggle';
+import UpdatePopup from '../../components/UpdatePopup/UpdatePopup';
+import AverageScorePopUp from '../../components/AverageScorePopUp/AverageScorePopUp';
+import Info from '../../components/Info/Info';
+import Quote from '../../components/Quote/Quote';
+import {SettingContextProvider} from '../../Context/SettingContext';
+import {ScoreContextProvider} from '../../Context/ScoreContext';
+import {QuoteContextProvider} from '../../Context/QuoteContext';
+
+function Home() {
+    return (
+        <SettingContextProvider>
+            <div className="top-left-controls">
+                <FontSizeSlider/>
+                <ModeToggle/>
+            </div>
+            <UpdatePopup/>
+            <ScoreContextProvider>
+                <AverageScorePopUp/>
+                <Info/>
+                <QuoteContextProvider>
+                    <Quote/>
+                </QuoteContextProvider>
+            </ScoreContextProvider>
+        </SettingContextProvider>
+    );
+}
+
+export default Home;

--- a/tp-react/src/pages/QuoteUpload/QuoteUpload.css
+++ b/tp-react/src/pages/QuoteUpload/QuoteUpload.css
@@ -1,0 +1,425 @@
+.quote-upload-container {
+    width: 80%;
+    max-width: 1000px;
+    min-width: 600px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+.quote-upload-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.5rem;
+}
+
+.quote-upload-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--color-primary);
+    margin: 0;
+}
+
+.quote-upload-close-btn {
+    border: none;
+    background: none;
+    color: var(--color-text-placeholder);
+    font-size: 1.25rem;
+    cursor: pointer;
+    padding: 0.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.2s;
+}
+
+.quote-upload-close-btn:hover {
+    color: var(--color-text-muted);
+}
+
+/* 로그인 필요 */
+.quote-upload-login-required {
+    text-align: center;
+    padding: 3rem;
+    color: var(--color-text-muted);
+}
+
+.quote-upload-login-required button {
+    margin-top: 1rem;
+    padding: 0.75rem 1.5rem;
+    border: none;
+    border-radius: 0.5rem;
+    background-color: var(--color-primary);
+    color: var(--color-white);
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.quote-upload-login-required button:hover {
+    background-color: var(--color-primary-dark);
+}
+
+/* 공개/비공개 안내 */
+.quote-upload-type-info {
+    margin-bottom: 1rem;
+}
+
+.quote-upload-type-hint {
+    font-size: 0.85rem;
+    color: var(--color-text-muted);
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.quote-upload-tooltip-trigger {
+    position: relative;
+    cursor: help;
+    display: inline-flex;
+    align-items: center;
+    color: var(--color-text-placeholder);
+}
+
+.quote-upload-tooltip {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 50%;
+    transform: translateX(-50%);
+    margin-top: 0.5rem;
+    padding: 0.75rem 1rem;
+    background-color: #333;
+    color: white;
+    border-radius: 0.5rem;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    z-index: 10;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1);
+    width: max-content;
+    max-width: 350px;
+}
+
+.quote-upload-tooltip p {
+    margin: 0;
+}
+
+.quote-upload-tooltip p + p {
+    margin-top: 0.5rem;
+}
+
+.quote-upload-tooltip-trigger:hover .quote-upload-tooltip {
+    display: block;
+}
+
+/* 입력 영역들 */
+.quote-upload-entries {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.quote-upload-entry {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    background-color: var(--color-bg-secondary);
+}
+
+.quote-upload-entry.error {
+    border-color: var(--color-error);
+}
+
+.quote-upload-entry-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+}
+
+.quote-upload-entry-number {
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: var(--color-primary);
+}
+
+.quote-upload-entry-delete-btn {
+    border: none;
+    background: none;
+    color: var(--color-text-placeholder);
+    font-size: 0.9rem;
+    cursor: pointer;
+    padding: 0.25rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.2s;
+}
+
+.quote-upload-entry-delete-btn:hover {
+    color: var(--color-error);
+}
+
+/* 각 entry의 공개/비공개 토글 */
+.quote-upload-entry-type-toggle {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+.quote-upload-entry-type-btn {
+    padding: 0.25rem 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.25rem;
+    background-color: transparent;
+    color: var(--color-text-placeholder);
+    font-size: 0.75rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.quote-upload-entry-type-btn:hover {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.quote-upload-entry-type-btn.active {
+    border-color: var(--color-primary);
+    background-color: var(--color-primary);
+    color: var(--color-white);
+}
+
+.quote-upload-entry-inputs {
+    display: flex;
+    gap: 1rem;
+    align-items: flex-end;
+}
+
+.quote-upload-sentence-wrapper {
+    flex: 1;
+    position: relative;
+}
+
+.quote-upload-char-count {
+    position: absolute;
+    right: 0;
+    bottom: 0.25rem;
+    font-size: 0.75rem;
+    color: var(--color-text-placeholder);
+}
+
+.quote-upload-char-count.warning {
+    color: var(--color-error);
+}
+
+.quote-upload-author-wrapper {
+    width: 150px;
+}
+
+.quote-upload-input {
+    width: 100%;
+    padding: 0.5rem 0;
+    border: none;
+    border-bottom: 1px solid var(--color-border);
+    background-color: transparent;
+    font-size: 1rem;
+    color: var(--color-text);
+    outline: none;
+    transition: border-color 0.2s;
+    font-family: inherit;
+}
+
+.quote-upload-input:focus {
+    border-bottom-color: var(--color-primary);
+}
+
+.quote-upload-input::placeholder {
+    color: var(--color-text-placeholder);
+}
+
+.quote-upload-sentence {
+    resize: none;
+    overflow: hidden;
+    min-height: 1.5rem;
+    line-height: 1.5;
+}
+
+.quote-upload-author {
+    resize: none;
+    overflow: hidden;
+    min-height: 1.5rem;
+    line-height: 1.5;
+}
+
+.quote-upload-entry-error {
+    font-size: 0.85rem;
+    color: var(--color-error);
+}
+
+/* 문장 추가 버튼 */
+.quote-upload-add-btn {
+    width: 100%;
+    padding: 0.75rem;
+    margin-bottom: 1.5rem;
+    border: 2px dashed var(--color-border);
+    border-radius: 0.5rem;
+    background-color: transparent;
+    color: var(--color-text-placeholder);
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.quote-upload-add-btn:hover:not(:disabled) {
+    border-color: var(--color-primary);
+    color: var(--color-primary);
+}
+
+.quote-upload-add-btn:disabled {
+    border-color: var(--color-border);
+    color: var(--color-text-placeholder);
+    cursor: not-allowed;
+    opacity: 0.6;
+}
+
+/* 하단 버튼 */
+.quote-upload-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.75rem;
+}
+
+.quote-upload-cancel-btn {
+    padding: 0.75rem 1.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    background-color: transparent;
+    color: var(--color-text-muted);
+    font-size: 1rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.quote-upload-cancel-btn:hover {
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text);
+}
+
+.quote-upload-submit-btn {
+    padding: 0.75rem 1.5rem;
+    border: none;
+    border-radius: 0.5rem;
+    background-color: var(--color-primary);
+    color: var(--color-white);
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.quote-upload-submit-btn:hover:not(:disabled) {
+    background-color: var(--color-primary-dark);
+}
+
+.quote-upload-submit-btn:disabled {
+    background-color: var(--color-border);
+    cursor: not-allowed;
+}
+
+/* 스피너 */
+.quote-upload-spinner {
+    width: 1rem;
+    height: 1rem;
+    border: 2px solid var(--color-white);
+    border-top-color: transparent;
+    border-radius: 50%;
+    animation: spin 0.8s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+/* 확인 팝업 */
+.quote-upload-confirm-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 3000;
+}
+
+.quote-upload-confirm-popup {
+    background-color: var(--color-popup-bg);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    max-width: 400px;
+    width: 90%;
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+}
+
+.quote-upload-confirm-message {
+    font-size: 1rem;
+    color: var(--color-text);
+    margin: 0 0 1.5rem 0;
+    text-align: center;
+    line-height: 1.5;
+}
+
+.quote-upload-confirm-actions {
+    display: flex;
+    gap: 0.75rem;
+}
+
+.quote-upload-confirm-cancel-btn {
+    flex: 1;
+    padding: 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    background-color: transparent;
+    color: var(--color-text-muted);
+    font-size: 1rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.quote-upload-confirm-cancel-btn:hover {
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text);
+}
+
+.quote-upload-confirm-ok-btn {
+    flex: 1;
+    padding: 0.75rem;
+    border: none;
+    border-radius: 0.5rem;
+    background-color: var(--color-primary);
+    color: var(--color-white);
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background-color 0.2s;
+}
+
+.quote-upload-confirm-ok-btn:hover {
+    background-color: var(--color-primary-dark);
+}

--- a/tp-react/src/pages/QuoteUpload/QuoteUpload.jsx
+++ b/tp-react/src/pages/QuoteUpload/QuoteUpload.jsx
@@ -1,0 +1,332 @@
+import {useState} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {FaCircleInfo, FaGlobe, FaLock, FaPlus, FaUpload, FaXmark} from 'react-icons/fa6';
+import {uploadQuote} from '../../utils/quoteApi';
+import {useAuth} from '../../Context/AuthContext';
+import './QuoteUpload.css';
+
+const MAX_ENTRIES = 5;
+const MIN_SENTENCE_LENGTH = 5;
+const MAX_SENTENCE_LENGTH = 100;
+const MAX_AUTHOR_LENGTH = 20;
+
+function QuoteUpload() {
+    const navigate = useNavigate();
+    const {user} = useAuth();
+    const [entries, setEntries] = useState([createEmptyEntry(0)]);
+    const [isUploading, setIsUploading] = useState(false);
+    const [showConfirm, setShowConfirm] = useState(false);
+    const [confirmMessage, setConfirmMessage] = useState('');
+    const [isResultPopup, setIsResultPopup] = useState(false);
+
+    function createEmptyEntry(id) {
+        return {
+            id,
+            type: 'public',
+            sentence: '',
+            author: '',
+            error: '',
+        };
+    }
+
+    const addEntry = () => {
+        if (entries.length >= MAX_ENTRIES) return;
+        const newId = entries.length > 0 ? Math.max(...entries.map(e => e.id)) + 1 : 0;
+        setEntries([...entries, createEmptyEntry(newId)]);
+    };
+
+    const removeEntry = (id) => {
+        if (entries.length <= 1) return;
+        setEntries(entries.filter(entry => entry.id !== id));
+    };
+
+    const updateEntry = (id, field, value) => {
+        // 문장 길이 제한
+        if (field === 'sentence' && value.length > MAX_SENTENCE_LENGTH) {
+            return;
+        }
+        // 출처 길이 제한
+        if (field === 'author' && value.length > MAX_AUTHOR_LENGTH) {
+            return;
+        }
+
+        setEntries(entries.map(entry => {
+            if (entry.id === id) {
+                return {...entry, [field]: value, error: ''};
+            }
+            return entry;
+        }));
+    };
+
+    const validateEntry = (entry) => {
+        const sentence = entry.sentence.trim();
+        if (!sentence) return '';
+        if (sentence.length < MIN_SENTENCE_LENGTH) {
+            return `문장은 ${MIN_SENTENCE_LENGTH}자 이상이어야 합니다.`;
+        }
+        if (sentence.length > MAX_SENTENCE_LENGTH) {
+            return `문장은 ${MAX_SENTENCE_LENGTH}자 이하여야 합니다.`;
+        }
+        if (entry.author && entry.author.length > MAX_AUTHOR_LENGTH) {
+            return `저자는 ${MAX_AUTHOR_LENGTH}자 이하여야 합니다.`;
+        }
+        return '';
+    };
+
+    const getValidEntries = () => {
+        return entries.filter(entry => entry.sentence.trim());
+    };
+
+    const handleUploadClick = () => {
+        const validEntries = getValidEntries();
+
+        if (validEntries.length === 0) {
+            alert('최소 1개의 문장을 입력해주세요.');
+            return;
+        }
+
+        // 유효성 검증
+        let hasError = false;
+        const updatedEntries = entries.map(entry => {
+            if (!entry.sentence.trim()) return entry;
+            const error = validateEntry(entry);
+            if (error) hasError = true;
+            return {...entry, error};
+        });
+        setEntries(updatedEntries);
+
+        if (hasError) return;
+
+        // 확인 팝업 메시지 생성
+        const publicCount = validEntries.filter(e => e.type === 'public').length;
+        const privateCount = validEntries.filter(e => e.type === 'private').length;
+
+        let message;
+        if (publicCount > 0 && privateCount > 0) {
+            message = `공개 ${publicCount}개, 비공개 ${privateCount}개의 문장을 업로드합니다.`;
+        } else if (publicCount > 0) {
+            message = `${publicCount}개의 문장을 공개로 업로드합니다.`;
+        } else {
+            message = `${privateCount}개의 문장을 비공개로 업로드합니다.`;
+        }
+
+        setConfirmMessage(message);
+        setIsResultPopup(false);
+        setShowConfirm(true);
+    };
+
+    const executeUpload = async () => {
+        setShowConfirm(false);
+        setIsUploading(true);
+
+        const validEntries = getValidEntries();
+        let successCount = 0;
+        const successIds = [];
+
+        for (const entry of validEntries) {
+            try {
+                await uploadQuote(entry.type, entry.sentence.trim(), entry.author.trim() || undefined);
+                successCount++;
+                successIds.push(entry.id);
+            } catch (error) {
+                const errorMessage = error.response?.data?.message || '업로드에 실패했습니다.';
+                setEntries(prev => prev.map(e =>
+                    e.id === entry.id ? {...e, error: errorMessage} : e
+                ));
+            }
+        }
+
+        setIsUploading(false);
+
+        if (successCount > 0) {
+            // 성공한 entry 제거
+            setEntries(prev => {
+                const remaining = prev.filter(e => !successIds.includes(e.id));
+                if (remaining.length === 0) {
+                    return [createEmptyEntry(0)];
+                }
+                return remaining;
+            });
+
+            // 결과 팝업
+            setConfirmMessage(`${successCount}개의 문장 업로드에 성공했습니다.`);
+            setIsResultPopup(true);
+            setShowConfirm(true);
+        }
+    };
+
+    const handleConfirmOk = () => {
+        if (isResultPopup) {
+            setShowConfirm(false);
+        } else {
+            executeUpload();
+        }
+    };
+
+    const handleTextareaChange = (e, id, field) => {
+        e.target.style.height = 'auto';
+        e.target.style.height = e.target.scrollHeight + 'px';
+        updateEntry(id, field, e.target.value);
+    };
+
+    // 로그인 필요
+    if (!user) {
+        return (
+            <div className="quote-upload-container">
+                <div className="quote-upload-header">
+                    <h1 className="quote-upload-title">문장 업로드</h1>
+                </div>
+                <div className="quote-upload-login-required">
+                    <p>로그인이 필요합니다.</p>
+                    <button onClick={() => navigate('/')}>홈으로 돌아가기</button>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className="quote-upload-container">
+            <div className="quote-upload-header">
+                <h1 className="quote-upload-title">문장 업로드</h1>
+            </div>
+
+            <div className="quote-upload-type-info">
+                <span className="quote-upload-type-hint">
+                    각 문장마다 공개/비공개를 선택할 수 있습니다.
+                    <span className="quote-upload-tooltip-trigger">
+                        <FaCircleInfo/>
+                        <span className="quote-upload-tooltip">
+                            <p><strong>공개</strong>: 관리자 승인 후 모든 사용자에게 노출됩니다.</p>
+                            <p><strong>비공개</strong>: 본인만 사용할 수 있습니다.</p>
+                        </span>
+                    </span>
+                </span>
+            </div>
+
+            <div className="quote-upload-entries">
+                {entries.map((entry, index) => (
+                    <div key={entry.id} className={`quote-upload-entry ${entry.error ? 'error' : ''}`}>
+                        <div className="quote-upload-entry-header">
+                            <span className="quote-upload-entry-number">{index + 1}</span>
+                            <button
+                                className="quote-upload-entry-delete-btn"
+                                onClick={() => removeEntry(entry.id)}
+                                style={{display: entries.length <= 1 ? 'none' : 'flex'}}
+                            >
+                                <FaXmark/>
+                            </button>
+                        </div>
+                        <div className="quote-upload-entry-type-toggle">
+                            <button
+                                className={`quote-upload-entry-type-btn ${entry.type === 'public' ? 'active' : ''}`}
+                                onClick={() => updateEntry(entry.id, 'type', 'public')}
+                            >
+                                <FaGlobe/>
+                                <span>공개</span>
+                            </button>
+                            <button
+                                className={`quote-upload-entry-type-btn ${entry.type === 'private' ? 'active' : ''}`}
+                                onClick={() => updateEntry(entry.id, 'type', 'private')}
+                            >
+                                <FaLock/>
+                                <span>비공개</span>
+                            </button>
+                        </div>
+                        <div className="quote-upload-entry-inputs">
+                            <div className="quote-upload-sentence-wrapper">
+                                <textarea
+                                    className="quote-upload-input quote-upload-sentence"
+                                    placeholder={`문장을 입력하세요 (${MIN_SENTENCE_LENGTH}-${MAX_SENTENCE_LENGTH}자)`}
+                                    maxLength={MAX_SENTENCE_LENGTH}
+                                    value={entry.sentence}
+                                    onChange={(e) => handleTextareaChange(e, entry.id, 'sentence')}
+                                    rows={1}
+                                />
+                                <span
+                                    className={`quote-upload-char-count ${entry.sentence.length > 0 && entry.sentence.length < MIN_SENTENCE_LENGTH ? 'warning' : ''}`}>
+                                    {entry.sentence.length}/{MAX_SENTENCE_LENGTH}
+                                </span>
+                            </div>
+                            <div className="quote-upload-author-wrapper">
+                                <textarea
+                                    className="quote-upload-input quote-upload-author"
+                                    placeholder="저자 (선택)"
+                                    maxLength={MAX_AUTHOR_LENGTH}
+                                    value={entry.author}
+                                    onChange={(e) => handleTextareaChange(e, entry.id, 'author')}
+                                    rows={1}
+                                />
+                            </div>
+                        </div>
+                        {entry.error && (
+                            <div className="quote-upload-entry-error">{entry.error}</div>
+                        )}
+                    </div>
+                ))}
+            </div>
+
+            <button
+                className="quote-upload-add-btn"
+                onClick={addEntry}
+                disabled={entries.length >= MAX_ENTRIES}
+            >
+                <FaPlus/>
+                <span>
+                    {entries.length >= MAX_ENTRIES
+                        ? `최대 ${MAX_ENTRIES}개`
+                        : `문장 추가 (${entries.length}/${MAX_ENTRIES})`}
+                </span>
+            </button>
+
+            <div className="quote-upload-actions">
+                <button className="quote-upload-cancel-btn" onClick={() => navigate('/')}>
+                    취소
+                </button>
+                <button
+                    className="quote-upload-submit-btn"
+                    onClick={handleUploadClick}
+                    disabled={isUploading}
+                >
+                    {isUploading ? (
+                        <>
+                            <span className="quote-upload-spinner"></span>
+                            <span>업로드 중...</span>
+                        </>
+                    ) : (
+                        <>
+                            <FaUpload/>
+                            <span>업로드</span>
+                        </>
+                    )}
+                </button>
+            </div>
+
+            {/* 확인/결과 팝업 */}
+            {showConfirm && (
+                <div className="quote-upload-confirm-overlay">
+                    <div className="quote-upload-confirm-popup">
+                        <p className="quote-upload-confirm-message">{confirmMessage}</p>
+                        <div className="quote-upload-confirm-actions">
+                            {!isResultPopup && (
+                                <button
+                                    className="quote-upload-confirm-cancel-btn"
+                                    onClick={() => setShowConfirm(false)}
+                                >
+                                    취소
+                                </button>
+                            )}
+                            <button
+                                className="quote-upload-confirm-ok-btn"
+                                onClick={handleConfirmOk}
+                            >
+                                확인
+                            </button>
+                        </div>
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default QuoteUpload;

--- a/tp-react/src/utils/quoteApi.js
+++ b/tp-react/src/utils/quoteApi.js
@@ -1,0 +1,43 @@
+import apiClient from './apiClient';
+
+/**
+ * 공개 문장 업로드
+ * @param {string} sentence - 문장 (5-100자)
+ * @param {string} [author] - 저자 (1-20자, 선택)
+ * @returns {Promise} API 응답
+ */
+export const uploadPublicQuote = async (sentence, author) => {
+    const body = {sentence};
+    if (author) {
+        body.author = author;
+    }
+    return apiClient.post('/quotes/public', body);
+};
+
+/**
+ * 비공개 문장 업로드
+ * @param {string} sentence - 문장 (5-100자)
+ * @param {string} [author] - 저자 (1-20자, 선택)
+ * @returns {Promise} API 응답
+ */
+export const uploadPrivateQuote = async (sentence, author) => {
+    const body = {sentence};
+    if (author) {
+        body.author = author;
+    }
+    return apiClient.post('/quotes/private', body);
+};
+
+/**
+ * 문장 업로드 (타입에 따라 분기)
+ * @param {'public' | 'private'} type - 문장 타입
+ * @param {string} sentence - 문장 (5-100자)
+ * @param {string} [author] - 저자 (1-20자, 선택)
+ * @returns {Promise} API 응답
+ */
+export const uploadQuote = async (type, sentence, author) => {
+    if (type === 'public') {
+        return uploadPublicQuote(sentence, author);
+    }
+    return uploadPrivateQuote(sentence, author);
+};


### PR DESCRIPTION
라우팅 설정
- react-router-dom 설치 및 라우팅 구조 적용
- / (메인), /quote/upload (문장 업로드) 라우트 추가
- Home 페이지 컴포넌트 분리

문장 업로드 페이지 (/quote/upload)
- 최대 5개 문장 동적 추가/삭제
- 각 문장마다 공개/비공개 선택 (기본값: 공개)
- 클라이언트 유효성 검증 (문장 5-100자, 저자 1-20자)
- 글자 수 실시간 표시 (5자 미만 시 경고 색상)
- 업로드 확인/결과 팝업
- 성공한 문장 자동 제거, 실패한 문장 유지

UI/UX 개선
- 헤더에 문장 업로드 버튼 추가 (비로그인 시 안내 알림)
- Title 클릭 시 홈으로 이동
- ProfilePopup 닫기 버튼 스타일 통일
- 저장하기 버튼 활성화 시 색상 강조

API
- quoteApi.js 생성 (uploadPublicQuote, uploadPrivateQuote)