### PR TITLE
feat: 유사도 reject 로깅 + 어드민 조회 + 언어별 임계값

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/config/SimilarityThresholdProperties.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/config/SimilarityThresholdProperties.java
@@ -1,0 +1,19 @@
+package com.typingpractice.typing_practice_be.quote.config;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "quote.similarity-threshold")
+public class SimilarityThresholdProperties {
+  private final float korean;
+  private final float english;
+
+  public SimilarityThresholdProperties(float korean, float english) {
+    this.korean = korean;
+    this.english = english;
+  }
+
+  public float getByLanguage(QuoteLanguage language) {
+    return language == QuoteLanguage.KOREAN ? korean : english;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/controller/AdminSimilarityRejectController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/controller/AdminSimilarityRejectController.java
@@ -1,0 +1,57 @@
+package com.typingpractice.typing_practice_be.quote.reject.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.dto.PageResult;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.reject.domain.QuoteSimilarityRejectLog;
+import com.typingpractice.typing_practice_be.quote.reject.dto.RejectSummaryResponse;
+import com.typingpractice.typing_practice_be.quote.reject.repository.QuoteSimilarityRejectLogRepository;
+import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/admin/stats/similarity-rejects")
+@RequiredArgsConstructor
+public class AdminSimilarityRejectController {
+  private final QuoteSimilarityRejectLogRepository rejectLogRepository;
+  private final QuoteRepository quoteRepository;
+
+  @GetMapping
+  public ApiResponse<PageResult<QuoteSimilarityRejectLog>> getRejects(
+      @RequestParam QuoteLanguage language,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
+      @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "50") int size) {
+    List<QuoteSimilarityRejectLog> logs =
+        rejectLogRepository.findByPeriod(language, from, to, page, size);
+
+    boolean hasNext = logs.size() > size;
+    List<QuoteSimilarityRejectLog> content = hasNext ? logs.subList(0, size) : logs;
+
+    return ApiResponse.ok(new PageResult<>(content, page, size, hasNext));
+  }
+
+  @GetMapping("/summary")
+  public ApiResponse<RejectSummaryResponse> getSummary(
+      @RequestParam QuoteLanguage language,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to) {
+    long rejectCount = rejectLogRepository.countByPeriod(language, from, to);
+    long uploadCount = quoteRepository.countByPeriod(language, from, to);
+    long totalAttempts = uploadCount + rejectCount;
+    double rejectRate = totalAttempts > 0 ? (double) rejectCount / totalAttempts : 0.0;
+    Double avgSimilarity = rejectLogRepository.avgSimilarityByPeriod(language, from, to);
+
+    return ApiResponse.ok(
+        RejectSummaryResponse.create(
+            rejectCount, totalAttempts, rejectRate, avgSimilarity != null ? avgSimilarity : 0.0));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/domain/QuoteSimilarityRejectLog.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/domain/QuoteSimilarityRejectLog.java
@@ -1,0 +1,48 @@
+package com.typingpractice.typing_practice_be.quote.reject.domain;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuoteSimilarityRejectLog {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private Long memberId;
+
+  @Column(length = 100)
+  private String inputSentence;
+
+  @Column(length = 100)
+  private String similarSentence;
+
+  private float similarity;
+
+  @Enumerated(EnumType.STRING)
+  private QuoteLanguage language;
+
+  private LocalDateTime createdAt;
+
+  public static QuoteSimilarityRejectLog create(
+      Long memberId,
+      String inputSentence,
+      String similarSentence,
+      float similarity,
+      QuoteLanguage language) {
+    QuoteSimilarityRejectLog log = new QuoteSimilarityRejectLog();
+    log.memberId = memberId;
+    log.inputSentence = inputSentence;
+    log.similarSentence = similarSentence;
+    log.similarity = similarity;
+    log.language = language;
+    log.createdAt = LocalDateTime.now();
+    return log;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/dto/RejectSummaryResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/dto/RejectSummaryResponse.java
@@ -1,0 +1,24 @@
+package com.typingpractice.typing_practice_be.quote.reject.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class RejectSummaryResponse {
+  private long rejectCount;
+  private long totalUploadAttempts;
+  private double rejectRate;
+  private double avgSimilarity;
+
+  public static RejectSummaryResponse create(
+      long rejectCount, long totalUploadAttempts, double rejectRate, double avgSimilarity) {
+    RejectSummaryResponse response = new RejectSummaryResponse();
+    response.rejectCount = rejectCount;
+    response.totalUploadAttempts = totalUploadAttempts;
+    response.rejectRate = rejectRate;
+    response.avgSimilarity = avgSimilarity;
+
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/repository/QuoteSimilarityRejectLogRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/repository/QuoteSimilarityRejectLogRepository.java
@@ -1,0 +1,61 @@
+package com.typingpractice.typing_practice_be.quote.reject.repository;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.reject.domain.QuoteSimilarityRejectLog;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class QuoteSimilarityRejectLogRepository {
+  private final EntityManager em;
+
+  public void save(QuoteSimilarityRejectLog log) {
+    em.persist(log);
+  }
+
+  public List<QuoteSimilarityRejectLog> findByPeriod(
+      QuoteLanguage language, LocalDateTime from, LocalDateTime to, int page, int size) {
+    return em.createQuery(
+            "select r from QuoteSimilarityRejectLog r "
+                + "where r.createdAt >= :from and r.createdAt <= :to "
+                + "and r.language = :language "
+                + "order by r.createdAt desc",
+            QuoteSimilarityRejectLog.class)
+        .setParameter("language", language)
+        .setParameter("from", from)
+        .setParameter("to", to)
+        .setFirstResult((page - 1) * size)
+        .setMaxResults(size + 1)
+        .getResultList();
+  }
+
+  public long countByPeriod(QuoteLanguage language, LocalDateTime from, LocalDateTime to) {
+    return em.createQuery(
+            "select count(r) from QuoteSimilarityRejectLog r "
+                + "where r.createdAt >= :from and r.createdAt <= :to "
+                + "and r.language = :language",
+            Long.class)
+        .setParameter("from", from)
+        .setParameter("to", to)
+        .setParameter("language", language)
+        .getSingleResult();
+  }
+
+  public Double avgSimilarityByPeriod(
+      QuoteLanguage language, LocalDateTime from, LocalDateTime to) {
+    return em.createQuery(
+            "select avg(r.similarity) from QuoteSimilarityRejectLog r "
+                + "where r.createdAt >= :from and r.createdAt <= :to "
+                + "and r.language = :language",
+            Double.class)
+        .setParameter("from", from)
+        .setParameter("to", to)
+        .setParameter("language", language)
+        .getSingleResult();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/service/QuoteSimilarityRejectService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/service/QuoteSimilarityRejectService.java
@@ -1,0 +1,29 @@
+package com.typingpractice.typing_practice_be.quote.reject.service;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.reject.domain.QuoteSimilarityRejectLog;
+import com.typingpractice.typing_practice_be.quote.reject.repository.QuoteSimilarityRejectLogRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuoteSimilarityRejectService {
+  private final QuoteSimilarityRejectLogRepository rejectLogRepository;
+
+  @Transactional
+  public void log(
+      Long memberId,
+      String inputSentence,
+      String similarSentence,
+      float similarity,
+      QuoteLanguage language) {
+    QuoteSimilarityRejectLog log =
+        QuoteSimilarityRejectLog.create(
+            memberId, inputSentence, similarSentence, similarity, language);
+
+    rejectLogRepository.save(log);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.quote.repository;
 
 import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.quote.config.SimilarityThresholdProperties;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
@@ -10,6 +11,7 @@ import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,6 +22,8 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class QuoteRepository {
   private final EntityManager em;
+
+  private final SimilarityThresholdProperties thresholdProperties;
 
   public void save(Quote quote) {
     em.persist(quote);
@@ -32,8 +36,6 @@ public class QuoteRepository {
         .setMaxResults(1)
         .getResultStream()
         .findFirst();
-
-    // return Optional.ofNullable(em.find(Quote.class, quoteId));
   }
 
   public List<Quote> findAll(QuotePaginationQuery query) {
@@ -170,8 +172,6 @@ public class QuoteRepository {
     return count > 0;
   }
 
-  private final float SIMILARITY_THRESHOLD = 0.5f;
-
   // 공개 업로드: 내 문장 + 공개 문장
   @SuppressWarnings("unchecked")
   public Optional<Object[]> findMostSimilar(
@@ -186,7 +186,7 @@ public class QuoteRepository {
             .setParameter("sentence", sentence)
             .setParameter("language", language.name())
             .setParameter("memberId", memberId)
-            .setParameter("threshold", SIMILARITY_THRESHOLD)
+            .setParameter("threshold", thresholdProperties.getByLanguage(language))
             .getResultList();
 
     return results.isEmpty() ? Optional.empty() : Optional.of(results.getFirst());
@@ -206,7 +206,7 @@ public class QuoteRepository {
             .setParameter("sentence", sentence)
             .setParameter("language", language.name())
             .setParameter("memberId", memberId)
-            .setParameter("threshold", SIMILARITY_THRESHOLD)
+            .setParameter("threshold", thresholdProperties.getByLanguage(language))
             .getResultList();
 
     return results.isEmpty() ? Optional.empty() : Optional.of(results.getFirst());
@@ -228,7 +228,7 @@ public class QuoteRepository {
             .setParameter("language", language.name())
             .setParameter("memberId", memberId)
             .setParameter("excludeId", excludeId)
-            .setParameter("threshold", SIMILARITY_THRESHOLD)
+            .setParameter("threshold", thresholdProperties.getByLanguage(language))
             .getResultList();
 
     return results.isEmpty() ? Optional.empty() : Optional.of(results.getFirst());
@@ -249,7 +249,7 @@ public class QuoteRepository {
             .setParameter("language", language.name())
             .setParameter("memberId", memberId)
             .setParameter("excludeId", excludeId)
-            .setParameter("threshold", SIMILARITY_THRESHOLD)
+            .setParameter("threshold", thresholdProperties.getByLanguage(language))
             .getResultList();
 
     return results.isEmpty() ? Optional.empty() : Optional.of(results.getFirst());
@@ -306,5 +306,17 @@ public class QuoteRepository {
         .setParameter("maxId", maxId)
         .setMaxResults(size)
         .getResultList();
+  }
+
+  public long countByPeriod(QuoteLanguage language, LocalDateTime from, LocalDateTime to) {
+    return em.createQuery(
+            "select count(q) from Quote q "
+                + "where q.createdAt >= :from and q.createdAt <= :to "
+                + "and q.language = :language",
+            Long.class)
+        .setParameter("from", from)
+        .setParameter("to", to)
+        .setParameter("language", language)
+        .getSingleResult();
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
@@ -12,6 +12,7 @@ import com.typingpractice.typing_practice_be.quote.query.PublicQuoteQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuoteCreateQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuoteUpdateQuery;
+import com.typingpractice.typing_practice_be.quote.reject.service.QuoteSimilarityRejectService;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
 import java.util.List;
 
@@ -30,6 +31,8 @@ public class QuoteService {
   private final QuoteProfileCalculator quoteProfileCalculator;
   private final DifficultySeedCalculator difficultySeedCalculator;
   private final GlobalQuoteStatisticsService globalQuoteStatisticsService;
+
+  private final QuoteSimilarityRejectService rejectService;
 
   private final QuoteRepository quoteRepository;
   private final MemberRepository memberRepository;
@@ -77,7 +80,11 @@ public class QuoteService {
           .findMostSimilar(sentence, language, memberId)
           .ifPresent(
               row -> {
-                throw new QuoteSimilarException((String) row[0], ((Number) row[1]).floatValue());
+                String similar = (String) row[0];
+                float sim = ((Number) row[1]).floatValue();
+                rejectService.log(memberId, sentence, similar, sim, language);
+
+                throw new QuoteSimilarException(similar, sim);
               });
 
     } else if (query.getType() == QuoteType.PRIVATE) {
@@ -93,7 +100,11 @@ public class QuoteService {
           .findMostSimilarInMyQuotes(sentence, language, memberId)
           .ifPresent(
               row -> {
-                throw new QuoteSimilarException((String) row[0], ((Number) row[1]).floatValue());
+                String similar = (String) row[0];
+                float sim = ((Number) row[1]).floatValue();
+                rejectService.log(memberId, sentence, similar, sim, language);
+
+                throw new QuoteSimilarException(similar, sim);
               });
     }
 
@@ -144,7 +155,11 @@ public class QuoteService {
               query.getSentence(), quote.getLanguage(), memberId, quoteId)
           .ifPresent(
               row -> {
-                throw new QuoteSimilarException((String) row[0], ((Number) row[1]).floatValue());
+                String similar = (String) row[0];
+                float sim = ((Number) row[1]).floatValue();
+                rejectService.log(memberId, query.getSentence(), similar, sim, quote.getLanguage());
+
+                throw new QuoteSimilarException(similar, sim);
               });
 
       quote.updateSentenceHash(sentenceHash);
@@ -203,7 +218,11 @@ public class QuoteService {
         .findMostSimilarExcluding(quote.getSentence(), quote.getLanguage(), memberId, quoteId)
         .ifPresent(
             row -> {
-              throw new QuoteSimilarException((String) row[0], ((Number) row[1]).floatValue());
+              String similar = (String) row[0];
+              float sim = ((Number) row[1]).floatValue();
+              rejectService.log(memberId, quote.getSentence(), similar, sim, quote.getLanguage());
+
+              throw new QuoteSimilarException(similar, sim);
             });
 
     quote.updateType(QuoteType.PUBLIC);

--- a/typing-practice-be/src/main/resources/application.yaml
+++ b/typing-practice-be/src/main/resources/application.yaml
@@ -25,3 +25,8 @@ server:
 
 google:
   token-uri: https://oauth2.googleapis.com/token
+
+quote:
+  similarity-threshold:
+    korean: 0.5
+    english: 0.5


### PR DESCRIPTION
- QuoteSimilarityRejectLog: reject 발생 시 입력문장, 유사문장, 유사도, 언어 기록
- QuoteSimilarityRejectService: reject 로깅 서비스
- AdminSimilarityRejectController: reject 목록 조회(페이징, 기간/언어 필터) + 요약(reject 수, 비율, 평균 유사도)
- SimilarityThresholdProperties: 언어별 임계값 yml 관리 (korean/english)
- QuoteRepository: 유사도 임계값을 설정 기반으로 변경, countByPeriod 추가
- QuoteService: reject 로깅을 유사도 검증 4곳에 적용