### PR TITLE
feat: 전역 통계 배치 + 수동 트리거 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -92,6 +92,15 @@ public class Quote extends BaseEntity {
     this.type = quoteType;
   }
 
+  public void updateProfile(QuoteProfile profile) {
+    this.profile = profile;
+  }
+
+  public void updateDifficulty(float seed) {
+    this.profile.setDifficultySeed(seed);
+    this.difficulty = seed;
+  }
+
   public void updateStatus(QuoteStatus quoteStatus) {
     this.status = quoteStatus;
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.quote.repository;
 
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
 import com.typingpractice.typing_practice_be.quote.query.PublicQuoteQuery;
@@ -18,103 +19,103 @@ import org.springframework.stereotype.Repository;
 @Repository
 @RequiredArgsConstructor
 public class QuoteRepository {
-	private final EntityManager em;
+  private final EntityManager em;
 
-	public void save(Quote quote) {
-		em.persist(quote);
-	}
+  public void save(Quote quote) {
+    em.persist(quote);
+  }
 
-	public Optional<Quote> findById(Long quoteId) {
-		return em.createQuery(
-										"select q from Quote q join fetch q.member m where q.id = :quoteId", Quote.class)
-						.setParameter("quoteId", quoteId)
-						.setMaxResults(1)
-						.getResultStream()
-						.findFirst();
+  public Optional<Quote> findById(Long quoteId) {
+    return em.createQuery(
+            "select q from Quote q join fetch q.member m where q.id = :quoteId", Quote.class)
+        .setParameter("quoteId", quoteId)
+        .setMaxResults(1)
+        .getResultStream()
+        .findFirst();
 
-		// return Optional.ofNullable(em.find(Quote.class, quoteId));
-	}
+    // return Optional.ofNullable(em.find(Quote.class, quoteId));
+  }
 
-	public List<Quote> findAll(QuotePaginationQuery query) {
-		int page = query.getPage();
-		int size = query.getSize();
+  public List<Quote> findAll(QuotePaginationQuery query) {
+    int page = query.getPage();
+    int size = query.getSize();
 
-		String jpql = "select q from Quote q";
+    String jpql = "select q from Quote q";
 
-		if (query.getStatus() != null && query.getType() != null) {
-			jpql += " where q.status = :status and q.type = :type";
-		} else if (query.getStatus() != null) {
-			jpql += " where q.status = :status";
-		} else if (query.getType() != null) {
-			jpql += " where q.type = :type";
-		}
+    if (query.getStatus() != null && query.getType() != null) {
+      jpql += " where q.status = :status and q.type = :type";
+    } else if (query.getStatus() != null) {
+      jpql += " where q.status = :status";
+    } else if (query.getType() != null) {
+      jpql += " where q.type = :type";
+    }
 
-		jpql += " order by q." + query.getOrderBy() + " " + query.getSortDirection();
+    jpql += " order by q." + query.getOrderBy() + " " + query.getSortDirection();
 
-		TypedQuery<Quote> typedQuery =
-						em.createQuery(jpql, Quote.class).setFirstResult((page - 1) * size).setMaxResults(size + 1);
+    TypedQuery<Quote> typedQuery =
+        em.createQuery(jpql, Quote.class).setFirstResult((page - 1) * size).setMaxResults(size + 1);
 
-		if (query.getStatus() != null) {
-			typedQuery.setParameter("status", query.getStatus());
-		}
+    if (query.getStatus() != null) {
+      typedQuery.setParameter("status", query.getStatus());
+    }
 
-		if (query.getType() != null) {
-			typedQuery.setParameter("type", query.getType());
-		}
+    if (query.getType() != null) {
+      typedQuery.setParameter("type", query.getType());
+    }
 
-		return typedQuery.getResultList();
-	}
+    return typedQuery.getResultList();
+  }
 
-	public List<Quote> findPublicQuotes(PublicQuoteQuery query) {
-		// 랜덤 순서
-		em.createNativeQuery("SELECT SETSEED(:seed)")
-						.setParameter("seed", query.getSeed())
-						.getSingleResult();
+  public List<Quote> findPublicQuotes(PublicQuoteQuery query) {
+    // 랜덤 순서
+    em.createNativeQuery("SELECT SETSEED(:seed)")
+        .setParameter("seed", query.getSeed())
+        .getSingleResult();
 
-		// 내 문장만 조회
-		if (query.getOnlyMyQuotes() && query.getMemberId() != null) {
-			String jpql = "select q from Quote q where q.member.id = :memberId and q.status !=:status";
+    // 내 문장만 조회
+    if (query.getOnlyMyQuotes() && query.getMemberId() != null) {
+      String jpql = "select q from Quote q where q.member.id = :memberId and q.status !=:status";
 
-			// 랜덤 순서
-			jpql += " order by function('RANDOM')";
+      // 랜덤 순서
+      jpql += " order by function('RANDOM')";
 
-			TypedQuery<Quote> typedQuery =
-							em.createQuery(jpql, Quote.class)
-											.setParameter("memberId", query.getMemberId())
-											.setParameter("status", QuoteStatus.HIDDEN)
-											.setFirstResult((query.getPage() - 1) * query.getCount())
-											.setMaxResults(query.getCount() + 1);
-			return typedQuery.getResultList();
-		} else {
-			// 전체 문장 조회
-			String jpql = "select q from Quote q where (q.status = :status and q.type = :type)";
+      TypedQuery<Quote> typedQuery =
+          em.createQuery(jpql, Quote.class)
+              .setParameter("memberId", query.getMemberId())
+              .setParameter("status", QuoteStatus.HIDDEN)
+              .setFirstResult((query.getPage() - 1) * query.getCount())
+              .setMaxResults(query.getCount() + 1);
+      return typedQuery.getResultList();
+    } else {
+      // 전체 문장 조회
+      String jpql = "select q from Quote q where (q.status = :status and q.type = :type)";
 
-			if (query.getMemberId() != null) {
-				jpql += " or (q.member.id = :memberId and q.status != :hiddenStatus)";
-				// jpql += " or (q.member.id = :memberId and q.status = :myQuoteStatus and q.type =
-				// :myQuoteType)";
-			}
+      if (query.getMemberId() != null) {
+        jpql += " or (q.member.id = :memberId and q.status != :hiddenStatus)";
+        // jpql += " or (q.member.id = :memberId and q.status = :myQuoteStatus and q.type =
+        // :myQuoteType)";
+      }
 
-			// 랜덤 순서
-			jpql += " order by function('RANDOM')";
+      // 랜덤 순서
+      jpql += " order by function('RANDOM')";
 
-			TypedQuery<Quote> typedQuery =
-							em.createQuery(jpql, Quote.class)
-											.setParameter("status", QuoteStatus.ACTIVE)
-											.setParameter("type", QuoteType.PUBLIC)
-											.setFirstResult((query.getPage() - 1) * query.getCount())
-											.setMaxResults(query.getCount() + 1);
+      TypedQuery<Quote> typedQuery =
+          em.createQuery(jpql, Quote.class)
+              .setParameter("status", QuoteStatus.ACTIVE)
+              .setParameter("type", QuoteType.PUBLIC)
+              .setFirstResult((query.getPage() - 1) * query.getCount())
+              .setMaxResults(query.getCount() + 1);
 
-			if (query.getMemberId() != null) {
-				typedQuery
-								.setParameter("memberId", query.getMemberId())
-								.setParameter("hiddenStatus", QuoteStatus.HIDDEN);
-				// .setParameter("myQuoteType", QuoteType.PRIVATE);
-			}
+      if (query.getMemberId() != null) {
+        typedQuery
+            .setParameter("memberId", query.getMemberId())
+            .setParameter("hiddenStatus", QuoteStatus.HIDDEN);
+        // .setParameter("myQuoteType", QuoteType.PRIVATE);
+      }
 
-			return typedQuery.getResultList();
-		}
-	}
+      return typedQuery.getResultList();
+    }
+  }
 
   /*public List<Quote> findByStatus(QuoteStatus quoteStatus) {
     return em.createQuery("select q from Quote q where q.status = :status", Quote.class)
@@ -122,38 +123,56 @@ public class QuoteRepository {
         .getResultList();
   }*/
 
-	public void deleteQuote(Quote quote) {
-		em.remove(quote);
-	}
+  public void deleteQuote(Quote quote) {
+    em.remove(quote);
+  }
 
-	public List<Quote> findByMember(Member member, QuotePaginationQuery query) {
-		int page = query.getPage();
-		int size = query.getSize();
+  public List<Quote> findByMember(Member member, QuotePaginationQuery query) {
+    int page = query.getPage();
+    int size = query.getSize();
 
-		String jpql = "select q from Quote q join q.member m where m.id = :memberId";
+    String jpql = "select q from Quote q join q.member m where m.id = :memberId";
 
-		if (query.getStatus() != null && query.getType() != null) {
-			jpql += " and q.status = :status and q.type = :type";
-		} else if (query.getStatus() != null) {
-			jpql += " and q.status = :status";
-		} else if (query.getType() != null) {
-			jpql += " and q.type = :type";
-		}
+    if (query.getStatus() != null && query.getType() != null) {
+      jpql += " and q.status = :status and q.type = :type";
+    } else if (query.getStatus() != null) {
+      jpql += " and q.status = :status";
+    } else if (query.getType() != null) {
+      jpql += " and q.type = :type";
+    }
 
-		jpql += " order by q." + query.getOrderBy() + " " + query.getSortDirection();
+    jpql += " order by q." + query.getOrderBy() + " " + query.getSortDirection();
 
-		TypedQuery<Quote> typedQuery =
-						em.createQuery(jpql, Quote.class).setFirstResult((page - 1) * size).setMaxResults(size + 1);
-		typedQuery.setParameter("memberId", member.getId());
+    TypedQuery<Quote> typedQuery =
+        em.createQuery(jpql, Quote.class).setFirstResult((page - 1) * size).setMaxResults(size + 1);
+    typedQuery.setParameter("memberId", member.getId());
 
-		if (query.getStatus() != null) {
-			typedQuery.setParameter("status", query.getStatus());
-		}
+    if (query.getStatus() != null) {
+      typedQuery.setParameter("status", query.getStatus());
+    }
 
-		if (query.getType() != null) {
-			typedQuery.setParameter("type", query.getType());
-		}
+    if (query.getType() != null) {
+      typedQuery.setParameter("type", query.getType());
+    }
 
-		return typedQuery.getResultList();
-	}
+    return typedQuery.getResultList();
+  }
+
+  public Long findMaxIdByLanguage(QuoteLanguage language) {
+    return em.createQuery("select max(q.id) from Quote q where q.language = :language", Long.class)
+        .setParameter("language", language)
+        .getSingleResult();
+  }
+
+  public List<Quote> findPageByLanguageAndIdRange(
+      QuoteLanguage language, Long cursorId, Long maxId, int size) {
+    return em.createQuery(
+            "select q from Quote q where q.language = :language and q.id > :cursorId and q.id <= :maxId order by q.id ASC",
+            Quote.class)
+        .setParameter("language", language)
+        .setParameter("cursorId", cursorId)
+        .setParameter("maxId", maxId)
+        .setMaxResults(size)
+        .getResultList();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
@@ -1,0 +1,21 @@
+package com.typingpractice.typing_practice_be.statistics.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.statistics.service.StatisticsBatchService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/stats")
+public class AdminStatisticsController {
+  private final StatisticsBatchService batchService;
+
+  @PostMapping("/recalculate")
+  public ApiResponse<Void> recalculate() {
+    batchService.runManualRecalculation();
+    return ApiResponse.ok(null);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/domain/GlobalQuoteStatistics.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/domain/GlobalQuoteStatistics.java
@@ -6,11 +6,13 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
+@ToString
 @SQLRestriction("deleted = false")
 @SQLDelete(
     sql =
@@ -104,4 +106,44 @@ public class GlobalQuoteStatistics extends BaseEntity {
 
     return stats;
   }
+
+  public static GlobalQuoteStatistics createFromAggregation(QuoteLanguage language, Object[] row) {
+    GlobalQuoteStatistics stats = new GlobalQuoteStatistics();
+    stats.language = language;
+
+    stats.lenMean = toFloat(row[0]);
+    stats.lenStd = toFloat(row[1]);
+    stats.puncMean = toFloat(row[2]);
+    stats.puncStd = toFloat(row[3]);
+    stats.spaceMean = toFloat(row[4]);
+    stats.spaceStd = toFloat(row[5]);
+    stats.digitMean = toFloat(row[6]);
+    stats.digitStd = toFloat(row[7]);
+
+    if (language == QuoteLanguage.KOREAN) {
+      stats.jamoMean = toFloat(row[8]);
+      stats.jamoStd = toFloat(row[9]);
+      stats.diphthongMean = toFloat(row[10]);
+      stats.diphthongStd = toFloat(row[11]);
+      stats.shiftJamoMean = toFloat(row[12]);
+      stats.shiftJamoStd = toFloat(row[13]);
+    } else {
+      stats.caseMean = toFloat(row[14]);
+      stats.caseStd = toFloat(row[15]);
+      stats.wordLenMean = toFloat(row[16]);
+      stats.wordLenStd = toFloat(row[17]);
+    }
+
+    return stats;
+  }
+
+  private static float toFloat(Object value) {
+    if (value == null) return 0f;
+    return ((Number) value).floatValue();
+  }
+
+  /*private static Float toFloatOrNull(Object value) {
+    if (value == null) return null;
+    return ((Number) value).floatValue();
+  }*/
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/repository/GlobalQuoteStatisticsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/repository/GlobalQuoteStatisticsRepository.java
@@ -35,4 +35,25 @@ public class GlobalQuoteStatisticsRepository {
     return em.createQuery("select count(s) from GlobalQuoteStatistics  s", Long.class)
         .getSingleResult();
   }
+
+  public Object[] aggregateByLanguage(QuoteLanguage language) {
+    return (Object[])
+        em.createNativeQuery(
+                """
+								SELECT
+										COALESCE(AVG(length), 0), COALESCE(STDDEV_POP(length), 0),
+										COALESCE(AVG(punc_rate), 0), COALESCE(STDDEV_POP(punc_rate), 0),
+										COALESCE(AVG(space_rate), 0), COALESCE(STDDEV_POP(space_rate), 0),
+										COALESCE(AVG(digit_rate), 0), COALESCE(STDDEV_POP(digit_rate), 0),
+										COALESCE(AVG(jamo_complex), 0), COALESCE(STDDEV_POP(jamo_complex), 0),
+										COALESCE(AVG(diphthong_rate), 0), COALESCE(STDDEV_POP(diphthong_rate), 0),
+										COALESCE(AVG(shift_jamo_rate), 0), COALESCE(STDDEV_POP(shift_jamo_rate), 0),
+										COALESCE(AVG(case_flip_rate), 0), COALESCE(STDDEV_POP(case_flip_rate), 0),
+										COALESCE(AVG(avg_word_len), 0), COALESCE(STDDEV_POP(avg_word_len), 0)
+								FROM quote
+								WHERE language = :language AND deleted = false
+								""")
+            .setParameter("language", language.name())
+            .getSingleResult();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
@@ -1,0 +1,21 @@
+package com.typingpractice.typing_practice_be.statistics.scheduler;
+
+import com.typingpractice.typing_practice_be.statistics.service.StatisticsBatchService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StatisticsScheduler {
+  private final StatisticsBatchService batchService;
+
+  @Scheduled(cron = "0 0 3 * * *")
+  public void runDailyBatch() {
+    log.info("전역 통계 배치 시작");
+    batchService.runScheduledBatch();
+    log.info("전역 통계 배치 완료");
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/GlobalQuoteStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/GlobalQuoteStatisticsService.java
@@ -10,10 +10,12 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.transaction.support.TransactionTemplate;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -31,6 +33,7 @@ public class GlobalQuoteStatisticsService {
           if (globalQuoteStatisticsRepository.count() == 0) {
             globalQuoteStatisticsRepository.save(GlobalQuoteStatistics.createKoreanDefault());
             globalQuoteStatisticsRepository.save(GlobalQuoteStatistics.createEnglishDefault());
+            log.info("전역 통계 초기값 생성");
           }
 
           cache =
@@ -41,11 +44,16 @@ public class GlobalQuoteStatisticsService {
                   .collect(
                       Collectors.toMap(GlobalQuoteStatistics::getLanguage, Function.identity()));
 
+          log.info("전역 통계 캐시 로드 완료 — keys={}", cache.keySet());
           return null;
         });
   }
 
   public GlobalQuoteStatistics getByLanguage(QuoteLanguage language) {
+    log.info(
+        "getByLanguage 호출 - language={}, cache keys={}",
+        language,
+        cache != null ? cache.keySet() : "null");
     return cache.get(language);
   }
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/StatisticsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/StatisticsBatchService.java
@@ -1,0 +1,132 @@
+package com.typingpractice.typing_practice_be.statistics.service;
+
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteProfile;
+import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
+import com.typingpractice.typing_practice_be.quote.service.DifficultySeedCalculator;
+import com.typingpractice.typing_practice_be.quote.service.QuoteProfileCalculator;
+import com.typingpractice.typing_practice_be.statistics.domain.GlobalQuoteStatistics;
+import com.typingpractice.typing_practice_be.statistics.repository.GlobalQuoteStatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StatisticsBatchService {
+  private final GlobalQuoteStatisticsRepository statsRepository;
+  private final GlobalQuoteStatisticsService statsService;
+  private final QuoteRepository quoteRepository;
+  private final DifficultySeedCalculator seedCalculator;
+  private final QuoteProfileCalculator quoteProfileCalculator;
+
+  private static final float CHANGE_THRESHOLD = 0.05f;
+  private static final int PAGE_SIZE = 100;
+
+  @Transactional
+  public void runScheduledBatch() {
+    for (QuoteLanguage lang : QuoteLanguage.values()) {
+      GlobalQuoteStatistics prev = statsService.getByLanguage(lang);
+      GlobalQuoteStatistics next = recalculateStats(lang);
+
+      if (shouldRecalculateSeeds(prev, next, lang)) {
+        log.info("[{}] 변화율 임계값 초과 -> seed 재계산 시작", lang);
+        recalculateAllSeeds(lang, next);
+      } else {
+        log.info("[{}] 변화율 임계값 미달 -> seed 재계산 스킵", lang);
+      }
+    }
+
+    statsService.refreshCache();
+  }
+
+  @Transactional
+  public void runManualRecalculation() {
+    for (QuoteLanguage lang : QuoteLanguage.values()) {
+      GlobalQuoteStatistics next = recalculateStats(lang);
+      log.info("[{}] 수동 트리거 -> seed 재계산 시작", lang);
+      recalculateAllSeeds(lang, next);
+    }
+
+    statsService.refreshCache();
+  }
+
+  private GlobalQuoteStatistics recalculateStats(QuoteLanguage lang) {
+    Object[] row = statsRepository.aggregateByLanguage(lang);
+    GlobalQuoteStatistics next = GlobalQuoteStatistics.createFromAggregation(lang, row);
+    statsRepository.save(next);
+    log.info(
+        "[{}] 전역 통계 재계산 완료 - lenMean = {}, puncMean = {}",
+        lang,
+        next.getLenMean(),
+        next.getPuncMean());
+
+    return next;
+  }
+
+  private boolean shouldRecalculateSeeds(
+      GlobalQuoteStatistics prev, GlobalQuoteStatistics next, QuoteLanguage lang) {
+    if (prev == null) return true;
+
+    // 공통 μ 비교
+    if (exceedsThreshold(prev.getLenMean(), next.getLenMean())) return true;
+    if (exceedsThreshold(prev.getPuncMean(), next.getPuncMean())) return true;
+    if (exceedsThreshold(prev.getSpaceMean(), next.getSpaceMean())) return true;
+    if (exceedsThreshold(prev.getDigitMean(), next.getDigitMean())) return true;
+
+    // 언어 전용 μ 비교
+    if (lang == QuoteLanguage.KOREAN) {
+      if (exceedsThreshold(prev.getJamoMean(), next.getJamoMean())) return true;
+      if (exceedsThreshold(prev.getDiphthongMean(), next.getDiphthongMean())) return true;
+      if (exceedsThreshold(prev.getShiftJamoMean(), next.getShiftJamoMean())) return true;
+    } else {
+      if (exceedsThreshold(prev.getCaseMean(), next.getCaseMean())) return true;
+      if (exceedsThreshold(prev.getWordLenMean(), next.getWordLenMean())) return true;
+    }
+
+    return false;
+  }
+
+  private boolean exceedsThreshold(Float prev, Float next) {
+    if (prev == null || next == null) return prev != next;
+    if (prev == 0f) return next != 0f;
+    return Math.abs(next - prev) / Math.abs(prev) > CHANGE_THRESHOLD;
+  }
+
+  private void recalculateAllSeeds(QuoteLanguage lang, GlobalQuoteStatistics stats) {
+    Long maxId = quoteRepository.findMaxIdByLanguage(lang);
+    if (maxId == null) return;
+
+    Long cursor = 0L;
+    int totalUpdated = 0;
+
+    while (true) {
+      List<Quote> quotes =
+          quoteRepository.findPageByLanguageAndIdRange(lang, cursor, maxId, PAGE_SIZE);
+      if (quotes.isEmpty()) break;
+
+      for (Quote quote : quotes) {
+        if (quote.getProfile() == null) {
+          QuoteProfile profile =
+              quoteProfileCalculator.calculate(quote.getSentence(), quote.getLanguage());
+
+          quote.updateProfile(profile);
+        }
+
+        float seed = seedCalculator.calculate(quote.getProfile(), stats, lang);
+        quote.updateDifficulty(seed);
+      }
+
+      totalUpdated += quotes.size();
+      cursor = quotes.getLast().getId();
+    }
+
+    log.info("[{}] seed 재계산 완료 - {}건 갱신", lang, totalUpdated);
+  }
+}


### PR DESCRIPTION
- StatisticsBatchService: 전역 통계(μ/σ) SQL 집계 재계산, 변화율 5% 임계값 기반 seed 재계산 트리거, 100건 단위 커서 페이징
- AdminStatisticsController: POST /admin/stats/recalculate 수동 트리거 API
- StatisticsScheduler: 매일 새벽 3시 자동 배치 (@Scheduled)
- GlobalQuoteStatistics: createFromAggregation() 팩토리 메서드 추가, COALESCE로 null→0 처리
- GlobalQuoteStatisticsRepository: aggregateByLanguage() 네이티브 쿼리 (AVG/STDDEV_POP)
- QuoteRepository: findMaxIdByLanguage(), findPageByLanguageAndIdRange() 추가
- Quote: updateDifficulty(), updateProfile() 메서드 추가
- profile이 null인 기존 문장은 배치 시 자동 생성 후 seed 계산