### PR TITLE
feat: MongoDB 연동 + TypingRecord 저장

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -62,6 +62,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers("/error")
                     .permitAll()
+                    .requestMatchers(HttpMethod.POST, "/typing-records")
+                    .permitAll()
 
                     // 관리자 전용
                     .requestMatchers("/admin/**")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/controller/TypingRecordController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/controller/TypingRecordController.java
@@ -1,0 +1,36 @@
+package com.typingpractice.typing_practice_be.typingrecord.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.typingrecord.dto.TypingRecordRequest;
+import com.typingpractice.typing_practice_be.typingrecord.query.TypingRecordQuery;
+import com.typingpractice.typing_practice_be.typingrecord.service.TypingRecordService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class TypingRecordController {
+  private final TypingRecordService typingRecordService;
+
+  private Long getMemberIdOrNull() {
+    try {
+      return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  @PostMapping("/typing-records")
+  public ApiResponse<Void> save(@RequestBody @Valid TypingRecordRequest request) {
+    Long memberId = getMemberIdOrNull();
+    TypingRecordQuery query = TypingRecordQuery.from(request);
+
+    typingRecordService.save(memberId, query);
+
+    return ApiResponse.ok(null);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/domain/TypingRecord.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/domain/TypingRecord.java
@@ -1,0 +1,60 @@
+package com.typingpractice.typing_practice_be.typingrecord.domain;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Document(collection = "typingRecord")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TypingRecord {
+  private static final int CPM_UPPER_LIMIT = 1500;
+  private static final float ACCURACY_LOWER_LIMIT = 0.5f;
+
+  @Id private String id;
+
+  private Long memberId;
+  private Long quoteId;
+  private QuoteLanguage language;
+  private int cpm;
+  private float accuracy;
+  private int charLength;
+  private int resetCount;
+  private boolean outlier;
+  private List<Typo> typos;
+  private LocalDateTime completedAt;
+
+  public static TypingRecord create(
+      Long memberId,
+      Long quoteId,
+      QuoteLanguage language,
+      int cpm,
+      float accuracy,
+      int charLength,
+      int resetCount,
+      List<Typo> typos) {
+    TypingRecord record = new TypingRecord();
+
+    record.memberId = memberId;
+    record.quoteId = quoteId;
+    record.language = language;
+    record.cpm = cpm;
+    record.accuracy = accuracy;
+    record.charLength = charLength;
+    record.resetCount = resetCount;
+    record.outlier = cpm > CPM_UPPER_LIMIT || accuracy < ACCURACY_LOWER_LIMIT;
+    record.typos = typos;
+    record.completedAt = LocalDateTime.now();
+    return record;
+  }
+
+  public boolean isLoggedIn() {
+    return memberId != null;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/domain/Typo.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/domain/Typo.java
@@ -1,0 +1,25 @@
+package com.typingpractice.typing_practice_be.typingrecord.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Typo {
+
+  private String expected; // 정답
+  private String actual; // 제출
+  private int position; // 몇번째 글자
+  private TypoType type; // INITIAL, MEDIAL, FINAL, LETTER
+
+  public static Typo create(String expected, String actual, int position, TypoType type) {
+    Typo typo = new Typo();
+    typo.expected = expected;
+    typo.actual = actual;
+    typo.position = position;
+    typo.type = type;
+
+    return typo;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/domain/TypoType.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/domain/TypoType.java
@@ -1,0 +1,8 @@
+package com.typingpractice.typing_practice_be.typingrecord.domain;
+
+public enum TypoType {
+  INITIAL, // 초성
+  MEDIAL, // 중성
+  FINAL, // 종성
+  LETTER // 영어/숫자/기호
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/TypingRecordRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/TypingRecordRequest.java
@@ -1,0 +1,52 @@
+package com.typingpractice.typing_practice_be.typingrecord.dto;
+
+import com.typingpractice.typing_practice_be.typingrecord.domain.Typo;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+public class TypingRecordRequest {
+  @NotNull @Positive private Long quoteId;
+
+  @NotNull @Positive private Integer cpm;
+
+  @NotNull private Float accuracy;
+
+  @NotNull @Positive private Integer charLength;
+
+  @NotNull private Integer resetCount;
+
+  @Valid private List<TypoRequest> typos;
+
+  public static TypingRecordRequest create(
+      Long quoteId,
+      Integer cpm,
+      Float accuracy,
+      Integer charLength,
+      Integer resetCount,
+      List<TypoRequest> typos) {
+    TypingRecordRequest request = new TypingRecordRequest();
+
+    request.quoteId = quoteId;
+    request.cpm = cpm;
+    request.accuracy = accuracy;
+    request.charLength = charLength;
+    request.resetCount = resetCount;
+    request.typos = typos;
+
+    return request;
+  }
+
+  public List<Typo> toTypos() {
+    if (typos == null || typos.isEmpty()) {
+      return List.of();
+    }
+    return typos.stream().map(TypoRequest::toTypo).toList();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/TypoRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/TypoRequest.java
@@ -1,0 +1,35 @@
+package com.typingpractice.typing_practice_be.typingrecord.dto;
+
+import com.typingpractice.typing_practice_be.typingrecord.domain.Typo;
+import com.typingpractice.typing_practice_be.typingrecord.domain.TypoType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class TypoRequest {
+  @NotNull private String expected;
+
+  @NotNull private String actual;
+
+  @NotNull private Integer position;
+
+  @NotNull private TypoType type;
+
+  public static TypoRequest create(
+      String expected, String actual, Integer position, TypoType type) {
+    TypoRequest request = new TypoRequest();
+
+    request.expected = expected;
+    request.actual = actual;
+    request.position = position;
+    request.type = type;
+
+    return request;
+  }
+
+  public Typo toTypo() {
+    return Typo.create(expected, actual, position, type);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/query/TypingRecordQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/query/TypingRecordQuery.java
@@ -1,0 +1,39 @@
+package com.typingpractice.typing_practice_be.typingrecord.query;
+
+import com.typingpractice.typing_practice_be.typingrecord.domain.Typo;
+import com.typingpractice.typing_practice_be.typingrecord.dto.TypingRecordRequest;
+import java.util.List;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class TypingRecordQuery {
+
+  private final Long quoteId;
+  private final int cpm;
+  private final float accuracy;
+  private final int charLength;
+  private final int resetCount;
+  private final List<Typo> typos;
+
+  private TypingRecordQuery(
+      Long quoteId, int cpm, float accuracy, int charLength, int resetCount, List<Typo> typos) {
+    this.quoteId = quoteId;
+    this.cpm = cpm;
+    this.accuracy = accuracy;
+    this.charLength = charLength;
+    this.resetCount = resetCount;
+    this.typos = typos;
+  }
+
+  public static TypingRecordQuery from(TypingRecordRequest request) {
+    return new TypingRecordQuery(
+        request.getQuoteId(),
+        request.getCpm(),
+        request.getAccuracy(),
+        request.getCharLength(),
+        request.getResetCount(),
+        request.toTypos());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
@@ -1,0 +1,16 @@
+package com.typingpractice.typing_practice_be.typingrecord.repository;
+
+import com.typingpractice.typing_practice_be.typingrecord.domain.TypingRecord;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class TypingRecordRepository {
+  private final MongoTemplate mongoTemplate;
+
+  public TypingRecord save(TypingRecord record) {
+    return mongoTemplate.save(record);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/service/TypingRecordService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/service/TypingRecordService.java
@@ -1,0 +1,35 @@
+package com.typingpractice.typing_practice_be.typingrecord.service;
+
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
+import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
+import com.typingpractice.typing_practice_be.typingrecord.domain.TypingRecord;
+import com.typingpractice.typing_practice_be.typingrecord.query.TypingRecordQuery;
+import com.typingpractice.typing_practice_be.typingrecord.repository.TypingRecordRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class TypingRecordService {
+  private final TypingRecordRepository typingRecordRepository;
+  private final QuoteRepository quoteRepository;
+
+  public TypingRecord save(Long memberId, TypingRecordQuery query) {
+    Quote quote =
+        quoteRepository.findById(query.getQuoteId()).orElseThrow(QuoteNotFoundException::new);
+
+    TypingRecord record =
+        TypingRecord.create(
+            memberId,
+            quote.getId(),
+            quote.getLanguage(),
+            query.getCpm(),
+            query.getAccuracy(),
+            query.getCharLength(),
+            query.getResetCount(),
+            query.getTypos());
+
+    return typingRecordRepository.save(record);
+  }
+}


### PR DESCRIPTION
- TypingRecord 도큐먼트 (MongoDB @Document)
  - 이상치 자동 판정 (cpm > 1500 or accuracy < 0.5 → outlier=true)
  - charLength로 타이핑 시점 문장 길이 스냅샷 저장
- Typo 내장 객체 + TypoType enum (INITIAL, MEDIAL, FINAL, LETTER)
- POST /typing-records (permitAll, 비로그인 허용)
- MongoTemplate 기반 TypingRecordRepository