### PR TITLE
feat: 2단계 정적 난이도 계산 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/DataInitService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/DataInitService.java
@@ -11,6 +11,8 @@ import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.domain.ReportReason;
 import com.typingpractice.typing_practice_be.report.repository.ReportRepository;
+import com.typingpractice.typing_practice_be.statistics.domain.GlobalQuoteStatistics;
+import com.typingpractice.typing_practice_be.statistics.repository.GlobalQuoteStatisticsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.CommandLineRunner;
@@ -29,16 +31,26 @@ public class DataInitService implements CommandLineRunner {
   private final MemberRepository memberRepository;
   private final QuoteRepository quoteRepository;
   private final ReportRepository reportRepository;
+  private final GlobalQuoteStatisticsRepository globalQuoteStatisticsRepository;
 
   @Override
   @Transactional
   public void run(String... args) {
+    initGlobalQuoteStatistics();
     initAdmin();
     List<Member> members = initMembers();
     List<Quote> quotes = initQuotes(members);
     initReports(members, quotes);
 
     log.info("초기 데이터 생성 완료");
+  }
+
+  private void initGlobalQuoteStatistics() {
+    if (globalQuoteStatisticsRepository.count() == 0) {
+      globalQuoteStatisticsRepository.save(GlobalQuoteStatistics.createKoreanDefault());
+      globalQuoteStatisticsRepository.save(GlobalQuoteStatistics.createEnglishDefault());
+      log.info("전역 통계 초기값 생성 완료");
+    }
   }
 
   private void initAdmin() {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/QuoteProfile.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/QuoteProfile.java
@@ -1,14 +1,12 @@
 package com.typingpractice.typing_practice_be.quote.domain;
 
 import jakarta.persistence.Embeddable;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Embeddable
 @Getter
 @Setter
+@ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuoteProfile {
   // 공통
@@ -27,4 +25,8 @@ public class QuoteProfile {
   // 영어 전용 (한국어 문장이면 null)
   private Float caseFlipRate; // 대소문자
   private Float avgWordLen; // 평균 단어 길이
+
+  public static QuoteProfile create() {
+    return new QuoteProfile();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/DifficultySeedCalculator.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/DifficultySeedCalculator.java
@@ -7,12 +7,66 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class DifficultySeedCalculator {
+  // 공통 가중치
+  private static final float W_LEN = 0.20f;
+  private static final float W_PUNC = 0.15f;
+  private static final float W_SPACE = 0.10f;
+  private static final float W_DIGIT = 0.15f;
+
+  // 한국어 전용 가중치
+  private static final float W_JAMO = 0.15f;
+  private static final float W_DIPHTHONG = 0.10f;
+  private static final float W_SHIFT_JAMO = 0.15f;
+
+  // 영어 전용 가중치
+  private static final float W_CASE = 0.25f;
+  private static final float W_WORD_LEN = 0.15f;
+
   public float calculate(
       QuoteProfile profile, GlobalQuoteStatistics stats, QuoteLanguage language) {
     // 공통 score 4개 + 언어 전용 score 3개
     // σ == 0이면 해당 score = 0
     // 가중합 → round(100 * sum) 반환
+    float sum = 0f;
 
-    return 0f;
+    // 공통
+    sum += W_LEN * zScore(profile.getLength(), stats.getLenMean(), stats.getLenStd());
+    sum += W_PUNC * zScore(profile.getPuncRate(), stats.getPuncMean(), stats.getPuncStd());
+    sum +=
+        W_SPACE * zScoreInverse(profile.getSpaceRate(), stats.getSpaceMean(), stats.getSpaceStd());
+    sum += W_DIGIT * zScore(profile.getDigitRate(), stats.getDigitMean(), stats.getDigitStd());
+
+    if (language == QuoteLanguage.KOREAN) {
+      sum += W_JAMO * zScore(profile.getJamoComplex(), stats.getJamoMean(), stats.getJamoStd());
+      sum +=
+          W_DIPHTHONG
+              * zScore(
+                  profile.getDiphthongRate(), stats.getDiphthongMean(), stats.getDiphthongStd());
+      sum +=
+          W_SHIFT_JAMO
+              * zScore(
+                  profile.getShiftJamoRate(), stats.getShiftJamoMean(), stats.getShiftJamoStd());
+    } else {
+      sum += W_CASE * zScore(profile.getCaseFlipRate(), stats.getCaseMean(), stats.getCaseStd());
+      sum +=
+          W_WORD_LEN
+              * zScore(profile.getAvgWordLen(), stats.getWordLenMean(), stats.getWordLenStd());
+    }
+
+    return Math.round(100 * sum);
+  }
+
+  private float zScore(float value, float mean, float std) {
+    if (std == 0f) return 0f;
+    return clip((value - mean) / std);
+  }
+
+  private float zScoreInverse(float value, float mean, float std) {
+    if (std == 0f) return 0f;
+    return clip((mean - value) / std);
+  }
+
+  private float clip(float value) {
+    return Math.max(0f, Math.min(1f, value));
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteProfileCalculator.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteProfileCalculator.java
@@ -4,14 +4,183 @@ import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteProfile;
 import org.springframework.stereotype.Component;
 
+import java.util.Set;
+
 @Component
 public class QuoteProfileCalculator {
+
+  // 겹모음 목록: ㅘ ㅙ ㅚ ㅝ ㅞ ㅟ ㅢ
+  private static final Set<Character> DIPHTHONGS = Set.of('ㅘ', 'ㅙ', 'ㅚ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅢ');
+
+  // 쌍자음: ㄲ ㄸ ㅃ ㅆ ㅉ, 특수모음: ㅒ ㅖ
+  private static final Set<Character> SHIFT_INITIALS = Set.of('ㄲ', 'ㄸ', 'ㅃ', 'ㅆ', 'ㅉ');
+  private static final Set<Character> SHIFT_VOWELS = Set.of('ㅒ', 'ㅖ');
+  private static final Set<Character> SHIFT_FINALS = Set.of('ㄲ', 'ㄸ', 'ㅃ', 'ㅆ', 'ㅉ');
+
+  // 겹받침 목록
+  private static final Set<Character> DOUBLE_FINALS =
+      Set.of('ㄳ', 'ㄵ', 'ㄶ', 'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅄ');
+
+  // 초성 인덱스 → 자모 매핑
+  private static final char[] INITIALS = {
+    'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+  };
+
+  // 중성 인덱스 → 자모 매핑
+  private static final char[] MEDIALS = {
+    'ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ', 'ㅡ',
+    'ㅢ', 'ㅣ'
+  };
+
+  // 종성 인덱스 → 자모 매핑 (0은 받침 없음)
+  private static final char[] FINALS = {
+    0, 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ', 'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ', 'ㅄ',
+    'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+  };
+
+  private char getInitial(int index) {
+    return INITIALS[index];
+  }
+
+  private char getMedial(int index) {
+    return MEDIALS[index];
+  }
+
+  private char getFinal(int index) {
+    return FINALS[index];
+  }
 
   public QuoteProfile calculate(String sentence, QuoteLanguage language) {
     // 공통: length, puncRate, spaceRate, digitRate
     // 한국어: jamoComplex, diphthongRate, shiftJamoRate
     // 영어: caseFlipRate, avgWordLen
     // difficultySeed 는 DifficultySeedCalculator 에서 설정
-    return null;
+    QuoteProfile profile = QuoteProfile.create();
+
+    int len = sentence.length();
+    profile.setLength(len);
+
+    // 공통 변수
+    int puncCount = 0;
+    int spaceCount = 0;
+    int digitCount = 0;
+
+    for (char c : sentence.toCharArray()) {
+      // 특수 기호 체크
+      if (Character.getType(c) == Character.OTHER_PUNCTUATION
+          || Character.getType(c) == Character.MATH_SYMBOL
+          || Character.getType(c) == Character.CURRENCY_SYMBOL
+          || Character.getType(c) == Character.OTHER_SYMBOL
+          || Character.getType(c) == Character.START_PUNCTUATION
+          || Character.getType(c) == Character.END_PUNCTUATION
+          || Character.getType(c) == Character.CONNECTOR_PUNCTUATION
+          || Character.getType(c) == Character.DASH_PUNCTUATION
+          || Character.getType(c) == Character.INITIAL_QUOTE_PUNCTUATION
+          || Character.getType(c) == Character.FINAL_QUOTE_PUNCTUATION) {
+        puncCount++;
+      }
+      // 띄어쓰기 체크
+      if (c == ' ') spaceCount++;
+      // 숫자 체크
+      if (Character.isDigit(c)) digitCount++;
+    }
+    profile.setPuncRate(len > 0 ? (float) puncCount / len : 0f);
+    profile.setSpaceRate(len > 0 ? (float) spaceCount / len : 0f);
+    profile.setDigitRate(len > 0 ? (float) digitCount / len : 0f);
+
+    if (language == QuoteLanguage.KOREAN) {
+      // 한국어 전용 특성
+      calculateKoreanFeatures(sentence, profile);
+    } else {
+      // 영어 전용 특성
+      calculateEnglishFeatures(sentence, profile);
+    }
+
+    return profile;
+  }
+
+  private void calculateKoreanFeatures(String sentence, QuoteProfile profile) {
+    int koChars = 0;
+    float jamoComplexSum = 0f;
+    int diphthongCount = 0;
+    int shiftJamoCount = 0;
+
+    for (char c : sentence.toCharArray()) {
+      if (c >= '가' && c <= '힣') {
+        koChars++;
+
+        int code = c - '가';
+        int initialIndex = code / (21 * 28);
+        int medialIndex = (code % (21 * 28)) / 28;
+        int finalIndex = code % 28;
+
+        // 초성
+        char initial = getInitial(initialIndex);
+        // 중성
+        char medial = getMedial(medialIndex);
+        // 종성
+        char finalChar = finalIndex > 0 ? getFinal(finalIndex) : 0;
+
+        // 받침 복잡도
+        if (finalIndex == 0) {
+          // 무받침: 0
+        } else if (DOUBLE_FINALS.contains(finalChar)) {
+          jamoComplexSum += 1.5f;
+        } else {
+          jamoComplexSum += 1.0f;
+        }
+
+        // 겹모음
+        if (DIPHTHONGS.contains(medial)) {
+          diphthongCount++;
+        }
+
+        // Shift 자모 (쌍자음 + 특수모음)
+        if (SHIFT_INITIALS.contains(initial)
+            || SHIFT_VOWELS.contains(medial)
+            || SHIFT_FINALS.contains(finalChar)) {
+          shiftJamoCount++;
+        }
+      }
+    }
+
+    if (koChars > 0) {
+      profile.setJamoComplex((jamoComplexSum / koChars) / 1.5f);
+      profile.setDiphthongRate((float) diphthongCount / koChars);
+      profile.setShiftJamoRate((float) shiftJamoCount / koChars);
+    } else {
+      profile.setJamoComplex(0f);
+      profile.setDiphthongRate(0f);
+      profile.setShiftJamoRate(0f);
+    }
+  }
+
+  private void calculateEnglishFeatures(String sentence, QuoteProfile profile) {
+    // 대소문자 전환율
+    int flipCount = 0;
+    char[] chars = sentence.toCharArray();
+
+    for (int i = 1; i < chars.length; i++) {
+      if (Character.isLetter(chars[i]) && Character.isLetter(chars[i - 1])) {
+        if (Character.isUpperCase(chars[i]) != Character.isUpperCase(chars[i - 1])) {
+          flipCount++;
+        }
+      }
+    }
+    profile.setCaseFlipRate(chars.length > 0 ? (float) flipCount / chars.length : 0f);
+
+    // 단어 평균 길이
+    String[] words = sentence.trim().split("\\s+");
+    if (words.length > 0) {
+      int totalChars = 0;
+
+      for (String word : words) {
+        totalChars += word.length();
+      }
+
+      profile.setAvgWordLen((float) totalChars / words.length);
+    } else {
+      profile.setAvgWordLen(0f);
+    }
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
@@ -66,6 +66,7 @@ public class QuoteService {
     QuoteProfile profile = quoteProfileCalculator.calculate(sentence, language);
     // 전역 통계
     GlobalQuoteStatistics stats = globalQuoteStatisticsService.getByLanguage(language);
+
     // difficulty seed 계산
     float seed = difficultySeedCalculator.calculate(profile, stats, language);
     profile.setDifficultySeed(seed);
@@ -78,7 +79,7 @@ public class QuoteService {
             query.getType(),
             query.getLanguage(),
             profile,
-            0f);
+            seed);
 
     quoteRepository.save(quote);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/repository/GlobalQuoteStatisticsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/repository/GlobalQuoteStatisticsRepository.java
@@ -1,8 +1,11 @@
 package com.typingpractice.typing_practice_be.statistics.repository;
 
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.statistics.domain.GlobalQuoteStatistics;
 import jakarta.persistence.EntityManager;
+
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -11,9 +14,25 @@ import org.springframework.stereotype.Repository;
 public class GlobalQuoteStatisticsRepository {
   private final EntityManager em;
 
-  public List<GlobalQuoteStatistics> findAll() {
-    return em.createQuery("select s from GlobalQuoteStatistics", GlobalQuoteStatistics.class)
-        .setMaxResults(50)
-        .getResultList();
+  public void save(GlobalQuoteStatistics stats) {
+    em.persist(stats);
+  }
+
+  public Optional<GlobalQuoteStatistics> findTopByLanguageOrderByCreatedAtDesc(
+      QuoteLanguage language) {
+    List<GlobalQuoteStatistics> result =
+        em.createQuery(
+                "select s from GlobalQuoteStatistics s where s.language = :language order by s.createdAt DESC",
+                GlobalQuoteStatistics.class)
+            .setParameter("language", language)
+            .setMaxResults(1)
+            .getResultList();
+
+    return result.isEmpty() ? Optional.empty() : Optional.of(result.getFirst());
+  }
+
+  public long count() {
+    return em.createQuery("select count(s) from GlobalQuoteStatistics  s", Long.class)
+        .getSingleResult();
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/GlobalQuoteStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/GlobalQuoteStatisticsService.java
@@ -4,25 +4,45 @@ import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.statistics.domain.GlobalQuoteStatistics;
 import com.typingpractice.typing_practice_be.statistics.repository.GlobalQuoteStatisticsRepository;
 import jakarta.annotation.PostConstruct;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
+import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class GlobalQuoteStatisticsService {
   private Map<QuoteLanguage, GlobalQuoteStatistics> cache;
   private final GlobalQuoteStatisticsRepository globalQuoteStatisticsRepository;
+  private final TransactionTemplate transactionTemplate;
 
   @PostConstruct
   public void init() {
     // DB 에서 전역 통계값 로드 -> cache 채움
-    cache =
-        globalQuoteStatisticsRepository.findAll().stream()
-            .collect(Collectors.toMap(GlobalQuoteStatistics::getLanguage, Function.identity()));
+
+    transactionTemplate.execute(
+        status -> {
+          if (globalQuoteStatisticsRepository.count() == 0) {
+            globalQuoteStatisticsRepository.save(GlobalQuoteStatistics.createKoreanDefault());
+            globalQuoteStatisticsRepository.save(GlobalQuoteStatistics.createEnglishDefault());
+          }
+
+          cache =
+              Arrays.stream(QuoteLanguage.values())
+                  .map(globalQuoteStatisticsRepository::findTopByLanguageOrderByCreatedAtDesc)
+                  .filter(Optional::isPresent)
+                  .map(Optional::get)
+                  .collect(
+                      Collectors.toMap(GlobalQuoteStatistics::getLanguage, Function.identity()));
+
+          return null;
+        });
   }
 
   public GlobalQuoteStatistics getByLanguage(QuoteLanguage language) {

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/AdminQuoteE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/AdminQuoteE2ETest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import com.typingpractice.typing_practice_be.auth.dto.LoginResponse;
 import com.typingpractice.typing_practice_be.auth.dto.TestLoginRequest;
 import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteCreateRequest;
@@ -51,7 +52,8 @@ public class AdminQuoteE2ETest {
 
   private Long createPublicQuote(String token) {
     HttpHeaders headers = createAuthHeader(token);
-    QuoteCreateRequest request = QuoteCreateRequest.create("테스트용 문장입니다.", null);
+    QuoteCreateRequest request =
+        QuoteCreateRequest.create("테스트용 문장입니다.", null, QuoteLanguage.KOREAN);
 
     ResponseEntity<ApiResponse<QuoteResponse>> response =
         restTemplate.exchange(
@@ -66,7 +68,8 @@ public class AdminQuoteE2ETest {
 
   private Long createPrivateQuote(String token) {
     HttpHeaders headers = createAuthHeader(token);
-    QuoteCreateRequest request = QuoteCreateRequest.create("테스트용 비공개 문장입니다.", null);
+    QuoteCreateRequest request =
+        QuoteCreateRequest.create("테스트용 비공개 문장입니다.", null, QuoteLanguage.KOREAN);
 
     ResponseEntity<ApiResponse<QuoteResponse>> response =
         restTemplate.exchange(

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/QuoteE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/QuoteE2ETest.java
@@ -7,6 +7,7 @@ import com.typingpractice.typing_practice_be.auth.dto.TestLoginRequest;
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.member.dto.MemberResponse;
 import com.typingpractice.typing_practice_be.member.dto.admin.MemberBanRequest;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteCreateRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationResponse;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteResponse;
@@ -93,7 +94,8 @@ public class QuoteE2ETest {
       String token = getAccessToken("1");
       HttpHeaders headers = createAuthHeader(token);
 
-      QuoteCreateRequest createRequest = QuoteCreateRequest.create("내 문장 필터링 테스트입니다.", null);
+      QuoteCreateRequest createRequest =
+          QuoteCreateRequest.create("내 문장 필터링 테스트입니다.", null, QuoteLanguage.KOREAN);
       ResponseEntity<ApiResponse<QuoteResponse>> createResponse =
           restTemplate.exchange(
               "/quotes/public",
@@ -204,7 +206,8 @@ public class QuoteE2ETest {
       HttpHeaders headers = createAuthHeader(token);
 
       // 비공개 문장 생성
-      QuoteCreateRequest createRequest = QuoteCreateRequest.create("내 문장 조회 테스트입니다.", null);
+      QuoteCreateRequest createRequest =
+          QuoteCreateRequest.create("내 문장 조회 테스트입니다.", null, QuoteLanguage.KOREAN);
       ResponseEntity<ApiResponse<QuoteResponse>> createResponse =
           restTemplate.exchange(
               "/quotes/private",
@@ -315,7 +318,8 @@ public class QuoteE2ETest {
     void success() {
       String token = getAccessToken(USER_PROVIDER_ID);
       HttpHeaders headers = createAuthHeader(token);
-      QuoteCreateRequest request = QuoteCreateRequest.create("테스트 공개 문장입니다.", "저자");
+      QuoteCreateRequest request =
+          QuoteCreateRequest.create("테스트 공개 문장입니다.", "저자", QuoteLanguage.KOREAN);
 
       ResponseEntity<ApiResponse<QuoteResponse>> response =
           restTemplate.exchange(
@@ -342,7 +346,8 @@ public class QuoteE2ETest {
                   .exchange(
                       "/quotes/public",
                       HttpMethod.POST,
-                      new HttpEntity<>(QuoteCreateRequest.create("1234", null), headers),
+                      new HttpEntity<>(
+                          QuoteCreateRequest.create("1234", null, QuoteLanguage.KOREAN), headers),
                       new ParameterizedTypeReference<ApiResponse<QuoteResponse>>() {})
                   .getStatusCode())
           .isEqualTo(HttpStatus.BAD_REQUEST);
@@ -353,7 +358,9 @@ public class QuoteE2ETest {
                   .exchange(
                       "/quotes/public",
                       HttpMethod.POST,
-                      new HttpEntity<>(QuoteCreateRequest.create("a".repeat(101), null), headers),
+                      new HttpEntity<>(
+                          QuoteCreateRequest.create("a".repeat(101), null, QuoteLanguage.ENGLISH),
+                          headers),
                       new ParameterizedTypeReference<ApiResponse<QuoteResponse>>() {})
                   .getStatusCode())
           .isEqualTo(HttpStatus.BAD_REQUEST);
@@ -365,7 +372,9 @@ public class QuoteE2ETest {
                       "/quotes/public",
                       HttpMethod.POST,
                       new HttpEntity<>(
-                          QuoteCreateRequest.create("테스트 문장입니다.", "a".repeat(21)), headers),
+                          QuoteCreateRequest.create(
+                              "테스트 문장입니다.", "a".repeat(21), QuoteLanguage.KOREAN),
+                          headers),
                       new ParameterizedTypeReference<ApiResponse<QuoteResponse>>() {})
                   .getStatusCode())
           .isEqualTo(HttpStatus.BAD_REQUEST);
@@ -404,7 +413,8 @@ public class QuoteE2ETest {
       String bannedToken = getAccessToken(uniqueProviderId);
       HttpHeaders bannedHeaders = createAuthHeader(bannedToken);
 
-      QuoteCreateRequest request = QuoteCreateRequest.create("밴 유저 테스트 문장", null);
+      QuoteCreateRequest request =
+          QuoteCreateRequest.create("밴 유저 테스트 문장", null, QuoteLanguage.KOREAN);
 
       // when
       ResponseEntity<ApiResponse<QuoteResponse>> exchange =
@@ -421,7 +431,8 @@ public class QuoteE2ETest {
     @Test
     @DisplayName("토큰 없이 요청 - 401")
     void unauthorizedWithoutToken() {
-      QuoteCreateRequest request = QuoteCreateRequest.create("테스트 공개 문장입니다.", null);
+      QuoteCreateRequest request =
+          QuoteCreateRequest.create("테스트 공개 문장입니다.", null, QuoteLanguage.KOREAN);
 
       ResponseEntity<ApiResponse<QuoteResponse>> response =
           restTemplate.exchange(
@@ -442,7 +453,8 @@ public class QuoteE2ETest {
     void success() {
       String token = getAccessToken("1");
       HttpHeaders headers = createAuthHeader(token);
-      QuoteCreateRequest request = QuoteCreateRequest.create("테스트 비공개 문장입니다.", null);
+      QuoteCreateRequest request =
+          QuoteCreateRequest.create("테스트 비공개 문장입니다.", null, QuoteLanguage.KOREAN);
 
       ResponseEntity<ApiResponse<QuoteResponse>> response =
           restTemplate.exchange(
@@ -460,7 +472,8 @@ public class QuoteE2ETest {
     @Test
     @DisplayName("토큰 없이 요청 - 401")
     void unauthorizedWithoutToken() {
-      QuoteCreateRequest request = QuoteCreateRequest.create("테스트 비공개 문장입니다.", null);
+      QuoteCreateRequest request =
+          QuoteCreateRequest.create("테스트 비공개 문장입니다.", null, QuoteLanguage.KOREAN);
 
       ResponseEntity<ApiResponse<QuoteResponse>> response =
           restTemplate.exchange(
@@ -484,7 +497,8 @@ public class QuoteE2ETest {
       String token = getAccessToken("1");
       HttpHeaders headers = createAuthHeader(token);
 
-      QuoteCreateRequest createRequest = QuoteCreateRequest.create("수정 테스트용 문장입니다.", null);
+      QuoteCreateRequest createRequest =
+          QuoteCreateRequest.create("수정 테스트용 문장입니다.", null, QuoteLanguage.KOREAN);
       ResponseEntity<ApiResponse<QuoteResponse>> createResponse =
           restTemplate.exchange(
               "/quotes/private",
@@ -554,7 +568,8 @@ public class QuoteE2ETest {
       String token = getAccessToken("1");
       HttpHeaders headers = createAuthHeader(token);
 
-      QuoteCreateRequest createRequest = QuoteCreateRequest.create("삭제 테스트용 문장입니다.", null);
+      QuoteCreateRequest createRequest =
+          QuoteCreateRequest.create("삭제 테스트용 문장입니다.", null, QuoteLanguage.KOREAN);
       ResponseEntity<ApiResponse<QuoteResponse>> createResponse =
           restTemplate.exchange(
               "/quotes/private",
@@ -597,7 +612,8 @@ public class QuoteE2ETest {
       String token = getAccessToken("1");
       HttpHeaders headers = createAuthHeader(token);
 
-      QuoteCreateRequest createRequest = QuoteCreateRequest.create("공개 전환 테스트용 문장입니다.", null);
+      QuoteCreateRequest createRequest =
+          QuoteCreateRequest.create("공개 전환 테스트용 문장입니다.", null, QuoteLanguage.KOREAN);
       ResponseEntity<ApiResponse<QuoteResponse>> createResponse =
           restTemplate.exchange(
               "/quotes/private",
@@ -640,7 +656,8 @@ public class QuoteE2ETest {
       HttpHeaders userHeaders = createAuthHeader(userToken);
 
       // 비공개 문장 생성
-      QuoteCreateRequest createRequest = QuoteCreateRequest.create("밴 전 생성한 문장", null);
+      QuoteCreateRequest createRequest =
+          QuoteCreateRequest.create("밴 전 생성한 문장", null, QuoteLanguage.KOREAN);
       ResponseEntity<ApiResponse<QuoteResponse>> createResponse =
           restTemplate.exchange(
               "/quotes/private",
@@ -698,7 +715,8 @@ public class QuoteE2ETest {
       String token = getAccessToken("1");
       HttpHeaders headers = createAuthHeader(token);
 
-      QuoteCreateRequest createRequest = QuoteCreateRequest.create("공개 취소 테스트용 문장입니다.", null);
+      QuoteCreateRequest createRequest =
+          QuoteCreateRequest.create("공개 취소 테스트용 문장입니다.", null, QuoteLanguage.KOREAN);
       ResponseEntity<ApiResponse<QuoteResponse>> createResponse =
           restTemplate.exchange(
               "/quotes/private",

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteUpdateRequest;
@@ -32,7 +33,8 @@ class AdminQuoteServiceTest {
   }
 
   private Quote createQuote(QuoteType type, QuoteStatus status) {
-    Quote quote = Quote.create(createMember(), "테스트 문장입니다.", "작자", type);
+    Quote quote =
+        Quote.create(createMember(), "테스트 문장입니다.", "작자", type, QuoteLanguage.KOREAN, null, 0f);
 
     if (type == QuoteType.PUBLIC && status == QuoteStatus.ACTIVE) {
       quote.approvePublish();

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/DifficultySeedCalculatorTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/DifficultySeedCalculatorTest.java
@@ -1,0 +1,216 @@
+package com.typingpractice.typing_practice_be.quote.service;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteProfile;
+import com.typingpractice.typing_practice_be.statistics.domain.GlobalQuoteStatistics;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class DifficultySeedCalculatorTest {
+  private final DifficultySeedCalculator calculator = new DifficultySeedCalculator();
+
+  @Nested
+  @DisplayName("한국어 난이도 계산")
+  class KoreanDifficulty {
+
+    @Test
+    @DisplayName("평균과 동일한 문장 - 모든 z점수 0, seed 0")
+    void averageSentence() {
+      GlobalQuoteStatistics stats = GlobalQuoteStatistics.createKoreanDefault();
+      QuoteProfile profile = createKoreanProfile(30, 0.05f, 0.18f, 0.01f, 0.5f, 0.08f, 0.05f);
+
+      float seed = calculator.calculate(profile, stats, QuoteLanguage.KOREAN);
+
+      assertThat(seed).isEqualTo(0f);
+    }
+
+    @Test
+    @DisplayName("모든 값이 평균보다 높은 문장 - 높은 seed")
+    void hardSentence() {
+      GlobalQuoteStatistics stats = GlobalQuoteStatistics.createKoreanDefault();
+      // 평균보다 1σ 이상 높은 값들
+      QuoteProfile profile = createKoreanProfile(50, 0.10f, 0.08f, 0.05f, 0.8f, 0.15f, 0.10f);
+      // spaceRate는 낮을수록 어려움 → 0.08은 평균(0.18)보다 낮으므로 어려움↑
+
+      float seed = calculator.calculate(profile, stats, QuoteLanguage.KOREAN);
+
+      assertThat(seed).isGreaterThan(50f);
+    }
+
+    @Test
+    @DisplayName("모든 값이 평균보다 낮은 문장 - seed 0")
+    void easySentence() {
+      GlobalQuoteStatistics stats = GlobalQuoteStatistics.createKoreanDefault();
+      QuoteProfile profile = createKoreanProfile(10, 0.01f, 0.30f, 0.0f, 0.1f, 0.01f, 0.01f);
+
+      float seed = calculator.calculate(profile, stats, QuoteLanguage.KOREAN);
+
+      assertThat(seed).isEqualTo(0f);
+    }
+
+    @Test
+    @DisplayName("seed는 0~100 범위")
+    void seedRange() {
+      GlobalQuoteStatistics stats = GlobalQuoteStatistics.createKoreanDefault();
+      // 극단적으로 높은 값
+      QuoteProfile profile = createKoreanProfile(200, 0.50f, 0.01f, 0.30f, 1.5f, 0.50f, 0.50f);
+
+      float seed = calculator.calculate(profile, stats, QuoteLanguage.KOREAN);
+
+      assertThat(seed).isBetween(0f, 100f);
+    }
+  }
+
+  @Nested
+  @DisplayName("영어 난이도 계산")
+  class EnglishDifficulty {
+
+    @Test
+    @DisplayName("평균과 동일한 문장 - seed 0")
+    void averageSentence() {
+      GlobalQuoteStatistics stats = GlobalQuoteStatistics.createEnglishDefault();
+      QuoteProfile profile = createEnglishProfile(40, 0.04f, 0.18f, 0.01f, 0.05f, 4.5f);
+
+      float seed = calculator.calculate(profile, stats, QuoteLanguage.ENGLISH);
+
+      assertThat(seed).isEqualTo(0f);
+    }
+
+    @Test
+    @DisplayName("모든 값이 평균보다 높은 문장 - 높은 seed")
+    void hardSentence() {
+      GlobalQuoteStatistics stats = GlobalQuoteStatistics.createEnglishDefault();
+      QuoteProfile profile = createEnglishProfile(80, 0.10f, 0.08f, 0.05f, 0.15f, 8.0f);
+
+      float seed = calculator.calculate(profile, stats, QuoteLanguage.ENGLISH);
+
+      assertThat(seed).isGreaterThan(50f);
+    }
+
+    @Test
+    @DisplayName("seed는 0~100 범위")
+    void seedRange() {
+      GlobalQuoteStatistics stats = GlobalQuoteStatistics.createEnglishDefault();
+      QuoteProfile profile = createEnglishProfile(200, 0.50f, 0.01f, 0.30f, 0.50f, 15.0f);
+
+      float seed = calculator.calculate(profile, stats, QuoteLanguage.ENGLISH);
+
+      assertThat(seed).isBetween(0f, 100f);
+    }
+  }
+
+  @Nested
+  @DisplayName("σ = 0 처리")
+  class SigmaZero {
+
+    @Test
+    @DisplayName("σ가 0인 항목의 score는 0")
+    void sigmaZeroReturnsZero() {
+      GlobalQuoteStatistics stats = GlobalQuoteStatistics.createKoreanDefault();
+      // digitStd를 0으로 설정하면 score_digit = 0이 되어야 함
+      // createKoreanDefault의 digitStd는 0.02f이므로 별도 stats가 필요
+
+      // 모든 std를 0으로 설정한 통계
+      GlobalQuoteStatistics zeroStats = createZeroStdStats(QuoteLanguage.KOREAN);
+      QuoteProfile profile = createKoreanProfile(50, 0.10f, 0.10f, 0.05f, 0.8f, 0.15f, 0.10f);
+
+      float seed = calculator.calculate(profile, zeroStats, QuoteLanguage.KOREAN);
+
+      assertThat(seed).isEqualTo(0f);
+    }
+  }
+
+  @Nested
+  @DisplayName("가중치 합계 검증")
+  class WeightValidation {
+
+    @Test
+    @DisplayName("한국어 - 모든 score가 1이면 seed = 100")
+    void koreanMaxSeed() {
+      GlobalQuoteStatistics stats = GlobalQuoteStatistics.createKoreanDefault();
+      // 모든 값을 평균 + 10σ 이상으로 설정 → 모든 score = 1.0
+      QuoteProfile profile = createKoreanProfile(1000, 1.0f, 0.0f, 1.0f, 10.0f, 1.0f, 1.0f);
+
+      float seed = calculator.calculate(profile, stats, QuoteLanguage.KOREAN);
+
+      assertThat(seed).isEqualTo(100f);
+    }
+
+    @Test
+    @DisplayName("영어 - 모든 score가 1이면 seed = 100")
+    void englishMaxSeed() {
+      GlobalQuoteStatistics stats = GlobalQuoteStatistics.createEnglishDefault();
+      QuoteProfile profile = createEnglishProfile(1000, 1.0f, 0.0f, 1.0f, 1.0f, 100.0f);
+
+      float seed = calculator.calculate(profile, stats, QuoteLanguage.ENGLISH);
+
+      assertThat(seed).isEqualTo(100f);
+    }
+  }
+
+  // === 헬퍼 메서드 ===
+
+  private QuoteProfile createKoreanProfile(
+      int length,
+      float puncRate,
+      float spaceRate,
+      float digitRate,
+      float jamoComplex,
+      float diphthongRate,
+      float shiftJamoRate) {
+    QuoteProfile profile = QuoteProfile.create();
+    profile.setLength(length);
+    profile.setPuncRate(puncRate);
+    profile.setSpaceRate(spaceRate);
+    profile.setDigitRate(digitRate);
+    profile.setJamoComplex(jamoComplex);
+    profile.setDiphthongRate(diphthongRate);
+    profile.setShiftJamoRate(shiftJamoRate);
+    return profile;
+  }
+
+  private QuoteProfile createEnglishProfile(
+      int length,
+      float puncRate,
+      float spaceRate,
+      float digitRate,
+      float caseFlipRate,
+      float avgWordLen) {
+    QuoteProfile profile = QuoteProfile.create();
+    profile.setLength(length);
+    profile.setPuncRate(puncRate);
+    profile.setSpaceRate(spaceRate);
+    profile.setDigitRate(digitRate);
+    profile.setCaseFlipRate(caseFlipRate);
+    profile.setAvgWordLen(avgWordLen);
+    return profile;
+  }
+
+  private GlobalQuoteStatistics createZeroStdStats(QuoteLanguage language) {
+    // 모든 std = 0인 통계 → 모든 score = 0
+    // GlobalQuoteStatistics에 접근하려면 팩토리 메서드나 테스트용 생성 방법 필요
+    // 현재 필드가 private이므로 리플렉션 사용
+    GlobalQuoteStatistics stats = GlobalQuoteStatistics.createKoreanDefault();
+    try {
+      setField(stats, "lenStd", 0f);
+      setField(stats, "puncStd", 0f);
+      setField(stats, "spaceStd", 0f);
+      setField(stats, "digitStd", 0f);
+      setField(stats, "jamoStd", 0f);
+      setField(stats, "diphthongStd", 0f);
+      setField(stats, "shiftJamoStd", 0f);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return stats;
+  }
+
+  private void setField(Object obj, String fieldName, Object value) throws Exception {
+    java.lang.reflect.Field field = obj.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(obj, value);
+  }
+}

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteProfileCalculatorTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteProfileCalculatorTest.java
@@ -1,0 +1,179 @@
+package com.typingpractice.typing_practice_be.quote.service;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteProfile;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class QuoteProfileCalculatorTest {
+  private final QuoteProfileCalculator calculator = new QuoteProfileCalculator();
+
+  @Nested
+  @DisplayName("공통 변수 계산")
+  class CommonFeatures {
+    @Test
+    @DisplayName("문장 길이 계산 - 공백 포함")
+    void length() {
+      QuoteProfile profile = calculator.calculate("안녕 하세요", QuoteLanguage.KOREAN);
+      assertThat(profile.getLength()).isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("문장부호 비율 계산")
+    void puncRate() {
+      // "안녕, 세상!" → 문장부호 , ! = 2개, 길이 6
+      QuoteProfile profile = calculator.calculate("안녕, 세상!", QuoteLanguage.KOREAN);
+      assertThat(profile.getPuncRate()).isCloseTo(2f / 7f, within(0.001f));
+    }
+
+    @Test
+    @DisplayName("띄어쓰기 비율 계산")
+    void spaceRate() {
+      // "가 나 다" → 공백 2개, 길이 5
+      QuoteProfile profile = calculator.calculate("가 나 다", QuoteLanguage.KOREAN);
+      assertThat(profile.getSpaceRate()).isCloseTo(2f / 5f, within(0.001f));
+    }
+
+    @Test
+    @DisplayName("숫자 비율 계산")
+    void digitRate() {
+      // "가격은 3000원" → 숫자 4개, 길이 8
+      QuoteProfile profile = calculator.calculate("가격은 3000원", QuoteLanguage.KOREAN);
+      assertThat(profile.getDigitRate()).isCloseTo(4f / 9f, within(0.001f));
+    }
+
+    @Test
+    @DisplayName("빈 문자열 처리")
+    void emptyString() {
+      QuoteProfile profile = calculator.calculate("", QuoteLanguage.KOREAN);
+      assertThat(profile.getLength()).isEqualTo(0);
+      assertThat(profile.getPuncRate()).isEqualTo(0f);
+      assertThat(profile.getSpaceRate()).isEqualTo(0f);
+      assertThat(profile.getDigitRate()).isEqualTo(0f);
+    }
+  }
+
+  @Nested
+  @DisplayName("한국어 전용 변수 계산")
+  class KoreanFeatures {
+
+    @Test
+    @DisplayName("자모 복잡도 - 무받침")
+    void jamoComplex_noFinal() {
+      // "가나다" → 모두 무받침, jamoComplex = 0
+      QuoteProfile profile = calculator.calculate("가나다", QuoteLanguage.KOREAN);
+      assertThat(profile.getJamoComplex()).isEqualTo(0f);
+    }
+
+    @Test
+    @DisplayName("자모 복잡도 - 단일받침")
+    void jamoComplex_singleFinal() {
+      // "간단한" → 간(ㄴ), 단(ㄴ), 한(ㄴ) 모두 단일받침
+      // jamoComplexSum = 3 * 1.0 = 3.0, 평균 = 3.0/3 = 1.0, /1.5 = 0.667
+      QuoteProfile profile = calculator.calculate("간단한", QuoteLanguage.KOREAN);
+      assertThat(profile.getJamoComplex()).isCloseTo(1.0f / 1.5f, within(0.001f));
+    }
+
+    @Test
+    @DisplayName("자모 복잡도 - 겹받침")
+    void jamoComplex_doubleFinal() {
+      // "읽닭" → 읽(ㄺ, 겹받침), 닭(ㄺ, 겹받침 아님 - ㄱ 단일)
+      // 읽: ㄺ → 겹받침 1.5, 닭: ㄹ+ㄱ = ㄺ → 겹받침 1.5
+      // 평균 = 3.0/2 = 1.5, /1.5 = 1.0
+      QuoteProfile profile = calculator.calculate("읽닭", QuoteLanguage.KOREAN);
+      assertThat(profile.getJamoComplex()).isCloseTo(1.0f, within(0.001f));
+    }
+
+    @Test
+    @DisplayName("겹모음 비율")
+    void diphthongRate() {
+      // "화과" → 화(ㅘ, 겹모음), 과(ㅘ, 겹모음), koChars = 2
+      QuoteProfile profile = calculator.calculate("화과", QuoteLanguage.KOREAN);
+      assertThat(profile.getDiphthongRate()).isCloseTo(1.0f, within(0.001f));
+    }
+
+    @Test
+    @DisplayName("겹모음 없는 문장")
+    void diphthongRate_none() {
+      // "가나다" → 겹모음 없음
+      QuoteProfile profile = calculator.calculate("가나다", QuoteLanguage.KOREAN);
+      assertThat(profile.getDiphthongRate()).isEqualTo(0f);
+    }
+
+    @Test
+    @DisplayName("Shift 자모 비율 - 쌍자음")
+    void shiftJamoRate_doubleConsonant() {
+      // "빠른" → 빠(ㅃ, shift 초성), 른(일반), koChars = 2
+      QuoteProfile profile = calculator.calculate("빠른", QuoteLanguage.KOREAN);
+      assertThat(profile.getShiftJamoRate()).isCloseTo(1f / 2f, within(0.001f));
+    }
+
+    @Test
+    @DisplayName("Shift 자모 비율 - 특수모음 ㅒ ㅖ")
+    void shiftJamoRate_specialVowel() {
+      // "얘기" → 얘(ㅒ, shift 모음), 기(일반), koChars = 2
+      QuoteProfile profile = calculator.calculate("얘기", QuoteLanguage.KOREAN);
+      assertThat(profile.getShiftJamoRate()).isCloseTo(1f / 2f, within(0.001f));
+    }
+
+    @Test
+    @DisplayName("영어 전용 필드는 null")
+    void englishFieldsNull() {
+      QuoteProfile profile = calculator.calculate("안녕하세요", QuoteLanguage.KOREAN);
+      assertThat(profile.getCaseFlipRate()).isNull();
+      assertThat(profile.getAvgWordLen()).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("영어 전용 변수 계산")
+  class EnglishFeatures {
+
+    @Test
+    @DisplayName("대소문자 전환율")
+    void caseFlipRate() {
+      // "AbCd" → A→b(전환), b→C(전환), C→d(전환) = 3회, 길이 4
+      QuoteProfile profile = calculator.calculate("AbCd", QuoteLanguage.ENGLISH);
+      assertThat(profile.getCaseFlipRate()).isCloseTo(3f / 4f, within(0.001f));
+    }
+
+    @Test
+    @DisplayName("대소문자 전환 없음")
+    void caseFlipRate_noFlip() {
+      // "hello" → 전환 없음
+      QuoteProfile profile = calculator.calculate("hello", QuoteLanguage.ENGLISH);
+      assertThat(profile.getCaseFlipRate()).isEqualTo(0f);
+    }
+
+    @Test
+    @DisplayName("대소문자 전환 - 공백 사이는 전환으로 안 셈")
+    void caseFlipRate_withSpace() {
+      // "Hello World" → H→e(전환), l→l(X), o→ (비문자), W→o(전환) ...
+      // 문자 간 전환만 체크, 공백은 isLetter가 false이므로 건너뜀
+      QuoteProfile profile = calculator.calculate("Hello World", QuoteLanguage.ENGLISH);
+      // H→e(전환), e→l(X), l→l(X), l→o(X), o→' '(건너뜀), ' '→W(건너뜀), W→o(전환), o→r(X), r→l(X), l→d(X)
+      // 전환 2회, 길이 11
+      assertThat(profile.getCaseFlipRate()).isCloseTo(2f / 11f, within(0.001f));
+    }
+
+    @Test
+    @DisplayName("단어 평균 길이")
+    void avgWordLen() {
+      // "I am good" → 단어 3개, 총 문자(공백 제외) 1+2+4 = 7, 평균 7/3
+      QuoteProfile profile = calculator.calculate("I am good", QuoteLanguage.ENGLISH);
+      assertThat(profile.getAvgWordLen()).isCloseTo(7f / 3f, within(0.001f));
+    }
+
+    @Test
+    @DisplayName("한국어 전용 필드는 null")
+    void koreanFieldsNull() {
+      QuoteProfile profile = calculator.calculate("hello world", QuoteLanguage.ENGLISH);
+      assertThat(profile.getJamoComplex()).isNull();
+      assertThat(profile.getDiphthongRate()).isNull();
+      assertThat(profile.getShiftJamoRate()).isNull();
+    }
+  }
+}

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteServiceTest.java
@@ -26,6 +26,9 @@ import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
 import java.lang.reflect.Field;
 import java.util.List;
 import java.util.Optional;
+
+import com.typingpractice.typing_practice_be.statistics.domain.GlobalQuoteStatistics;
+import com.typingpractice.typing_practice_be.statistics.service.GlobalQuoteStatisticsService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -39,6 +42,11 @@ class QuoteServiceTest {
   @Mock private QuoteRepository quoteRepository;
   @Mock private MemberRepository memberRepository;
   @Mock private DailyLimitService dailyLimitService;
+
+  @Mock private QuoteLanguageValidator quoteLanguageValidator;
+  @Mock private QuoteProfileCalculator quoteProfileCalculator;
+  @Mock private DifficultySeedCalculator difficultySeedCalculator;
+  @Mock private GlobalQuoteStatisticsService globalQuoteStatisticsService;
 
   @InjectMocks private QuoteService quoteService;
 
@@ -59,7 +67,7 @@ class QuoteServiceTest {
   }
 
   private Quote createQuote(Member member, QuoteType type, QuoteStatus status) {
-    Quote quote = Quote.create(member, "테스트 문장입니다.", "저자", type, QuoteLanguage.KOREAN, 0f);
+    Quote quote = Quote.create(member, "테스트 문장입니다.", "저자", type, QuoteLanguage.KOREAN, null, 0f);
     if (type == QuoteType.PUBLIC && status == QuoteStatus.ACTIVE) {
       quote.approvePublish();
     }
@@ -68,8 +76,9 @@ class QuoteServiceTest {
   }
 
   private QuoteCreateQuery createCreateQuery(QuoteType type) {
-    QuoteCreateRequest request = QuoteCreateRequest.create("테스트 문장입니다.", "저자");
-    return QuoteCreateQuery.from(request, type);
+    QuoteCreateRequest request =
+        QuoteCreateRequest.create("테스트 문장입니다.", "저자", QuoteLanguage.KOREAN);
+    return QuoteCreateQuery.from(request, type, QuoteLanguage.KOREAN);
   }
 
   private QuoteUpdateQuery createUpdateQuery(String sentence, String author) {
@@ -126,6 +135,11 @@ class QuoteServiceTest {
 
       when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
       when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(true);
+      when(quoteProfileCalculator.calculate(anyString(), any(QuoteLanguage.class)))
+          .thenReturn(QuoteProfile.create());
+      when(globalQuoteStatisticsService.getByLanguage(any(QuoteLanguage.class)))
+          .thenReturn(GlobalQuoteStatistics.createKoreanDefault());
+      when(difficultySeedCalculator.calculate(any(), any(), any())).thenReturn(0f);
 
       // when
       Quote result = quoteService.create(1L, query);
@@ -134,7 +148,6 @@ class QuoteServiceTest {
       assertThat(result.getType()).isEqualTo(QuoteType.PRIVATE);
       assertThat(result.getStatus()).isEqualTo(QuoteStatus.ACTIVE);
       verify(quoteRepository).save(any(Quote.class));
-      // verify(dailyLimitService).incrementQuoteUploadCount(1L);
     }
 
     @Test
@@ -146,6 +159,11 @@ class QuoteServiceTest {
 
       when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
       when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(true);
+      when(quoteProfileCalculator.calculate(anyString(), any(QuoteLanguage.class)))
+          .thenReturn(QuoteProfile.create());
+      when(globalQuoteStatisticsService.getByLanguage(any(QuoteLanguage.class)))
+          .thenReturn(GlobalQuoteStatistics.createKoreanDefault());
+      when(difficultySeedCalculator.calculate(any(), any(), any())).thenReturn(0f);
 
       // when
       Quote result = quoteService.create(1L, query);

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/report/AdminReportE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/report/AdminReportE2ETest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 
 import com.typingpractice.typing_practice_be.BaseE2ETest;
 import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteCreateRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteResponse;
 import com.typingpractice.typing_practice_be.report.domain.ReportReason;
@@ -31,7 +32,8 @@ public class AdminReportE2ETest extends BaseE2ETest {
     String userToken = getAccessToken(USER_PROVIDER_ID);
     HttpHeaders userHeaders = createAuthHeader(userToken);
 
-    QuoteCreateRequest request = QuoteCreateRequest.create("신고 테스트용 문장", null);
+    QuoteCreateRequest request =
+        QuoteCreateRequest.create("신고 테스트용 문장", null, QuoteLanguage.KOREAN);
     ResponseEntity<ApiResponse<QuoteResponse>> createResponse =
         restTemplate.exchange(
             "/quotes/public",

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/report/ReportE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/report/ReportE2ETest.java
@@ -7,6 +7,7 @@ import com.typingpractice.typing_practice_be.auth.dto.LoginResponse;
 import com.typingpractice.typing_practice_be.auth.dto.TestLoginRequest;
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.member.dto.admin.MemberBanRequest;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteCreateRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteResponse;
 import com.typingpractice.typing_practice_be.report.domain.ReportReason;
@@ -30,7 +31,8 @@ public class ReportE2ETest extends BaseE2ETest {
     String userToken = getAccessToken(USER_PROVIDER_ID);
     HttpHeaders userHeaders = createAuthHeader(userToken);
 
-    QuoteCreateRequest request = QuoteCreateRequest.create("신고 테스트용 문장입니다.", null);
+    QuoteCreateRequest request =
+        QuoteCreateRequest.create("신고 테스트용 문장입니다.", null, QuoteLanguage.KOREAN);
     ResponseEntity<ApiResponse<QuoteResponse>> createResponse =
         restTemplate.exchange(
             "/quotes/public",

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/report/service/AdminReportServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/report/service/AdminReportServiceTest.java
@@ -9,6 +9,7 @@ import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
@@ -58,7 +59,9 @@ class AdminReportServiceTest {
   }
 
   private Quote createQuote() {
-    Quote quote = Quote.create(createMember(99L), "테스트 문장", "저자", QuoteType.PUBLIC);
+    Quote quote =
+        Quote.create(
+            createMember(99L), "테스트 문장", "저자", QuoteType.PUBLIC, QuoteLanguage.KOREAN, null, 0f);
     quote.approvePublish();
     return quote;
   }

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/report/service/ReportServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/report/service/ReportServiceTest.java
@@ -11,6 +11,7 @@ import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
@@ -65,7 +66,8 @@ class ReportServiceTest {
   }
 
   private Quote createQuote(QuoteType type, QuoteStatus status) {
-    Quote quote = Quote.create(createMember(99L), "테스트 문장", "저자", type);
+    Quote quote =
+        Quote.create(createMember(99L), "테스트 문장", "저자", type, QuoteLanguage.KOREAN, null, 0f);
     if (type == QuoteType.PUBLIC && status == QuoteStatus.ACTIVE) {
       quote.approvePublish();
     }


### PR DESCRIPTION
- QuoteProfileCalculator: 한국어(자모 복잡도, 겹모음, Shift 자모) / 영어(대소문자 전환, 단어 길이) 입력 변수 계산 구현
- DifficultySeedCalculator: z점수 기반 가중합 난이도 계산 구현 (clip 0~1, σ=0 처리)
- GlobalQuoteStatisticsService: TransactionTemplate으로 초기화 + 메모리 캐싱
- GlobalQuoteStatisticsRepository: EntityManager 기반 save, findTop, count 구현
- QuoteService.create()에 seed 값 전달 수정 (0f → seed)
- QuoteProfile에 create() 팩토리 메서드, @ToString 추가
- QuoteProfileCalculatorTest, DifficultySeedCalculatorTest 단위 테스트 추가
- Quote.create() 시그니처 변경에 따른 기존 테스트 전체 수정