### PR TITLE
feat: 정적 난이도 계산 스켈레톤 구조 추가

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/DataInitService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/DataInitService.java
@@ -69,7 +69,8 @@ public class DataInitService implements CommandLineRunner {
       QuoteType type = i % 5 == 0 ? QuoteType.PRIVATE : QuoteType.PUBLIC;
 
       Quote quote =
-          Quote.create(owner, "테스트 문장입니다. 번호: " + i, "작자 " + i, type, QuoteLanguage.KOREAN, 0f);
+          Quote.create(
+              owner, "테스트 문장입니다. 번호: " + i, "작자 " + i, type, QuoteLanguage.KOREAN, null, 0f);
 
       if (type == QuoteType.PUBLIC && i % 5 < 4) {
         quote.approvePublish();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -32,6 +32,8 @@ public class Quote extends BaseEntity {
 
   private Float difficulty;
 
+  @Embedded private QuoteProfile profile;
+
   private String sentence;
   private String author;
 
@@ -50,6 +52,7 @@ public class Quote extends BaseEntity {
       String author,
       QuoteType type,
       QuoteLanguage language,
+      QuoteProfile profile,
       Float difficulty) {
     Quote quote = new Quote();
     quote.member = member;
@@ -57,6 +60,7 @@ public class Quote extends BaseEntity {
     quote.author = author != null ? author : DEFAULT_AUTHOR;
     quote.type = type;
     quote.language = language;
+    quote.profile = profile;
     quote.difficulty = difficulty;
     quote.reportCount = 0;
     quote.status = quote.type == QuoteType.PUBLIC ? QuoteStatus.PENDING : QuoteStatus.ACTIVE;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/QuoteProfile.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/QuoteProfile.java
@@ -1,0 +1,30 @@
+package com.typingpractice.typing_practice_be.quote.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuoteProfile {
+  // 공통
+  private int length; // 길이
+  private float puncRate; // 문장부호 비율
+  private float spaceRate; // 띄어쓰기 비율
+  private float digitRate; // 문장 내 숫자 비율
+
+  private float difficultySeed; // 문장 고유 난이도
+
+  // 한국어 전용 (영어 문장이면 null)
+  private Float jamoComplex; // 받침 점수
+  private Float diphthongRate; // 겹모음 ㅢ, ㅘ
+  private Float shiftJamoRate; // 쌍자음, 특수모음
+
+  // 영어 전용 (한국어 문장이면 null)
+  private Float caseFlipRate; // 대소문자
+  private Float avgWordLen; // 평균 단어 길이
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/DifficultySeedCalculator.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/DifficultySeedCalculator.java
@@ -1,0 +1,18 @@
+package com.typingpractice.typing_practice_be.quote.service;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteProfile;
+import com.typingpractice.typing_practice_be.statistics.domain.GlobalQuoteStatistics;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DifficultySeedCalculator {
+  public float calculate(
+      QuoteProfile profile, GlobalQuoteStatistics stats, QuoteLanguage language) {
+    // 공통 score 4개 + 언어 전용 score 3개
+    // σ == 0이면 해당 score = 0
+    // 가중합 → round(100 * sum) 반환
+
+    return 0f;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteProfileCalculator.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteProfileCalculator.java
@@ -1,0 +1,17 @@
+package com.typingpractice.typing_practice_be.quote.service;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteProfile;
+import org.springframework.stereotype.Component;
+
+@Component
+public class QuoteProfileCalculator {
+
+  public QuoteProfile calculate(String sentence, QuoteLanguage language) {
+    // 공통: length, puncRate, spaceRate, digitRate
+    // 한국어: jamoComplex, diphthongRate, shiftJamoRate
+    // 영어: caseFlipRate, avgWordLen
+    // difficultySeed 는 DifficultySeedCalculator 에서 설정
+    return null;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
@@ -6,9 +6,7 @@ import com.typingpractice.typing_practice_be.dailylimit.exception.DailyQuoteUplo
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
-import com.typingpractice.typing_practice_be.quote.domain.Quote;
-import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
-import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
+import com.typingpractice.typing_practice_be.quote.domain.*;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotOwnedException;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotProcessableException;
@@ -18,6 +16,9 @@ import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuoteUpdateQuery;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
 import java.util.List;
+
+import com.typingpractice.typing_practice_be.statistics.domain.GlobalQuoteStatistics;
+import com.typingpractice.typing_practice_be.statistics.service.GlobalQuoteStatisticsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -27,6 +28,10 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class QuoteService {
   private final QuoteLanguageValidator quoteLanguageValidator;
+  private final QuoteProfileCalculator quoteProfileCalculator;
+  private final DifficultySeedCalculator difficultySeedCalculator;
+  private final GlobalQuoteStatisticsService globalQuoteStatisticsService;
+
   private final QuoteRepository quoteRepository;
   private final MemberRepository memberRepository;
 
@@ -53,7 +58,17 @@ public class QuoteService {
       throw new DailyQuoteUploadLimitException();
     }
 
-    quoteLanguageValidator.validate(query.getSentence(), query.getLanguage());
+    String sentence = query.getSentence();
+    QuoteLanguage language = query.getLanguage();
+    // 언어 검증
+    quoteLanguageValidator.validate(sentence, language);
+    // 입력 변수
+    QuoteProfile profile = quoteProfileCalculator.calculate(sentence, language);
+    // 전역 통계
+    GlobalQuoteStatistics stats = globalQuoteStatisticsService.getByLanguage(language);
+    // difficulty seed 계산
+    float seed = difficultySeedCalculator.calculate(profile, stats, language);
+    profile.setDifficultySeed(seed);
 
     Quote quote =
         Quote.create(
@@ -62,6 +77,7 @@ public class QuoteService {
             query.getAuthor(),
             query.getType(),
             query.getLanguage(),
+            profile,
             0f);
 
     quoteRepository.save(quote);

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/domain/GlobalQuoteStatistics.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/domain/GlobalQuoteStatistics.java
@@ -1,0 +1,107 @@
+package com.typingpractice.typing_practice_be.statistics.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@SQLRestriction("deleted = false")
+@SQLDelete(
+    sql =
+        "UPDATE global_quote_statistics set deleted = true, deleted_at = NOW() where global_quote_statistics_id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GlobalQuoteStatistics extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "global_quote_statistics_id")
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  private QuoteLanguage language; // KOREAN, ENGLISH
+
+  // 공통
+  private float lenMean;
+  private float lenStd;
+
+  private float puncMean;
+  private float puncStd;
+
+  private float spaceMean;
+  private float spaceStd;
+
+  private float digitMean;
+  private float digitStd;
+
+  // 한국어 전용 (ENGLISH 행은 null)
+  private Float jamoMean;
+  private Float jamoStd;
+
+  private Float diphthongMean;
+  private Float diphthongStd;
+
+  private Float shiftJamoMean;
+  private Float shiftJamoStd;
+
+  // 영어 전용 (KOREAN 행은 null)
+  private Float caseMean;
+  private Float caseStd;
+
+  private Float wordLenMean;
+  private Float wordLenStd;
+
+  public static GlobalQuoteStatistics createKoreanDefault() {
+    GlobalQuoteStatistics stats = new GlobalQuoteStatistics();
+    stats.language = QuoteLanguage.KOREAN;
+    // stats.updatedAt = LocalDateTime.now();
+
+    // 공통 초기값
+    stats.lenMean = 30f;
+    stats.lenStd = 10f;
+    stats.puncMean = 0.05f;
+    stats.puncStd = 0.03f;
+    stats.spaceMean = 0.18f;
+    stats.spaceStd = 0.05f;
+    stats.digitMean = 0.01f;
+    stats.digitStd = 0.02f;
+
+    // 한국어 전용
+    stats.jamoMean = 0.5f;
+    stats.jamoStd = 0.2f;
+    stats.diphthongMean = 0.08f;
+    stats.diphthongStd = 0.05f;
+    stats.shiftJamoMean = 0.05f;
+    stats.shiftJamoStd = 0.03f;
+
+    return stats;
+  }
+
+  public static GlobalQuoteStatistics createEnglishDefault() {
+    GlobalQuoteStatistics stats = new GlobalQuoteStatistics();
+    stats.language = QuoteLanguage.ENGLISH;
+    // stats.updatedAt = LocalDateTime.now();
+
+    // 공통 초기값
+    stats.lenMean = 40f;
+    stats.lenStd = 15f;
+    stats.puncMean = 0.04f;
+    stats.puncStd = 0.02f;
+    stats.spaceMean = 0.18f;
+    stats.spaceStd = 0.04f;
+    stats.digitMean = 0.01f;
+    stats.digitStd = 0.02f;
+
+    // 영어 전용
+    stats.caseMean = 0.05f;
+    stats.caseStd = 0.03f;
+    stats.wordLenMean = 4.5f;
+    stats.wordLenStd = 1.5f;
+
+    return stats;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/repository/GlobalQuoteStatisticsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/repository/GlobalQuoteStatisticsRepository.java
@@ -1,0 +1,19 @@
+package com.typingpractice.typing_practice_be.statistics.repository;
+
+import com.typingpractice.typing_practice_be.statistics.domain.GlobalQuoteStatistics;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GlobalQuoteStatisticsRepository {
+  private final EntityManager em;
+
+  public List<GlobalQuoteStatistics> findAll() {
+    return em.createQuery("select s from GlobalQuoteStatistics", GlobalQuoteStatistics.class)
+        .setMaxResults(50)
+        .getResultList();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/GlobalQuoteStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/GlobalQuoteStatisticsService.java
@@ -1,0 +1,36 @@
+package com.typingpractice.typing_practice_be.statistics.service;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.statistics.domain.GlobalQuoteStatistics;
+import com.typingpractice.typing_practice_be.statistics.repository.GlobalQuoteStatisticsRepository;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GlobalQuoteStatisticsService {
+  private Map<QuoteLanguage, GlobalQuoteStatistics> cache;
+  private final GlobalQuoteStatisticsRepository globalQuoteStatisticsRepository;
+
+  @PostConstruct
+  public void init() {
+    // DB 에서 전역 통계값 로드 -> cache 채움
+    cache =
+        globalQuoteStatisticsRepository.findAll().stream()
+            .collect(Collectors.toMap(GlobalQuoteStatistics::getLanguage, Function.identity()));
+  }
+
+  public GlobalQuoteStatistics getByLanguage(QuoteLanguage language) {
+    return cache.get(language);
+  }
+
+  public void refreshCache() {
+    // 배치 완료 후 호출
+    init();
+  }
+}


### PR DESCRIPTION
- QuoteProfile @Embeddable 추가 (공통 + 언어별 입력 변수 필드)
- GlobalQuoteStatistics 엔티티 추가 (언어별 μ/σ 전역 통계)
- GlobalQuoteStatisticsRepository, GlobalQuoteStatisticsService 추가 (메모리 캐싱)
- QuoteProfileCalculator, DifficultySeedCalculator 스텁 추가
- Quote 엔티티에 profile 필드 추가, create() 시그니처 변경
- QuoteService.create()에 프로필 계산 → 전역 통계 조회 → seed 계산 흐름 연결