### PR TITLE
feat: QuoteTypingStats 배치 집계 + 어드민 수동 트리거

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.statistics.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsBatchService;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.service.QuoteTypingStatsBatchService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,11 +12,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/admin/stats")
 public class AdminStatisticsController {
-  private final GlobalQuoteStatisticsBatchService batchService;
+  private final GlobalQuoteStatisticsBatchService globalQuoteStatisticsBatchService;
+  private final QuoteTypingStatsBatchService quoteTypingStatsBatchService;
 
-  @PostMapping("/recalculate")
+  @PostMapping("/global-quote/recalculate")
   public ApiResponse<Void> recalculate() {
-    batchService.runManualRecalculation();
+    globalQuoteStatisticsBatchService.runManualRecalculation();
+    return ApiResponse.ok(null);
+  }
+
+  @PostMapping("/quote-typing/recalculate")
+  public ApiResponse<Void> recalculateQuoteTypingStats() {
+    quoteTypingStatsBatchService.runManualRecalculation();
     return ApiResponse.ok(null);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.statistics.scheduler;
 
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsBatchService;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.service.QuoteTypingStatsBatchService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -10,12 +11,14 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class StatisticsScheduler {
-  private final GlobalQuoteStatisticsBatchService batchService;
+  private final GlobalQuoteStatisticsBatchService globalQuoteStatisticsBatchService;
+  private final QuoteTypingStatsBatchService quoteTypingStatsBatchService;
 
   @Scheduled(cron = "0 0 3 * * *")
   public void runDailyBatch() {
     log.info("전역 통계 배치 시작");
-    batchService.runScheduledBatch();
+    quoteTypingStatsBatchService.runScheduledBatch(); // 문장 별 타이핑 통계
+    globalQuoteStatisticsBatchService.runScheduledBatch(); // 전체 문장의 profile 통계
     log.info("전역 통계 배치 완료");
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
@@ -1,9 +1,15 @@
 package com.typingpractice.typing_practice_be.typingrecord.repository;
 
 import com.typingpractice.typing_practice_be.typingrecord.domain.TypingRecord;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.QuoteTypingAggregation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -12,5 +18,63 @@ public class TypingRecordRepository {
 
   public TypingRecord save(TypingRecord record) {
     return mongoTemplate.save(record);
+  }
+
+  public List<QuoteTypingAggregation> aggregateByQuoteIds(List<Long> quoteIds) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(Criteria.where("outlier").is(false).and("quoteId").in(quoteIds)),
+            Aggregation.group("quoteId")
+                .first("language")
+                .as("language")
+                .count()
+                .as("attemptsCount")
+                .avg("cpm")
+                .as("avgCpm")
+                .avg("accuracy")
+                .as("avgAcc")
+                .avg("resetCount")
+                .as("avgResetCount"),
+            Aggregation.project()
+                .and("_id")
+                .as("quoteId")
+                .andInclude("language", "attemptsCount", "avgCpm", "avgAcc", "avgResetCount"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", QuoteTypingAggregation.class)
+        .getMappedResults();
+  }
+
+  public List<QuoteTypingAggregation> aggregateByQuoteIdsBetween(
+      List<Long> quoteIds, LocalDateTime from, LocalDateTime to) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(
+                Criteria.where("outlier")
+                    .is(false)
+                    .and("quoteId")
+                    .in(quoteIds)
+                    .and("completedAt")
+                    .gte(from)
+                    .lt(to)),
+            Aggregation.group("quoteId")
+                .first("language")
+                .as("language")
+                .count()
+                .as("attemptsCount")
+                .avg("cpm")
+                .as("avgCpm")
+                .avg("accuracy")
+                .as("avgAcc")
+                .avg("resetCount")
+                .as("avgResetCount"),
+            Aggregation.project()
+                .and("_id")
+                .as("quoteId")
+                .andInclude("language", "attemptsCount", "avgCpm", "avgAcc", "avgResetCount"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", QuoteTypingAggregation.class)
+        .getMappedResults();
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/QuoteTypingStats.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/QuoteTypingStats.java
@@ -1,0 +1,65 @@
+package com.typingpractice.typing_practice_be.typingrecord.statistics.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuoteTypingStats extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "quote_typing_stats_id")
+  private Long id;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "quote_id", unique = true)
+  private Quote quote;
+
+  @Enumerated(EnumType.STRING)
+  private QuoteLanguage language;
+
+  private int attemptsCount;
+  private float avgCpm;
+  private float avgAcc;
+  private float avgResetCount;
+
+  public static QuoteTypingStats create(
+      Quote quote,
+      QuoteLanguage language,
+      int attemptsCount,
+      float avgCpm,
+      float avgAcc,
+      float avgResetCount) {
+    QuoteTypingStats stats = new QuoteTypingStats();
+    stats.quote = quote;
+    stats.language = language;
+    stats.attemptsCount = attemptsCount;
+    stats.avgCpm = avgCpm;
+    stats.avgAcc = avgAcc;
+    stats.avgResetCount = avgResetCount;
+
+    return stats;
+  }
+
+  public void merge(int newCount, float newAvgCpm, float newAvgAcc, float newAvgResetCount) {
+    int totalCount = this.attemptsCount + newCount;
+    this.avgCpm = (this.avgCpm * this.attemptsCount + newAvgCpm * newCount) / totalCount;
+    this.avgAcc = (this.avgAcc * this.attemptsCount + newAvgAcc * newCount) / totalCount;
+    this.avgResetCount =
+        (this.avgResetCount * this.attemptsCount + newAvgResetCount * newCount) / totalCount;
+    this.attemptsCount = totalCount;
+  }
+
+  public void overwrite(int attemptsCount, float avgCpm, float avgAcc, float avgResetCount) {
+    this.attemptsCount = attemptsCount;
+    this.avgCpm = avgCpm;
+    this.avgAcc = avgAcc;
+    this.avgResetCount = avgResetCount;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/QuoteTypingAggregation.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/QuoteTypingAggregation.java
@@ -1,0 +1,15 @@
+package com.typingpractice.typing_practice_be.typingrecord.statistics.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuoteTypingAggregation {
+  private Long quoteId;
+  private String language;
+  private int attemptsCount;
+  private double avgCpm;
+  private double avgAcc;
+  private double avgResetCount;
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/QuoteTypingStatsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/QuoteTypingStatsRepository.java
@@ -1,0 +1,26 @@
+package com.typingpractice.typing_practice_be.typingrecord.statistics.repository;
+
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.QuoteTypingStats;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class QuoteTypingStatsRepository {
+  private final EntityManager em;
+
+  public void save(QuoteTypingStats stats) {
+    em.persist(stats);
+  }
+
+  public Optional<QuoteTypingStats> findByQuoteId(Long quoteId) {
+    return em.createQuery(
+            "select s from QuoteTypingStats s where s.quote.id = :quoteId", QuoteTypingStats.class)
+        .setParameter("quoteId", quoteId)
+        .getResultStream()
+        .findFirst();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/QuoteTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/QuoteTypingStatsBatchService.java
@@ -1,0 +1,123 @@
+package com.typingpractice.typing_practice_be.typingrecord.statistics.service;
+
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
+import com.typingpractice.typing_practice_be.typingrecord.repository.TypingRecordRepository;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.QuoteTypingStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.QuoteTypingAggregation;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.QuoteTypingStatsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class QuoteTypingStatsBatchService {
+  private final QuoteRepository quoteRepository;
+  private final TypingRecordRepository typingRecordRepository;
+  private final QuoteTypingStatsRepository quoteTypingStatsRepository;
+
+  private static final int PAGE_SIZE = 1000;
+
+  // 스케줄 배치: 전날 하루치 증분 집계
+  @Transactional
+  public void runScheduledBatch() {
+    LocalDateTime from = LocalDate.now().minusDays(1).atStartOfDay();
+    LocalDateTime to = LocalDate.now().minusDays(1).atTime(LocalTime.MAX);
+
+    log.info("QuoteTypingStats 증분 배치 시작 - 범위: {} ~ {}", from, to);
+    int totalProcessed = processPages(from, to, false);
+    log.info("QuoteTypingStats 증분 배치 완료 - {}건 처리", totalProcessed);
+  }
+
+  // 수동 재계산: 전체 덮어쓰기
+  @Transactional
+  public void runManualRecalculation() {
+    log.info("QuoteTypingStats 전체 재계산 시작");
+    int totalProcessed = processPages(null, null, true);
+    log.info("QuoteTypingStats 전체 재계산 완료 - {}건 처리", totalProcessed);
+  }
+
+  private int processPages(LocalDateTime from, LocalDateTime to, boolean overwrite) {
+    int totalProcessed = 0;
+
+    for (QuoteLanguage language : QuoteLanguage.values()) {
+      Long maxId = quoteRepository.findMaxIdByLanguage(language);
+      if (maxId == null) continue; // 해당 언어 문장 없음
+
+      Long cursor = 0L;
+
+      while (true) {
+        List<Quote> quotes =
+            quoteRepository.findPageByLanguageAndIdRange(language, cursor, maxId, PAGE_SIZE);
+        if (quotes.isEmpty()) break; // 전체 문장 처리 완료
+
+        List<Long> quoteIds = quotes.stream().map(Quote::getId).toList();
+
+        // 타이핑 기록 통계값
+        List<QuoteTypingAggregation> aggregations =
+            overwrite
+                ? typingRecordRepository.aggregateByQuoteIds(quoteIds)
+                : typingRecordRepository.aggregateByQuoteIdsBetween(quoteIds, from, to);
+
+        // {quoteId: 타이핑 통계값} map 변환
+        Map<Long, QuoteTypingAggregation> aggMap =
+            aggregations.stream()
+                .collect(Collectors.toMap(QuoteTypingAggregation::getQuoteId, a -> a));
+
+        // Quote 의 타이핑 통계 반영
+        for (Quote quote : quotes) {
+          QuoteTypingAggregation agg = aggMap.get(quote.getId());
+          if (agg == null) continue; // 통계값이 없는 경우
+
+          QuoteTypingStats stats =
+              quoteTypingStatsRepository.findByQuoteId(quote.getId()).orElse(null);
+
+          if (stats == null) {
+            // 기존 타이핑 통계가 없으면 생성
+            stats =
+                QuoteTypingStats.create(
+                    quote,
+                    language,
+                    agg.getAttemptsCount(),
+                    (float) agg.getAvgCpm(),
+                    (float) agg.getAvgAcc(),
+                    (float) agg.getAvgResetCount());
+            quoteTypingStatsRepository.save(stats);
+          } else if (overwrite) {
+            // 덮어쓰기
+            stats.overwrite(
+                agg.getAttemptsCount(),
+                (float) agg.getAvgCpm(),
+                (float) agg.getAvgAcc(),
+                (float) agg.getAvgResetCount());
+          } else {
+            // 업데이트
+            stats.merge(
+                agg.getAttemptsCount(),
+                (float) agg.getAvgCpm(),
+                (float) agg.getAvgAcc(),
+                (float) agg.getAvgResetCount());
+          }
+
+          totalProcessed++;
+        }
+
+        cursor = quotes.getLast().getId();
+      }
+    }
+
+    return totalProcessed;
+  }
+}


### PR DESCRIPTION
- QuoteTypingStats 엔티티 (Quote @OneToOne, 누적 통계)
- QuoteTypingStatsRepository (save, findByQuoteId)
- TypingRecordRepository 집계 메서드 (aggregateByQuoteIds, aggregateByQuoteIdsBetween)
- QuoteTypingStatsBatchService
  - 스케줄 배치: 전날 하루치 증분 집계 (merge)
  - 수동 재계산: 전체 덮어쓰기 (overwrite)
  - Quote 커서 기반 페이징으로 MongoDB 집계
- StatisticsScheduler에 QuoteTypingStats 배치 추가
- AdminStatisticsController 엔드포인트 분리
  - POST /admin/stats/global-quote/recalculate
  - POST /admin/stats/quote-typing/recalculate