### PR TITLE
feat: Quote 조회 API 연동 및 문장 소스 선택 기능 구현

### DIFF
--- a/tp-react/prototype.css
+++ b/tp-react/prototype.css
@@ -440,6 +440,64 @@ body.dark {
     color: #999;
 }
 
+/* 문장 소스 선택 */
+.quote-top-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.quote-source-selector {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.quote-source-btn {
+    padding: 0.25rem 0.5rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.375rem;
+    background-color: transparent;
+    color: #999;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.quote-source-btn:hover {
+    border-color: #666;
+    color: #666;
+}
+
+.quote-source-btn.active {
+    border-color: #666;
+    background-color: #666;
+    color: white;
+}
+
+.quote-source-btn.dark {
+    border-color: #3f3f46;
+    color: #71717a;
+}
+
+.quote-source-btn.dark:hover {
+    border-color: #a1a1aa;
+    color: #a1a1aa;
+}
+
+.quote-source-btn.dark.active {
+    border-color: #71717a;
+    background-color: #71717a;
+    color: white;
+}
+
+.quote-top-row .author-container {
+    margin-bottom: 0;
+}
+
 /* 타이핑 영역 */
 .quote-container {
     width: 80%;

--- a/tp-react/prototype.js
+++ b/tp-react/prototype.js
@@ -434,10 +434,10 @@ function createUploadEntry(index) {
     entry.id = `uploadEntry${index}`;
     entry.dataset.index = index;
     entry.dataset.type = 'public'; // 기본값: 공개
-    
+
     const isDark = document.getElementById('body').classList.contains('dark');
     if (isDark) entry.classList.add('dark');
-    
+
     entry.innerHTML = `
         <div class="upload-entry-header">
             <span class="upload-entry-number">${index + 1}</span>
@@ -477,12 +477,12 @@ function createUploadEntry(index) {
         </div>
         <div class="upload-entry-message" id="uploadMessage${index}"></div>
     `;
-    
+
     // 삭제 버튼 이벤트
     entry.querySelector('.upload-entry-delete-btn').addEventListener('click', () => {
         removeUploadEntry(entry);
     });
-    
+
     // 공개/비공개 토글 이벤트
     entry.querySelectorAll('.upload-entry-type-btn').forEach(btn => {
         btn.addEventListener('click', () => {
@@ -491,18 +491,18 @@ function createUploadEntry(index) {
             entry.dataset.type = btn.dataset.type;
         });
     });
-    
+
     return entry;
 }
 
 // 입력 영역 추가
 function addUploadEntry() {
     if (currentEntryCount >= MAX_UPLOAD_ENTRIES) return;
-    
+
     const entry = createUploadEntry(currentEntryCount);
     uploadEntries.appendChild(entry);
     currentEntryCount++;
-    
+
     updateAddButton();
     updateDeleteButtons();
 }
@@ -510,10 +510,10 @@ function addUploadEntry() {
 // 입력 영역 삭제
 function removeUploadEntry(entry) {
     if (currentEntryCount <= 1) return;
-    
+
     entry.remove();
     currentEntryCount--;
-    
+
     // 번호 재정렬
     renumberEntries();
     updateAddButton();
@@ -527,11 +527,11 @@ function renumberEntries() {
         entry.id = `uploadEntry${index}`;
         entry.dataset.index = index;
         entry.querySelector('.upload-entry-number').textContent = index + 1;
-        
+
         const sentenceInput = entry.querySelector('input[id^="uploadSentence"]');
         const authorInput = entry.querySelector('input[id^="uploadAuthor"]');
         const messageEl = entry.querySelector('div[id^="uploadMessage"]');
-        
+
         sentenceInput.id = `uploadSentence${index}`;
         authorInput.id = `uploadAuthor${index}`;
         messageEl.id = `uploadMessage${index}`;
@@ -560,7 +560,7 @@ function updateAddButton() {
 // 팝업 열기
 function openUploadPopup() {
     uploadPopupOverlay.classList.remove('display-none');
-    
+
     const isDark = document.getElementById('body').classList.contains('dark');
     if (isDark) {
         uploadPopup.classList.add('dark');
@@ -572,7 +572,7 @@ function openUploadPopup() {
         document.getElementById('uploadCancelBtn').classList.add('dark');
         document.getElementById('uploadSubmitBtn').classList.add('dark');
     }
-    
+
     // 초기화: 입력 영역 비우고 1개만 생성
     uploadEntries.innerHTML = '';
     currentEntryCount = 0;
@@ -602,10 +602,10 @@ let isResultPopup = false;
 function showUploadConfirm(entries) {
     pendingUploadEntries = entries;
     isResultPopup = false;
-    
+
     const publicCount = entries.filter(e => e.type === 'public').length;
     const privateCount = entries.filter(e => e.type === 'private').length;
-    
+
     let message = '';
     if (publicCount > 0 && privateCount > 0) {
         message = `공개 ${publicCount}개, 비공개 ${privateCount}개의 문장을 업로드합니다.`;
@@ -615,7 +615,7 @@ function showUploadConfirm(entries) {
         message = `${privateCount}개의 문장을 비공개로 업로드합니다.`;
     }
     uploadConfirmMessage.textContent = message;
-    
+
     const isDark = document.getElementById('body').classList.contains('dark');
     if (isDark) {
         uploadConfirmPopup.classList.add('dark');
@@ -628,7 +628,7 @@ function showUploadConfirm(entries) {
         document.getElementById('uploadConfirmCancelBtn').classList.remove('dark');
         document.getElementById('uploadConfirmOkBtn').classList.remove('dark');
     }
-    
+
     uploadConfirmOverlay.classList.remove('display-none');
 }
 
@@ -652,7 +652,7 @@ document.getElementById('uploadConfirmOkBtn').addEventListener('click', () => {
 function showResultPopup(message) {
     isResultPopup = true;
     uploadConfirmMessage.textContent = message;
-    
+
     const isDark = document.getElementById('body').classList.contains('dark');
     if (isDark) {
         uploadConfirmPopup.classList.add('dark');
@@ -665,10 +665,10 @@ function showResultPopup(message) {
         document.getElementById('uploadConfirmCancelBtn').classList.remove('dark');
         document.getElementById('uploadConfirmOkBtn').classList.remove('dark');
     }
-    
+
     // 취소 버튼 숨김
     document.getElementById('uploadConfirmCancelBtn').classList.add('display-none');
-    
+
     uploadConfirmOverlay.classList.remove('display-none');
 }
 
@@ -681,37 +681,37 @@ function hideResultPopup() {
 // 업로드 버튼 클릭 - 확인 팝업 표시
 document.getElementById('uploadSubmitBtn').addEventListener('click', () => {
     const entries = [];
-    
+
     // 입력된 문장들 수집
     for (let i = 0; i < currentEntryCount; i++) {
         const entryEl = document.getElementById(`uploadEntry${i}`);
         const sentenceEl = document.getElementById(`uploadSentence${i}`);
         const authorEl = document.getElementById(`uploadAuthor${i}`);
-        
+
         if (!entryEl || !sentenceEl || !authorEl) continue;
-        
+
         const sentence = sentenceEl.value.trim();
         const author = authorEl.value.trim();
         const type = entryEl.dataset.type || 'public';
         const messageEl = document.getElementById(`uploadMessage${i}`);
-        
+
         // 메시지 초기화
         if (messageEl) {
             messageEl.textContent = '';
             messageEl.className = 'upload-entry-message';
         }
         entryEl.classList.remove('error', 'success');
-        
+
         if (sentence) {
-            entries.push({ index: i, sentence, author, type });
+            entries.push({index: i, sentence, author, type});
         }
     }
-    
+
     if (entries.length === 0) {
         alert('최소 1개의 문장을 입력해주세요.');
         return;
     }
-    
+
     showUploadConfirm(entries);
 });
 
@@ -720,19 +720,19 @@ async function executeUpload(entries) {
     const submitBtn = document.getElementById('uploadSubmitBtn');
     submitBtn.disabled = true;
     submitBtn.innerHTML = '<i class="fa-solid fa-spinner fa-spin"></i><span>업로드 중...</span>';
-    
+
     // 각 문장 업로드 시뮬레이션
     let successCount = 0;
     const successIndices = [];
-    
+
     for (let i = 0; i < entries.length; i++) {
         const entry = entries[i];
-        const { index, sentence, author, type } = entry;
+        const {index, sentence, author, type} = entry;
         const messageEl = document.getElementById(`uploadMessage${index}`);
         const entryEl = document.getElementById(`uploadEntry${index}`);
         const sentenceInput = document.getElementById(`uploadSentence${index}`);
         const authorInput = document.getElementById(`uploadAuthor${index}`);
-        
+
         // 유효성 검증
         if (sentence.length < 5 || sentence.length > 100) {
             messageEl.textContent = '문장은 5-100자여야 합니다.';
@@ -740,7 +740,7 @@ async function executeUpload(entries) {
             entryEl.classList.add('error');
             continue;
         }
-        
+
         // API 호출 시뮬레이션
         try {
             // 실제로는 fetch 호출
@@ -749,11 +749,11 @@ async function executeUpload(entries) {
             //     headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${token}` },
             //     body: JSON.stringify({ sentence, author: author || undefined })
             // });
-            
+
             // 시뮬레이션: 2, 4번째 문장은 실패 (i는 0부터 시작하므로 i=1, i=3이 실패)
             await new Promise(resolve => setTimeout(resolve, 500));
             const isSuccess = i % 2 === 0; // 1, 3, 5번째 성공 / 2, 4번째 실패
-            
+
             if (isSuccess) {
                 successCount++;
                 successIndices.push(index);
@@ -767,10 +767,10 @@ async function executeUpload(entries) {
             entryEl.classList.add('error');
         }
     }
-    
+
     submitBtn.disabled = false;
     submitBtn.innerHTML = '<i class="fa-solid fa-upload"></i><span>업로드</span>';
-    
+
     // 성공한 entry 제거 및 결과 팝업
     if (successCount > 0) {
         // 성공한 entry 제거
@@ -779,7 +779,7 @@ async function executeUpload(entries) {
             if (entryEl) entryEl.remove();
         });
         currentEntryCount -= successCount;
-        
+
         // entry가 0개면 1개 추가
         if (currentEntryCount === 0) {
             addUploadEntry();
@@ -788,7 +788,7 @@ async function executeUpload(entries) {
             updateAddButton();
             updateDeleteButtons();
         }
-        
+
         // 결과 팝업 표시
         showResultPopup(`${successCount}개의 문장 업로드에 성공했습니다.`);
     }
@@ -825,11 +825,11 @@ function generateMockQuotes(page, type, status) {
     const mockData = [];
     const types = ['PUBLIC', 'PRIVATE'];
     const statuses = ['PENDING', 'ACTIVE'];
-    
+
     for (let i = 0; i < 10; i++) {
         const quoteType = types[Math.floor(Math.random() * types.length)];
         let quoteStatus;
-        
+
         // PUBLIC은 PENDING, ACTIVE 가능
         // PRIVATE은 ACTIVE만 가능
         if (quoteType === 'PRIVATE') {
@@ -837,11 +837,11 @@ function generateMockQuotes(page, type, status) {
         } else {
             quoteStatus = statuses[Math.floor(Math.random() * statuses.length)];
         }
-        
+
         // 필터 적용
         if (type !== 'all' && quoteType !== type) continue;
         if (status !== 'all' && quoteStatus !== status) continue;
-        
+
         mockData.push({
             quoteId: (page - 1) * 10 + i + 1,
             sentence: `이것은 ${(page - 1) * 10 + i + 1}번째 테스트 문장입니다. 타이핑 연습을 위한 샘플 텍스트입니다.`,
@@ -851,7 +851,7 @@ function generateMockQuotes(page, type, status) {
             createdAt: new Date().toISOString(),
         });
     }
-    
+
     return {
         page: page,
         size: 10,
@@ -862,27 +862,27 @@ function generateMockQuotes(page, type, status) {
 
 function openMyQuotesPopup() {
     const overlay = document.getElementById('myQuotesPopupOverlay');
-    
+
     // 상태 초기화
     myQuotesCurrentPage = 1;
     myQuotesHasNext = true;
     myQuotesTypeFilter = 'all';
     myQuotesStatusFilter = 'all';
-    
+
     // 필터 버튼 초기화
     document.querySelectorAll('.my-quotes-filter-btn').forEach(btn => {
         btn.classList.remove('active');
         if (btn.dataset.type === 'all') btn.classList.add('active');
         if (btn.dataset.status === 'all') btn.classList.add('active');
     });
-    
+
     // 목록 초기화
     document.getElementById('myQuotesList').innerHTML = '';
     document.getElementById('myQuotesLoading').classList.add('display-none');
     document.getElementById('myQuotesEmpty').classList.add('display-none');
-    
+
     overlay.classList.remove('display-none');
-    
+
     // 초기 데이터 로드
     loadMyQuotes();
 }
@@ -914,7 +914,7 @@ document.querySelectorAll('.my-quotes-filter-btn').forEach(btn => {
             btn.classList.add('active');
             myQuotesStatusFilter = btn.dataset.status;
         }
-        
+
         // 목록 초기화 후 다시 로드
         myQuotesCurrentPage = 1;
         myQuotesHasNext = true;
@@ -926,31 +926,31 @@ document.querySelectorAll('.my-quotes-filter-btn').forEach(btn => {
 
 async function loadMyQuotes() {
     if (myQuotesIsLoading || !myQuotesHasNext) return;
-    
+
     myQuotesIsLoading = true;
     const loadingEl = document.getElementById('myQuotesLoading');
-    
+
     loadingEl.classList.remove('display-none');
-    
+
     // API 호출 시뮬레이션
     await new Promise(resolve => setTimeout(resolve, 500));
-    
+
     const response = generateMockQuotes(myQuotesCurrentPage, myQuotesTypeFilter, myQuotesStatusFilter);
-    
+
     loadingEl.classList.add('display-none');
     myQuotesIsLoading = false;
-    
+
     if (response.content.length === 0 && myQuotesCurrentPage === 1) {
         document.getElementById('myQuotesEmpty').classList.remove('display-none');
         return;
     }
-    
+
     // 카드 추가
     const listEl = document.getElementById('myQuotesList');
     response.content.forEach(quote => {
         listEl.appendChild(createQuoteCard(quote));
     });
-    
+
     myQuotesHasNext = response.hasNext;
     myQuotesCurrentPage++;
 }
@@ -959,11 +959,11 @@ function createQuoteCard(quote) {
     const card = document.createElement('div');
     card.className = 'my-quote-card';
     card.dataset.quoteId = quote.quoteId;
-    
+
     // 타입 뱃지
     const typeBadgeClass = quote.type === 'PUBLIC' ? 'type-public' : 'type-private';
     const typeText = quote.type === 'PUBLIC' ? '공개' : '비공개';
-    
+
     // 상태 뱃지
     let statusBadgeClass, statusText;
     switch (quote.status) {
@@ -976,7 +976,7 @@ function createQuoteCard(quote) {
             statusText = '활성';
             break;
     }
-    
+
     // 액션 버튼 결정
     let actionsHtml = '';
     if (quote.type === 'PRIVATE' && quote.status === 'ACTIVE') {
@@ -993,7 +993,7 @@ function createQuoteCard(quote) {
         `;
     }
     // PUBLIC + ACTIVE: 액션 없음
-    
+
     card.innerHTML = `
         <div class="my-quote-card-header">
             <span class="my-quote-badge ${typeBadgeClass}">${typeText}</span>
@@ -1005,7 +1005,7 @@ function createQuoteCard(quote) {
             ${actionsHtml}
         </div>
     `;
-    
+
     return card;
 }
 
@@ -1024,18 +1024,18 @@ function openEditPopup(quoteId) {
     const sentence = card.querySelector('.my-quote-sentence').textContent;
     const authorEl = card.querySelector('.my-quote-author');
     const author = authorEl ? authorEl.textContent.replace('- ', '') : '';
-    
+
     const overlay = document.getElementById('quoteEditPopupOverlay');
     const sentenceInput = document.getElementById('quoteEditSentence');
     const authorInput = document.getElementById('quoteEditAuthor');
-    
+
     sentenceInput.value = sentence;
     authorInput.value = author;
     updateEditCharCount();
     updateEditSaveButton(sentence, author);
-    
+
     overlay.classList.remove('display-none');
-    
+
     // 팝업이 보인 후 높이 조절
     requestAnimationFrame(() => {
         adjustEditTextareaHeight();
@@ -1067,7 +1067,7 @@ function updateEditCharCount() {
     const count = quoteEditSentence.value.length;
     const countEl = document.getElementById('quoteEditCharCount');
     countEl.textContent = `${count}/100`;
-    
+
     if (count > 0 && count < 5) {
         countEl.classList.add('warning');
     } else {
@@ -1083,7 +1083,7 @@ function adjustEditTextareaHeight() {
 function updateEditSaveButton() {
     const sentence = quoteEditSentence.value.trim();
     const saveBtn = document.getElementById('quoteEditSaveBtn');
-    
+
     if (sentence.length >= 5 && sentence.length <= 100) {
         saveBtn.disabled = false;
     } else {
@@ -1094,10 +1094,10 @@ function updateEditSaveButton() {
 document.getElementById('quoteEditSaveBtn').addEventListener('click', async () => {
     const sentence = quoteEditSentence.value.trim();
     const author = quoteEditAuthor.value.trim();
-    
+
     // API 호출 시뮬레이션
-    console.log('수정 요청:', { quoteId: editingQuoteId, sentence, author });
-    
+    console.log('수정 요청:', {quoteId: editingQuoteId, sentence, author});
+
     // 카드 업데이트
     const card = document.querySelector(`.my-quote-card[data-quote-id="${editingQuoteId}"]`);
     card.querySelector('.my-quote-sentence').textContent = sentence;
@@ -1114,7 +1114,7 @@ document.getElementById('quoteEditSaveBtn').addEventListener('click', async () =
     } else if (authorEl) {
         authorEl.remove();
     }
-    
+
     closeEditPopup();
 });
 
@@ -1138,13 +1138,13 @@ document.getElementById('deleteConfirmOverlay').addEventListener('click', (e) =>
 document.getElementById('deleteConfirmOkBtn').addEventListener('click', async () => {
     // API 호출 시뮬레이션
     console.log('삭제 요청:', deletingQuoteId);
-    
+
     // 카드 제거
     const card = document.querySelector(`.my-quote-card[data-quote-id="${deletingQuoteId}"]`);
     card.remove();
-    
+
     closeDeleteConfirm();
-    
+
     // 목록이 비었는지 확인
     if (document.getElementById('myQuotesList').children.length === 0) {
         document.getElementById('myQuotesEmpty').classList.remove('display-none');
@@ -1154,17 +1154,17 @@ document.getElementById('deleteConfirmOkBtn').addEventListener('click', async ()
 // 공개 전환
 async function publishQuote(quoteId) {
     console.log('공개 전환 요청:', quoteId);
-    
+
     // 카드 업데이트 (PRIVATE -> PUBLIC, ACTIVE -> PENDING)
     const card = document.querySelector(`.my-quote-card[data-quote-id="${quoteId}"]`);
-    
+
     // 뱃지 업데이트
     const header = card.querySelector('.my-quote-card-header');
     header.innerHTML = `
         <span class="my-quote-badge type-public">공개</span>
         <span class="my-quote-badge status-pending">대기중</span>
     `;
-    
+
     // 액션 버튼 업데이트
     const footer = card.querySelector('.my-quote-card-footer');
     footer.innerHTML = `
@@ -1175,17 +1175,17 @@ async function publishQuote(quoteId) {
 // 공개 취소
 async function cancelPublish(quoteId) {
     console.log('공개 취소 요청:', quoteId);
-    
+
     // 카드 업데이트 (PUBLIC -> PRIVATE, PENDING -> ACTIVE)
     const card = document.querySelector(`.my-quote-card[data-quote-id="${quoteId}"]`);
-    
+
     // 뱃지 업데이트
     const header = card.querySelector('.my-quote-card-header');
     header.innerHTML = `
         <span class="my-quote-badge type-private">비공개</span>
         <span class="my-quote-badge status-active">활성</span>
     `;
-    
+
     // 액션 버튼 업데이트
     const footer = card.querySelector('.my-quote-card-footer');
     footer.innerHTML = `
@@ -1193,4 +1193,114 @@ async function cancelPublish(quoteId) {
         <button class="my-quote-action-btn danger" onclick="openDeleteConfirm(${quoteId})">삭제</button>
         <button class="my-quote-action-btn primary" onclick="publishQuote(${quoteId})">공개전환</button>
     `;
+}
+
+// ===========================================
+// 문장 소스 선택
+// ===========================================
+let quoteSource = 'all'; // 'all' | 'my'
+
+const quoteSourceAllBtn = document.getElementById('quoteSourceAll');
+const quoteSourceMyBtn = document.getElementById('quoteSourceMy');
+
+// 로그인 상태 확인
+function isLoggedIn() {
+    return !document.getElementById('loginBtn').classList.contains('display-none');
+}
+
+// 문장 소스 변경
+function setQuoteSource(source) {
+    quoteSource = source;
+
+    // 버튼 상태 업데이트
+    quoteSourceAllBtn.classList.toggle('active', source === 'all');
+    quoteSourceMyBtn.classList.toggle('active', source === 'my');
+
+    // 문장 다시 로드
+    console.log('문장 소스 변경:', source);
+}
+
+// 전체 문장 버튼
+quoteSourceAllBtn.addEventListener('click', () => {
+    setQuoteSource('all');
+});
+
+// 내 문장만 버튼
+quoteSourceMyBtn.addEventListener('click', () => {
+    // 비로그인 상태 체크
+    if (document.getElementById('loginBtn').classList.contains('display-none') === false) {
+        // 로그인 안내 팝업
+        showLoginRequiredPopup();
+        return;
+    }
+    setQuoteSource('my');
+});
+
+// 로그인 필요 안내 팝업
+function showLoginRequiredPopup() {
+    const message = '내 문장을 사용하려면 로그인이 필요합니다.';
+
+    // 기존 확인 팝업 재활용
+    const overlay = document.getElementById('uploadConfirmOverlay');
+    const popup = document.getElementById('uploadConfirmPopup');
+    const messageEl = document.getElementById('uploadConfirmMessage');
+    const cancelBtn = document.getElementById('uploadConfirmCancelBtn');
+    const okBtn = document.getElementById('uploadConfirmOkBtn');
+
+    messageEl.textContent = message;
+    cancelBtn.textContent = '취소';
+    okBtn.textContent = '로그인';
+
+    // 다크모드 적용
+    const isDark = document.getElementById('body').classList.contains('dark');
+    if (isDark) {
+        popup.classList.add('dark');
+        messageEl.classList.add('dark');
+        cancelBtn.classList.add('dark');
+        okBtn.classList.add('dark');
+    }
+
+    // 취소 버튼 보이게
+    cancelBtn.classList.remove('display-none');
+
+    // 일회성 이벤트 핸들러
+    const handleOk = () => {
+        overlay.classList.add('display-none');
+        // 로그인 버튼 클릭
+        document.getElementById('loginBtn').click();
+        okBtn.removeEventListener('click', handleOk);
+        cancelBtn.removeEventListener('click', handleCancel);
+        // 버튼 텍스트 복원
+        cancelBtn.textContent = '취소';
+        okBtn.textContent = '확인';
+    };
+
+    const handleCancel = () => {
+        overlay.classList.add('display-none');
+        okBtn.removeEventListener('click', handleOk);
+        cancelBtn.removeEventListener('click', handleCancel);
+        // 버튼 텍스트 복원
+        cancelBtn.textContent = '취소';
+        okBtn.textContent = '확인';
+    };
+
+    okBtn.addEventListener('click', handleOk);
+    cancelBtn.addEventListener('click', handleCancel);
+
+    overlay.classList.remove('display-none');
+}
+
+// 다크모드 토글 시 버튼 스타일 업데이트
+const originalToggleTheme = toggleTheme;
+toggleTheme = function () {
+    originalToggleTheme();
+    const isDark = document.getElementById('body').classList.contains('dark');
+    quoteSourceAllBtn.classList.toggle('dark', isDark);
+    quoteSourceMyBtn.classList.toggle('dark', isDark);
+};
+
+// 초기 다크모드 상태 반영
+if (document.getElementById('body').classList.contains('dark')) {
+    quoteSourceAllBtn.classList.add('dark');
+    quoteSourceMyBtn.classList.add('dark');
 }

--- a/tp-react/src/App.js
+++ b/tp-react/src/App.js
@@ -1,6 +1,6 @@
 import "./App.css";
 
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { ThemeContextProvider } from "./Context/ThemeContext";
 import { AuthProvider } from "./Context/AuthContext";
 import { ErrorProvider } from "./Context/ErrorContext";
@@ -26,6 +26,7 @@ function App() {
                   <Route path="/" element={<Home />} />
                   <Route path="/quote/upload" element={<QuoteUpload />} />
                   <Route path="/quote/my" element={<MyQuotes />} />
+                  <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
                 <Contact />
                 <Analytics/>

--- a/tp-react/src/Context/AuthContext.jsx
+++ b/tp-react/src/Context/AuthContext.jsx
@@ -1,4 +1,4 @@
-import React, {createContext, useContext, useState, useEffect} from 'react';
+import React, {createContext, useContext, useState, useEffect, useCallback} from 'react';
 import {refreshAccessToken as refreshTokenApi} from '../utils/authApi';
 import {Storage_Refresh_Token} from '../const/config.const';
 import {setAccessToken as setApiAccessToken} from '../utils/apiClient';
@@ -12,6 +12,9 @@ export const AuthProvider = ({children}) => {
     const [refreshToken, setRefreshToken] = useState(null);
     const [isLoading, setIsLoading] = useState(false);
     const [isInitialized, setIsInitialized] = useState(false);
+    
+    // 로그인 트리거 (다른 컴포넌트에서 로그인 요청 시 사용)
+    const [loginTrigger, setLoginTrigger] = useState(0);
 
     // 앱 시작 시 자동 로그인
     useEffect(() => {
@@ -94,6 +97,11 @@ export const AuthProvider = ({children}) => {
         setUser(userData);
     };
 
+    // 로그인 트리거 함수 (다른 컴포넌트에서 호출)
+    const triggerLogin = useCallback(() => {
+        setLoginTrigger(prev => prev + 1);
+    }, []);
+
     return (
         <AuthContext.Provider value={{
             user, 
@@ -104,7 +112,9 @@ export const AuthProvider = ({children}) => {
             setIsLoading, 
             login, 
             logout,
-            updateUser
+            updateUser,
+            loginTrigger,
+            triggerLogin,
         }}>
             {children}
         </AuthContext.Provider>

--- a/tp-react/src/Context/QuoteContext.jsx
+++ b/tp-react/src/Context/QuoteContext.jsx
@@ -1,6 +1,8 @@
-import {createContext, useContext, useEffect, useState} from "react";
-import {defaultQuotes} from "../const/default-quotes.const";
+import {createContext, useCallback, useContext, useEffect, useRef, useState} from "react";
 import {useScore} from "./ScoreContext";
+import {useAuth} from "./AuthContext";
+import {useError} from "./ErrorContext";
+import {getQuotes} from "../utils/quoteApi";
 
 export const QuoteContext = createContext(null);
 
@@ -12,65 +14,151 @@ export const useQuote = () => {
     return context;
 };
 
+// 상수
+const QUOTES_PER_PAGE = 100;
+const QUOTE_SOURCE = {
+    ALL: 'all',
+    MY: 'my',
+};
+
+// 시드 생성 함수 (소수점 둘째자리까지, -1.0 ~ 1.0)
+const generateSeed = () => Math.round((Math.random() * 2 - 1) * 100) / 100;
+
 export const QuoteContextProvider = ({children}) => {
     const {setInputCheck} = useScore();
+    const {user} = useAuth();
+    const {showError} = useError();
 
-    const [quotes, setQuotes] = useState(defaultQuotes);
+    // Refs
+    const seedRef = useRef(generateSeed());
+    const currentPageRef = useRef(1);
+    const hasNextRef = useRef(true);
+    const isLoadingRef = useRef(false);
+
+    // 문장 소스
+    const [quoteSource, setQuoteSource] = useState(QUOTE_SOURCE.ALL);
+
+    // 문장 목록
+    const [quotes, setQuotes] = useState([]);
     const [quotesIndex, setQuotesIndex] = useState(0);
     const [sentence, setSentence] = useState("");
     const [author, setAuthor] = useState("");
 
-    useEffect(() => {
-        // Fisher-Yates 셔플
-        const shuffleArray = (array) => {
-            const shuffled = [...array];
-            for (let i = shuffled.length - 1; i > 0; i--) {
-                const j = Math.floor(Math.random() * (i + 1));
-                [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
-            }
-            return shuffled;
-        };
+    // UI 상태
+    const [isLoading, setIsLoading] = useState(false);
+    const [isEmpty, setIsEmpty] = useState(false);
 
-        console.log(defaultQuotes.length);
-
-        const initQuotes = shuffleArray(defaultQuotes);
-
-        setQuotes(initQuotes);
+    // 상태 초기화
+    const resetState = useCallback(() => {
+        setQuotes([]);
         setQuotesIndex(0);
+        setSentence("");
+        setAuthor("");
+        currentPageRef.current = 1;
+        hasNextRef.current = true;
+        setIsEmpty(false);
+    }, []);
 
-        const initialQuote = initQuotes[0];
-
-        if (initialQuote && initialQuote.sentence) {
-            setSentence(initialQuote.sentence);
-            setAuthor(initialQuote.author);
-            setInputCheck(new Array(initialQuote.sentence.length).fill("none"));
-        }
+    // 현재 문장 설정
+    const setCurrentQuote = useCallback((quote) => {
+        if (!quote?.sentence) return;
+        setSentence(quote.sentence);
+        setAuthor(quote.author || '');
+        setInputCheck(new Array(quote.sentence.length).fill("none"));
     }, [setInputCheck]);
 
+    // 문장 로드
+    const loadQuotes = useCallback(async (page = 1, reset = false, source = quoteSource) => {
+        if (isLoadingRef.current) return;
+
+        isLoadingRef.current = true;
+        setIsLoading(true);
+
+        try {
+            const response = await getQuotes({
+                page,
+                count: QUOTES_PER_PAGE,
+                seed: seedRef.current,
+                onlyMyQuotes: source === QUOTE_SOURCE.MY,
+            });
+            const data = response.data.data;
+            const content = data.content || [];
+
+            if (reset) {
+                setQuotes(content);
+                setQuotesIndex(0);
+            } else {
+                setQuotes(prev => [...prev, ...content]);
+            }
+
+            hasNextRef.current = data.hasNext ?? false;
+            currentPageRef.current = page;
+            setIsEmpty(reset && content.length === 0);
+
+            // 첫 로드 시 첫 번째 문장 설정
+            if (reset && content.length > 0) {
+                setCurrentQuote(content[0]);
+            }
+        } catch (error) {
+            console.error('문장 로드 실패:', error);
+            showError('문장을 불러오는데 실패했습니다.');
+            if (reset) {
+                setIsEmpty(true);
+            }
+        } finally {
+            isLoadingRef.current = false;
+            setIsLoading(false);
+        }
+    }, [quoteSource, setCurrentQuote, showError]);
+
+    // 로그아웃 시 전체 문장으로 초기화
     useEffect(() => {
+        if (!user && quoteSource === QUOTE_SOURCE.MY) {
+            setQuoteSource(QUOTE_SOURCE.ALL);
+        }
+    }, [user, quoteSource]);
+
+    // 소스 변경 시 로드
+    useEffect(() => {
+        resetState();
+        loadQuotes(1, true, quoteSource);
+    }, [quoteSource]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // 문장 인덱스 변경 시
+    useEffect(() => {
+        if (quotes.length === 0) return;
+
+        // 이전 문장 (인덱스 < 0)
         if (quotesIndex < 0) {
             setQuotesIndex(quotes.length - 1);
             return;
         }
 
+        // 다음 문장 (인덱스 >= 길이)
         if (quotesIndex >= quotes.length) {
-            setQuotesIndex(0);
+            if (hasNextRef.current && !isLoadingRef.current) {
+                // 다음 페이지 로드
+                loadQuotes(currentPageRef.current + 1, false, quoteSource);
+            } else {
+                // 마지막 페이지 끝: 시드 재생성 후 첫 페이지로
+                seedRef.current = generateSeed();
+                resetState();
+                loadQuotes(1, true, quoteSource);
+            }
             return;
         }
 
-        const currentQuote = quotes[quotesIndex];
+        setCurrentQuote(quotes[quotesIndex]);
+    }, [quotesIndex, quotes]); // eslint-disable-line react-hooks/exhaustive-deps
 
-        if (!currentQuote || !currentQuote.sentence) {
-            return;
+    // 문장 소스 변경 핸들러
+    const changeQuoteSource = useCallback((source) => {
+        if (source === QUOTE_SOURCE.MY && !user) {
+            return false;
         }
-
-        setInputCheck(() => {
-            return new Array(currentQuote.sentence.length).fill("none");
-        });
-
-        setSentence(currentQuote.sentence);
-        setAuthor(currentQuote.author);
-    }, [quotesIndex, quotes, setInputCheck]);
+        setQuoteSource(source);
+        return true;
+    }, [user]);
 
     return (
         <QuoteContext.Provider
@@ -79,6 +167,10 @@ export const QuoteContextProvider = ({children}) => {
                 author,
                 quotesIndex,
                 setQuotesIndex,
+                quoteSource,
+                changeQuoteSource,
+                isLoading,
+                isEmpty,
             }}
         >
             {children}

--- a/tp-react/src/components/Head/Head.jsx
+++ b/tp-react/src/components/Head/Head.jsx
@@ -1,4 +1,4 @@
-import React, {useState, useEffect} from "react";
+import React, {useState, useEffect, useRef} from "react";
 import {useNavigate} from "react-router-dom";
 import Title from "./title/Title";
 import DarkModeButton from "./themeButton/DarkModeButton";
@@ -25,8 +25,9 @@ const Head = () => {
     const navigate = useNavigate();
     const {isDark} = useTheme();
     const {showError} = useError();
-    const {user, accessToken, refreshToken, isLoading, setIsLoading, login} = useAuth();
+    const {user, accessToken, refreshToken, isLoading, setIsLoading, login, loginTrigger} = useAuth();
     const [showNicknamePopup, setShowNicknamePopup] = useState(false);
+    const prevLoginTriggerRef = useRef(loginTrigger);
 
     // user가 변경될 때마다 닉네임이 UUID 형식인지 체크
     useEffect(() => {
@@ -72,6 +73,14 @@ const Head = () => {
             showError('구글 로그인에 실패했습니다.');
         },
     });
+
+    // 다른 컴포넌트에서 로그인 트리거 시 googleLogin 호출
+    useEffect(() => {
+        if (loginTrigger > 0 && loginTrigger !== prevLoginTriggerRef.current) {
+            prevLoginTriggerRef.current = loginTrigger;
+            googleLogin();
+        }
+    }, [loginTrigger, googleLogin]);
 
     const handleLogin = () => {
         googleLogin();

--- a/tp-react/src/components/Quote/Quote.css
+++ b/tp-react/src/components/Quote/Quote.css
@@ -14,8 +14,14 @@
 .quote-container-upper {
 }
 
+.quote-top-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.75rem;
+}
+
 .author-container {
-    margin-bottom: 0.5rem;
     display: flex;
     flex-direction: row-reverse;
 }

--- a/tp-react/src/components/Quote/Quote.jsx
+++ b/tp-react/src/components/Quote/Quote.jsx
@@ -2,15 +2,18 @@ import "./Quote.css";
 import { useState, useEffect } from "react";
 import Sentence from "./Sentence/Sentence";
 import Author from "./Author/Author";
-import { useTheme } from "../../Context/ThemeContext";
 import Input from "./Input/Input";
 import InputDisplay from "./InputDisplay/InputDisplay";
+import QuoteSourceSelector from "./QuoteSourceSelector/QuoteSourceSelector";
+import QuoteLoading from "./QuoteLoading/QuoteLoading";
+import QuoteEmpty from "./QuoteEmpty/QuoteEmpty";
+import { useTheme } from "../../Context/ThemeContext";
 import { useQuote } from "../../Context/QuoteContext";
 import { useSetting } from "../../Context/SettingContext";
 
 const Quote = () => {
   const { isDark } = useTheme();
-  const { author, sentence } = useQuote();
+  const { author, sentence, isLoading, isEmpty } = useQuote();
   const { isCompactMode } = useSetting();
   const [inputValue, setInputValue] = useState("");
 
@@ -26,25 +29,30 @@ const Quote = () => {
     return className;
   };
 
-  /**
-   * Quote : 인용문 = 문장 (sentence) + 저자 (author)
-   * Sentence : 문장
-   * Author : 저자
-   */
+  const showLoading = isLoading && !sentence;
+  const showEmpty = isEmpty && !isLoading;
+  const showContent = !isEmpty && sentence;
 
   return (
     <div className={getQuoteContainerClassName()}>
-      <div className={"quote-container-upper"}>
-        {/* QuoteDisplay*/}
-        <div className={`author-container ${isDark ? "author-dark" : ""}`}>
-          <Author author={author} />
+      <div className="quote-container-upper">
+        {/* 문장 소스 선택 + 저자 */}
+        <div className="quote-top-row">
+          <QuoteSourceSelector />
+          <div className={`author-container ${isDark ? "author-dark" : ""}`}>
+            <Author author={author} />
+          </div>
         </div>
-        <div className="sentence-input-wrapper">
-          <Sentence inputLength={inputValue.length} inputValue={inputValue} />
-          <InputDisplay input={inputValue} />
-          {/* QuoteInput */}
-          <Input onInputChange={setInputValue} />
-        </div>
+
+        {showLoading && <QuoteLoading />}
+        {showEmpty && <QuoteEmpty />}
+        {showContent && (
+          <div className="sentence-input-wrapper">
+            <Sentence inputLength={inputValue.length} inputValue={inputValue} />
+            <InputDisplay input={inputValue} />
+            <Input onInputChange={setInputValue} />
+          </div>
+        )}
       </div>
     </div>
   );

--- a/tp-react/src/components/Quote/QuoteEmpty/QuoteEmpty.css
+++ b/tp-react/src/components/Quote/QuoteEmpty/QuoteEmpty.css
@@ -1,0 +1,41 @@
+.quote-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: 3rem;
+    color: #999;
+}
+
+.quote-empty.dark {
+    color: #71717a;
+}
+
+.quote-empty > svg {
+    font-size: 3rem;
+    margin-bottom: 1rem;
+}
+
+.quote-empty p {
+    font-size: 1rem;
+    margin: 0 0 0.5rem 0;
+}
+
+.quote-empty-upload-btn {
+    padding: 0.5rem 1rem;
+    border: none;
+    background-color: transparent;
+    color: var(--color-text-muted);
+    border-radius: 0.375rem;
+    font-size: 0.9rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.quote-empty-upload-btn:hover {
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text);
+}

--- a/tp-react/src/components/Quote/QuoteEmpty/QuoteEmpty.jsx
+++ b/tp-react/src/components/Quote/QuoteEmpty/QuoteEmpty.jsx
@@ -1,0 +1,29 @@
+import {useNavigate} from 'react-router-dom';
+import {FaFileCircleQuestion, FaPlus} from 'react-icons/fa6';
+import {useTheme} from '../../../Context/ThemeContext';
+import {useQuote} from '../../../Context/QuoteContext';
+import './QuoteEmpty.css';
+
+const QuoteEmpty = () => {
+    const navigate = useNavigate();
+    const {isDark} = useTheme();
+    const {quoteSource} = useQuote();
+
+    return (
+        <div className={`quote-empty ${isDark ? 'dark' : ''}`}>
+            <FaFileCircleQuestion/>
+            <p>등록된 문장이 없습니다.</p>
+            {quoteSource === 'my' && (
+                <button
+                    className="quote-empty-upload-btn"
+                    onClick={() => navigate('/quote/upload')}
+                >
+                    <FaPlus/>
+                    <span>문장 업로드</span>
+                </button>
+            )}
+        </div>
+    );
+};
+
+export default QuoteEmpty;

--- a/tp-react/src/components/Quote/QuoteLoading/QuoteLoading.css
+++ b/tp-react/src/components/Quote/QuoteLoading/QuoteLoading.css
@@ -1,0 +1,36 @@
+.quote-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    padding: 2rem;
+    color: #666;
+    font-size: 0.9rem;
+}
+
+.quote-loading.dark {
+    color: #a1a1aa;
+}
+
+.quote-loading-spinner {
+    width: 1.25rem;
+    height: 1.25rem;
+    border: 2px solid #e5e7eb;
+    border-top-color: #6d28d9;
+    border-radius: 50%;
+    animation: quote-spin 0.8s linear infinite;
+}
+
+.quote-loading.dark .quote-loading-spinner {
+    border-color: #3f3f46;
+    border-top-color: #8b5cf6;
+}
+
+@keyframes quote-spin {
+    0% {
+        transform: rotate(0deg);
+    }
+    100% {
+        transform: rotate(360deg);
+    }
+}

--- a/tp-react/src/components/Quote/QuoteLoading/QuoteLoading.jsx
+++ b/tp-react/src/components/Quote/QuoteLoading/QuoteLoading.jsx
@@ -1,0 +1,15 @@
+import {useTheme} from '../../../Context/ThemeContext';
+import './QuoteLoading.css';
+
+const QuoteLoading = () => {
+    const {isDark} = useTheme();
+
+    return (
+        <div className={`quote-loading ${isDark ? 'dark' : ''}`}>
+            <div className="quote-loading-spinner"></div>
+            <span>문장을 불러오는 중...</span>
+        </div>
+    );
+};
+
+export default QuoteLoading;

--- a/tp-react/src/components/Quote/QuoteSourceSelector/QuoteSourceSelector.css
+++ b/tp-react/src/components/Quote/QuoteSourceSelector/QuoteSourceSelector.css
@@ -1,0 +1,46 @@
+.quote-source-selector {
+    display: flex;
+    gap: 0.5rem;
+}
+
+.quote-source-btn {
+    padding: 0.25rem 0.5rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.375rem;
+    background-color: transparent;
+    color: #999;
+    font-size: 0.8rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.quote-source-btn:hover {
+    border-color: #666;
+    color: #666;
+}
+
+.quote-source-btn.active {
+    border-color: #666;
+    background-color: #666;
+    color: white;
+}
+
+/* 다크 모드 */
+.quote-source-btn.dark {
+    border-color: #3f3f46;
+    color: #71717a;
+}
+
+.quote-source-btn.dark:hover {
+    border-color: #a1a1aa;
+    color: #a1a1aa;
+}
+
+.quote-source-btn.dark.active {
+    border-color: #71717a;
+    background-color: #71717a;
+    color: white;
+}

--- a/tp-react/src/components/Quote/QuoteSourceSelector/QuoteSourceSelector.jsx
+++ b/tp-react/src/components/Quote/QuoteSourceSelector/QuoteSourceSelector.jsx
@@ -1,0 +1,68 @@
+import {useState} from 'react';
+import {FaGlobe, FaUser} from 'react-icons/fa';
+import {useTheme} from '../../../Context/ThemeContext';
+import {useQuote} from '../../../Context/QuoteContext';
+import {useAuth} from '../../../Context/AuthContext';
+import ConfirmPopup from '../../ConfirmPopup/ConfirmPopup';
+import './QuoteSourceSelector.css';
+
+const QuoteSourceSelector = () => {
+    const {isDark} = useTheme();
+    const {quoteSource, changeQuoteSource} = useQuote();
+    const {triggerLogin} = useAuth();
+    const [showLoginPopup, setShowLoginPopup] = useState(false);
+
+    const handleAllClick = () => {
+        changeQuoteSource('all');
+    };
+
+    const handleMyClick = () => {
+        const success = changeQuoteSource('my');
+        if (!success) {
+            setShowLoginPopup(true);
+        }
+    };
+
+    const handleLoginConfirm = () => {
+        setShowLoginPopup(false);
+        // AuthContext의 triggerLogin 호출 → Head에서 googleLogin 실행
+        triggerLogin();
+    };
+
+    const handleLoginCancel = () => {
+        setShowLoginPopup(false);
+    };
+
+    return (
+        <>
+            <div className="quote-source-selector">
+                <button
+                    className={`quote-source-btn ${quoteSource === 'all' ? 'active' : ''} ${isDark ? 'dark' : ''}`}
+                    onClick={handleAllClick}
+                >
+                    <FaGlobe/>
+                    <span>전체 문장</span>
+                </button>
+                <button
+                    className={`quote-source-btn ${quoteSource === 'my' ? 'active' : ''} ${isDark ? 'dark' : ''}`}
+                    onClick={handleMyClick}
+                >
+                    <FaUser/>
+                    <span>내 문장만</span>
+                </button>
+            </div>
+
+            {showLoginPopup && (
+                <ConfirmPopup
+                    message="내 문장을 사용하려면 로그인이 필요합니다."
+                    onConfirm={handleLoginConfirm}
+                    onCancel={handleLoginCancel}
+                    confirmText="로그인"
+                    cancelText="취소"
+                />
+            )}
+        </>
+    );
+};
+
+export default QuoteSourceSelector;

--- a/tp-react/src/pages/MyQuotes/MyQuotes.jsx
+++ b/tp-react/src/pages/MyQuotes/MyQuotes.jsx
@@ -18,6 +18,13 @@ function MyQuotes() {
     const { user } = useAuth();
     const { showError } = useError();
 
+    // 로그아웃 시 홈으로 이동
+    useEffect(() => {
+        if (!user) {
+            navigate('/');
+        }
+    }, [user, navigate]);
+
     // 필터 상태
     const [typeFilter, setTypeFilter] = useState('all');
     const [statusFilter, setStatusFilter] = useState('all');

--- a/tp-react/src/pages/QuoteUpload/QuoteUpload.jsx
+++ b/tp-react/src/pages/QuoteUpload/QuoteUpload.jsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useState, useEffect} from 'react';
 import {useNavigate} from 'react-router-dom';
 import {FaCircleInfo, FaGlobe, FaLock, FaPlus, FaUpload, FaXmark} from 'react-icons/fa6';
 import {uploadQuote} from '../../utils/quoteApi';
@@ -18,6 +18,13 @@ function QuoteUpload() {
     const [showConfirm, setShowConfirm] = useState(false);
     const [confirmMessage, setConfirmMessage] = useState('');
     const [isResultPopup, setIsResultPopup] = useState(false);
+
+    // 로그아웃 시 홈으로 이동
+    useEffect(() => {
+        if (!user) {
+            navigate('/');
+        }
+    }, [user, navigate]);
 
     function createEmptyEntry(id) {
         return {

--- a/tp-react/src/utils/quoteApi.js
+++ b/tp-react/src/utils/quoteApi.js
@@ -1,6 +1,26 @@
 import apiClient from './apiClient';
 
 /**
+ * 공개 문장 랜덤 조회
+ * @param {Object} params - 쿼리 파라미터
+ * @param {number} [params.page=1] - 페이지 번호
+ * @param {number} [params.count=100] - 조회 개수 (100-300)
+ * @param {number} params.seed - 랜덤 시드 (-1.0 ~ 1.0)
+ * @param {boolean} [params.onlyMyQuotes=false] - 내 문장만 조회
+ * @returns {Promise} API 응답
+ */
+export const getQuotes = async (params = {}) => {
+    const queryParams = new URLSearchParams();
+    if (params.page) queryParams.append('page', params.page);
+    if (params.count) queryParams.append('count', params.count);
+    if (params.seed !== undefined) queryParams.append('seed', params.seed);
+    if (params.onlyMyQuotes) queryParams.append('onlyMyQuotes', params.onlyMyQuotes);
+
+    const queryString = queryParams.toString();
+    return apiClient.get(`/quotes${queryString ? `?${queryString}` : ''}`);
+};
+
+/**
  * 공개 문장 업로드
  * @param {string} sentence - 문장 (5-100자)
  * @param {string} [author] - 저자 (1-20자, 선택)

--- a/tp-react/typing-practice-prototype.html
+++ b/tp-react/typing-practice-prototype.html
@@ -121,8 +121,21 @@
 
 <!-- 타이핑 영역 -->
 <div class="quote-container default-mode" id="quoteContainer">
-    <div class="author-container">
-        <span class="author-text">웰러비</span>
+    <div class="quote-top-row">
+        <!-- 문장 소스 선택 -->
+        <div class="quote-source-selector">
+            <button class="quote-source-btn active" id="quoteSourceAll">
+                <i class="fa-solid fa-globe"></i>
+                <span>전체 문장</span>
+            </button>
+            <button class="quote-source-btn" id="quoteSourceMy">
+                <i class="fa-solid fa-user"></i>
+                <span>내 문장만</span>
+            </button>
+        </div>
+        <div class="author-container">
+            <span class="author-text">웰러비</span>
+        </div>
     </div>
     <div class="sentence-input-wrapper">
         <div class="character-container" id="characterContainer">


### PR DESCRIPTION
- quoteApi.js에 getQuotes 함수 추가
- QuoteContext 수정
  - 시드 기반 랜덤 조회 (소수점 둘째자리)
  - 페이지네이션 (문장 소진 시 다음 페이지 로드)
  - 마지막 페이지 끝나면 시드 재생성 후 첫 페이지로
- 문장 소스 선택 UI (전체 문장 / 내 문장만)
  - QuoteSourceSelector 컴포넌트
  - 비로그인 + 내 문장만 선택 시 로그인 팝업
- AuthContext에 triggerLogin 추가 (다른 컴포넌트에서 로그인 트리거)
- 로딩/빈 결과 UI 컴포넌트 분리
  - QuoteLoading, QuoteEmpty
- 로그아웃 처리
  - 내 문장만 상태에서 로그아웃 시 전체 문장으로 초기화
  - QuoteUpload, MyQuotes 페이지에서 로그아웃 시 홈으로 이동
- QuoteContext 리팩토링
  - QUOTE_SOURCE 상수, resetState/setCurrentQuote 함수 분리