### PR TITLE
fix: 유사도 reject 로그 트랜잭션 분리 (REQUIRES_NEW)

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/service/QuoteSimilarityRejectService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/service/QuoteSimilarityRejectService.java
@@ -5,6 +5,7 @@ import com.typingpractice.typing_practice_be.quote.reject.domain.QuoteSimilarity
 import com.typingpractice.typing_practice_be.quote.reject.repository.QuoteSimilarityRejectLogRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -13,7 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class QuoteSimilarityRejectService {
   private final QuoteSimilarityRejectLogRepository rejectLogRepository;
 
-  @Transactional
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
   public void log(
       Long memberId,
       String inputSentence,


### PR DESCRIPTION
- QuoteSimilarityRejectService.log()의 트랜잭션 전파를 REQUIRES_NEW로 변경
- 기존: QuoteService와 같은 트랜잭션 참여 → 예외 발생 시 reject 로그도 롤백
- 수정: 별도 트랜잭션으로 분리 → 예외 발생과 무관하게 reject 로그 커밋