### PR TITLE
refactor: QuoteTypingStats에 totalAttemptsCount/validAttemptsCount 분리

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
@@ -2,14 +2,16 @@ package com.typingpractice.typing_practice_be.typingrecord.repository;
 
 import com.typingpractice.typing_practice_be.typingrecord.domain.TypingRecord;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.QuoteTypingAggregation;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.bson.Document;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Repository;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -20,6 +22,20 @@ public class TypingRecordRepository {
     return mongoTemplate.save(record);
   }
 
+  public Map<Long, Integer> countAllByQuoteIds(List<Long> quoteIds) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(Criteria.where("quoteId").in(quoteIds)),
+            Aggregation.group("quoteId").count().as("count"),
+            Aggregation.project().and("_id").as("quoteId").andInclude("count"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", Document.class)
+        .getMappedResults()
+        .stream()
+        .collect(Collectors.toMap(doc -> doc.getLong("quoteId"), doc -> doc.getInteger("count")));
+  }
+
   public List<QuoteTypingAggregation> aggregateByQuoteIds(List<Long> quoteIds) {
     Aggregation aggregation =
         Aggregation.newAggregation(
@@ -28,7 +44,7 @@ public class TypingRecordRepository {
                 .first("language")
                 .as("language")
                 .count()
-                .as("attemptsCount")
+                .as("validAttemptsCount")
                 .avg("cpm")
                 .as("avgCpm")
                 .avg("accuracy")
@@ -38,11 +54,27 @@ public class TypingRecordRepository {
             Aggregation.project()
                 .and("_id")
                 .as("quoteId")
-                .andInclude("language", "attemptsCount", "avgCpm", "avgAcc", "avgResetCount"));
+                .andInclude("language", "validAttemptsCount", "avgCpm", "avgAcc", "avgResetCount"));
 
     return mongoTemplate
         .aggregate(aggregation, "typingRecord", QuoteTypingAggregation.class)
         .getMappedResults();
+  }
+
+  public Map<Long, Integer> countAllByQuoteIdsBetween(
+      List<Long> quoteIds, LocalDateTime from, LocalDateTime to) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(
+                Criteria.where("quoteId").in(quoteIds).and("completedAt").gte(from).lt(to)),
+            Aggregation.group("quoteId").count().as("count"),
+            Aggregation.project().and("_id").as("quoteId").andInclude("count"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", Document.class)
+        .getMappedResults()
+        .stream()
+        .collect(Collectors.toMap(doc -> doc.getLong("quoteId"), doc -> doc.getInteger("count")));
   }
 
   public List<QuoteTypingAggregation> aggregateByQuoteIdsBetween(
@@ -61,7 +93,7 @@ public class TypingRecordRepository {
                 .first("language")
                 .as("language")
                 .count()
-                .as("attemptsCount")
+                .as("validAttemptsCount")
                 .avg("cpm")
                 .as("avgCpm")
                 .avg("accuracy")
@@ -71,7 +103,7 @@ public class TypingRecordRepository {
             Aggregation.project()
                 .and("_id")
                 .as("quoteId")
-                .andInclude("language", "attemptsCount", "avgCpm", "avgAcc", "avgResetCount"));
+                .andInclude("language", "validAttemptsCount", "avgCpm", "avgAcc", "avgResetCount"));
 
     return mongoTemplate
         .aggregate(aggregation, "typingRecord", QuoteTypingAggregation.class)

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/QuoteTypingStats.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/QuoteTypingStats.java
@@ -24,7 +24,8 @@ public class QuoteTypingStats extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private QuoteLanguage language;
 
-  private int attemptsCount;
+  private int totalAttemptsCount;
+  private int validAttemptsCount;
   private float avgCpm;
   private float avgAcc;
   private float avgResetCount;
@@ -32,14 +33,16 @@ public class QuoteTypingStats extends BaseEntity {
   public static QuoteTypingStats create(
       Quote quote,
       QuoteLanguage language,
-      int attemptsCount,
+      int totalAttemptsCount,
+      int validAttemptsCount,
       float avgCpm,
       float avgAcc,
       float avgResetCount) {
     QuoteTypingStats stats = new QuoteTypingStats();
     stats.quote = quote;
     stats.language = language;
-    stats.attemptsCount = attemptsCount;
+    stats.totalAttemptsCount = totalAttemptsCount;
+    stats.validAttemptsCount = validAttemptsCount;
     stats.avgCpm = avgCpm;
     stats.avgAcc = avgAcc;
     stats.avgResetCount = avgResetCount;
@@ -47,17 +50,34 @@ public class QuoteTypingStats extends BaseEntity {
     return stats;
   }
 
-  public void merge(int newCount, float newAvgCpm, float newAvgAcc, float newAvgResetCount) {
-    int totalCount = this.attemptsCount + newCount;
-    this.avgCpm = (this.avgCpm * this.attemptsCount + newAvgCpm * newCount) / totalCount;
-    this.avgAcc = (this.avgAcc * this.attemptsCount + newAvgAcc * newCount) / totalCount;
-    this.avgResetCount =
-        (this.avgResetCount * this.attemptsCount + newAvgResetCount * newCount) / totalCount;
-    this.attemptsCount = totalCount;
+  public void merge(
+      int newTotalCount,
+      int newValidCount,
+      float newAvgCpm,
+      float newAvgAcc,
+      float newAvgResetCount) {
+    int mergedValidCount = this.validAttemptsCount + newValidCount;
+    if (mergedValidCount > 0) {
+      this.avgCpm =
+          (this.avgCpm * this.validAttemptsCount + newAvgCpm * newValidCount) / mergedValidCount;
+      this.avgAcc =
+          (this.avgAcc * this.validAttemptsCount + newAvgAcc * newValidCount) / mergedValidCount;
+      this.avgResetCount =
+          (this.avgResetCount * this.validAttemptsCount + newAvgResetCount * newValidCount)
+              / mergedValidCount;
+    }
+    this.totalAttemptsCount += newTotalCount;
+    this.validAttemptsCount = mergedValidCount;
   }
 
-  public void overwrite(int attemptsCount, float avgCpm, float avgAcc, float avgResetCount) {
-    this.attemptsCount = attemptsCount;
+  public void overwrite(
+      int totalAttemptsCount,
+      int validAttemptsCount,
+      float avgCpm,
+      float avgAcc,
+      float avgResetCount) {
+    this.totalAttemptsCount = totalAttemptsCount;
+    this.validAttemptsCount = validAttemptsCount;
     this.avgCpm = avgCpm;
     this.avgAcc = avgAcc;
     this.avgResetCount = avgResetCount;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/QuoteTypingAggregation.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/QuoteTypingAggregation.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 public class QuoteTypingAggregation {
   private Long quoteId;
   private String language;
-  private int attemptsCount;
+  private int validAttemptsCount;
   private double avgCpm;
   private double avgAcc;
   private double avgResetCount;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/QuoteTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/QuoteTypingStatsBatchService.java
@@ -71,6 +71,11 @@ public class QuoteTypingStatsBatchService {
                 ? typingRecordRepository.aggregateByQuoteIds(quoteIds)
                 : typingRecordRepository.aggregateByQuoteIdsBetween(quoteIds, from, to);
 
+        Map<Long, Integer> totalAttemptsCount =
+            overwrite
+                ? typingRecordRepository.countAllByQuoteIds(quoteIds)
+                : typingRecordRepository.countAllByQuoteIdsBetween(quoteIds, from, to);
+
         // {quoteId: 타이핑 통계값} map 변환
         Map<Long, QuoteTypingAggregation> aggMap =
             aggregations.stream()
@@ -79,6 +84,7 @@ public class QuoteTypingStatsBatchService {
         // Quote 의 타이핑 통계 반영
         for (Quote quote : quotes) {
           QuoteTypingAggregation agg = aggMap.get(quote.getId());
+          Integer totalAttemptCount = totalAttemptsCount.get(quote.getId());
           if (agg == null) continue; // 통계값이 없는 경우
 
           QuoteTypingStats stats =
@@ -90,7 +96,9 @@ public class QuoteTypingStatsBatchService {
                 QuoteTypingStats.create(
                     quote,
                     language,
-                    agg.getAttemptsCount(),
+                    // agg.getTotalAttemptsCount(),
+                    totalAttemptCount,
+                    agg.getValidAttemptsCount(),
                     (float) agg.getAvgCpm(),
                     (float) agg.getAvgAcc(),
                     (float) agg.getAvgResetCount());
@@ -98,14 +106,18 @@ public class QuoteTypingStatsBatchService {
           } else if (overwrite) {
             // 덮어쓰기
             stats.overwrite(
-                agg.getAttemptsCount(),
+                // agg.getTotalAttemptsCount(),
+                totalAttemptCount,
+                agg.getValidAttemptsCount(),
                 (float) agg.getAvgCpm(),
                 (float) agg.getAvgAcc(),
                 (float) agg.getAvgResetCount());
           } else {
             // 업데이트
             stats.merge(
-                agg.getAttemptsCount(),
+                // agg.getTotalAttemptsCount(),
+                totalAttemptCount,
+                agg.getValidAttemptsCount(),
                 (float) agg.getAvgCpm(),
                 (float) agg.getAvgAcc(),
                 (float) agg.getAvgResetCount());


### PR DESCRIPTION
- attemptsCount → totalAttemptsCount + validAttemptsCount 분리
- TypingRecordRepository: 전체 count 쿼리(countAllByQuoteIds) 별도 추가
- 집계 쿼리는 outlier=false만, 전체 count는 별도 쿼리로 처리
- merge, overwrite에 totalCount/validCount 반영
- Between 버전도 동일하게 분리