### PR TITLE
feat: Quote 엔티티에 language, difficulty 필드 추가 및 언어 혼용 검증

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/DataInitService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/DataInitService.java
@@ -4,6 +4,7 @@ import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.domain.MemberRole;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
@@ -67,7 +68,8 @@ public class DataInitService implements CommandLineRunner {
       Member owner = members.get(i % 10);
       QuoteType type = i % 5 == 0 ? QuoteType.PRIVATE : QuoteType.PUBLIC;
 
-      Quote quote = Quote.create(owner, "테스트 문장입니다. 번호: " + i, "작자 " + i, type);
+      Quote quote =
+          Quote.create(owner, "테스트 문장입니다. 번호: " + i, "작자 " + i, type, QuoteLanguage.KOREAN, 0f);
 
       if (type == QuoteType.PUBLIC && i % 5 < 4) {
         quote.approvePublish();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
   QUOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 예문을 찾을 수 없습니다."),
   QUOTE_NOT_OWNED(HttpStatus.FORBIDDEN, "문장에 대한 권한이 없습니다."),
   QUOTE_NOT_PROCESSABLE(HttpStatus.BAD_REQUEST, "처리할 수 없는 문장입니다."),
+  QUOTE_LANGUAGE_MISMATCH(HttpStatus.BAD_REQUEST, "선택한 언어와 맞지 않는 문자가 포함되어 있습니다."),
 
   EMPTY_UPDATE_REQUEST(HttpStatus.BAD_REQUEST, "수정할 내용이 없습니다."),
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -27,6 +27,11 @@ public class Quote extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private QuoteType type;
 
+  @Enumerated(EnumType.STRING)
+  private QuoteLanguage language;
+
+  private Float difficulty;
+
   private String sentence;
   private String author;
 
@@ -39,12 +44,20 @@ public class Quote extends BaseEntity {
   public static final String DEFAULT_AUTHOR = "작자 미상";
   public static final int HIDDEN_THRESHOLD = 5; // 자동 숨김 기준값
 
-  public static Quote create(Member member, String sentence, String author, QuoteType type) {
+  public static Quote create(
+      Member member,
+      String sentence,
+      String author,
+      QuoteType type,
+      QuoteLanguage language,
+      Float difficulty) {
     Quote quote = new Quote();
     quote.member = member;
     quote.sentence = sentence;
     quote.author = author != null ? author : DEFAULT_AUTHOR;
     quote.type = type;
+    quote.language = language;
+    quote.difficulty = difficulty;
     quote.reportCount = 0;
     quote.status = quote.type == QuoteType.PUBLIC ? QuoteStatus.PENDING : QuoteStatus.ACTIVE;
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/QuoteLanguage.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/QuoteLanguage.java
@@ -1,0 +1,6 @@
+package com.typingpractice.typing_practice_be.quote.domain;
+
+public enum QuoteLanguage {
+  KOREAN,
+  ENGLISH
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteCreateRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteCreateRequest.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.quote.dto;
 
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import jakarta.validation.constraints.NotEmpty;
 import lombok.Getter;
 import lombok.ToString;
@@ -15,10 +16,13 @@ public class QuoteCreateRequest {
   @Length(min = 1, max = 20)
   private String author;
 
-  public static QuoteCreateRequest create(String sentence, String author) {
+  private QuoteLanguage language;
+
+  public static QuoteCreateRequest create(String sentence, String author, QuoteLanguage language) {
     QuoteCreateRequest request = new QuoteCreateRequest();
     request.sentence = sentence;
     request.author = author;
+    request.language = language != null ? language : QuoteLanguage.KOREAN;
 
     return request;
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteResponse.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.quote.dto;
 
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
 import java.time.LocalDateTime;
@@ -12,6 +13,8 @@ import lombok.ToString;
 public class QuoteResponse {
   private Long quoteId;
   private String sentence;
+  private QuoteLanguage language;
+  private Float difficulty;
   private String author;
   private QuoteType type;
   private QuoteStatus status;
@@ -24,6 +27,8 @@ public class QuoteResponse {
 
     response.quoteId = quote.getId();
     response.sentence = quote.getSentence();
+    response.language = quote.getLanguage();
+    response.difficulty = quote.getDifficulty();
     response.author = quote.getAuthor();
     response.type = quote.getType();
     response.status = quote.getStatus();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/exception/QuoteLanguageMismatchException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/exception/QuoteLanguageMismatchException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.quote.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class QuoteLanguageMismatchException extends BusinessException {
+  public QuoteLanguageMismatchException() {
+    super(ErrorCode.QUOTE_LANGUAGE_MISMATCH);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/query/QuoteCreateQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/query/QuoteCreateQuery.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.quote.query;
 
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteCreateRequest;
 import lombok.Getter;
@@ -12,23 +13,28 @@ public class QuoteCreateQuery {
   private final String sentence;
   private final String author;
   private final QuoteType type;
+  private final QuoteLanguage language;
 
-  private QuoteCreateQuery(String sentence, String author, QuoteType type) {
+  private QuoteCreateQuery(String sentence, String author, QuoteType type, QuoteLanguage language) {
 
     this.sentence = sentence;
     this.author = author;
     this.type = type;
+    this.language = language;
   }
 
-  public static QuoteCreateQuery from(QuoteCreateRequest request, QuoteType type) {
-    return new QuoteCreateQuery(request.getSentence(), request.getAuthor(), type);
+  public static QuoteCreateQuery from(
+      QuoteCreateRequest request, QuoteType type, QuoteLanguage language) {
+    return new QuoteCreateQuery(request.getSentence(), request.getAuthor(), type, language);
   }
 
   public static QuoteCreateQuery ofPublic(QuoteCreateRequest request) {
-    return new QuoteCreateQuery(request.getSentence(), request.getAuthor(), QuoteType.PUBLIC);
+    return new QuoteCreateQuery(
+        request.getSentence(), request.getAuthor(), QuoteType.PUBLIC, request.getLanguage());
   }
 
   public static QuoteCreateQuery ofPrivate(QuoteCreateRequest request) {
-    return new QuoteCreateQuery(request.getSentence(), request.getAuthor(), QuoteType.PRIVATE);
+    return new QuoteCreateQuery(
+        request.getSentence(), request.getAuthor(), QuoteType.PRIVATE, request.getLanguage());
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteLanguageValidator.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteLanguageValidator.java
@@ -1,0 +1,23 @@
+package com.typingpractice.typing_practice_be.quote.service;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.exception.QuoteLanguageMismatchException;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+@Component
+public class QuoteLanguageValidator {
+  private static final Pattern ENGLISH_LETTER = Pattern.compile("[A-Za-z]");
+  private static final Pattern KOREAN_LETTER = Pattern.compile("[가-힣ㄱ-ㅎㅏ-ㅣ]");
+
+  public void validate(String sentence, QuoteLanguage language) {
+    if (language == QuoteLanguage.KOREAN && ENGLISH_LETTER.matcher(sentence).find()) {
+      throw new QuoteLanguageMismatchException();
+    }
+
+    if (language == QuoteLanguage.ENGLISH && KOREAN_LETTER.matcher(sentence).find()) {
+      throw new QuoteLanguageMismatchException();
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class QuoteService {
+  private final QuoteLanguageValidator quoteLanguageValidator;
   private final QuoteRepository quoteRepository;
   private final MemberRepository memberRepository;
 
@@ -52,7 +53,16 @@ public class QuoteService {
       throw new DailyQuoteUploadLimitException();
     }
 
-    Quote quote = Quote.create(member, query.getSentence(), query.getAuthor(), query.getType());
+    quoteLanguageValidator.validate(query.getSentence(), query.getLanguage());
+
+    Quote quote =
+        Quote.create(
+            member,
+            query.getSentence(),
+            query.getAuthor(),
+            query.getType(),
+            query.getLanguage(),
+            0f);
 
     quoteRepository.save(quote);
 

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteServiceTest.java
@@ -10,10 +10,7 @@ import com.typingpractice.typing_practice_be.dailylimit.exception.DailyQuoteUplo
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
-import com.typingpractice.typing_practice_be.quote.domain.Quote;
-import com.typingpractice.typing_practice_be.quote.domain.QuoteOrderBy;
-import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
-import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
+import com.typingpractice.typing_practice_be.quote.domain.*;
 import com.typingpractice.typing_practice_be.quote.dto.PublicQuoteRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteCreateRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationRequest;
@@ -62,7 +59,7 @@ class QuoteServiceTest {
   }
 
   private Quote createQuote(Member member, QuoteType type, QuoteStatus status) {
-    Quote quote = Quote.create(member, "테스트 문장입니다.", "저자", type);
+    Quote quote = Quote.create(member, "테스트 문장입니다.", "저자", type, QuoteLanguage.KOREAN, 0f);
     if (type == QuoteType.PUBLIC && status == QuoteStatus.ACTIVE) {
       quote.approvePublish();
     }


### PR DESCRIPTION
- QuoteLanguage enum 추가 (KOREAN, ENGLISH)
- Quote 엔티티에 language, difficulty 필드 추가
- QuoteLanguageValidator 구현 (한국어 문장 영어 포함 불가, 반대도 동일)
- QuoteCreateRequest에 language 필드 추가 (기본값 KOREAN)
- QuoteResponse에 language, difficulty 필드 추가
- ErrorCode.QUOTE_LANGUAGE_MISMATCH 추가