### PR TITLE
feat: MemberTypingStats 엔티티 + 집계 메서드

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.typingrecord.repository;
 
 import com.typingpractice.typing_practice_be.typingrecord.domain.TypingRecord;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypingAggregation;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.QuoteTypingAggregation;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.bson.Document;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.ArithmeticOperators;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Repository;
 
@@ -107,6 +109,80 @@ public class TypingRecordRepository {
 
     return mongoTemplate
         .aggregate(aggregation, "typingRecord", QuoteTypingAggregation.class)
+        .getMappedResults();
+  }
+
+  public List<MemberTypingAggregation> aggregateByMemberIds(List<Long> memberIds) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(Criteria.where("memberId").in(memberIds)),
+            Aggregation.group("memberId")
+                .count()
+                .as("totalAttempts")
+                .avg("cpm")
+                .as("avgCpm")
+                .avg("accuracy")
+                .as("avgAcc")
+                .max("cpm")
+                .as("bestCpm")
+                .sum(ArithmeticOperators.valueOf("charLength").divideBy("cpm"))
+                .as("totalPracticeTimeMin")
+                .sum("resetCount")
+                .as("totalResetCount")
+                .max("completedAt")
+                .as("lastPracticedAt"),
+            Aggregation.project()
+                .and("_id")
+                .as("memberId")
+                .andInclude(
+                    "totalAttempts",
+                    "avgCpm",
+                    "avgAcc",
+                    "bestCpm",
+                    "totalPracticeTimeMin",
+                    "totalResetCount",
+                    "lastPracticedAt"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", MemberTypingAggregation.class)
+        .getMappedResults();
+  }
+
+  public List<MemberTypingAggregation> aggregateByMemberIdsBetween(
+      List<Long> memberIds, LocalDateTime from, LocalDateTime to) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(
+                Criteria.where("memberId").in(memberIds).and("completedAt").gte(from).lt(to)),
+            Aggregation.group("memberId")
+                .count()
+                .as("totalAttempts")
+                .avg("cpm")
+                .as("avgCpm")
+                .avg("accuracy")
+                .as("avgAcc")
+                .max("cpm")
+                .as("bestCpm")
+                .sum(ArithmeticOperators.valueOf("charLength").divideBy("cpm"))
+                .as("totalPracticeTimeMin")
+                .sum("resetCount")
+                .as("totalResetCount")
+                .max("completedAt")
+                .as("lastPracticedAt"),
+            Aggregation.project()
+                .and("_id")
+                .as("memberId")
+                .andInclude(
+                    "totalAttempts",
+                    "avgCpm",
+                    "avgAcc",
+                    "bestCpm",
+                    "totalPracticeTimeMin",
+                    "totalResetCount",
+                    "lastPracticedAt"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", MemberTypingAggregation.class)
         .getMappedResults();
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberTypingStats.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberTypingStats.java
@@ -1,0 +1,92 @@
+package com.typingpractice.typing_practice_be.typingrecord.statistics.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberTypingStats extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "member_typing_stats_id")
+  private Long id;
+
+  @OneToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", unique = true)
+  private Member member;
+
+  private int totalAttempts;
+  private float avgCpm;
+  private float avgAcc;
+  private int bestCpm;
+  private long totalPracticeTimeMin;
+  private int totalResetCount;
+  private LocalDateTime lastPracticedAt;
+
+  public static MemberTypingStats create(
+      Member member,
+      int totalAttempts,
+      float avgCpm,
+      float avgAcc,
+      int bestCpm,
+      long totalPracticeTimeMin,
+      int totalResetCount,
+      LocalDateTime lastPracticedAt) {
+    MemberTypingStats stats = new MemberTypingStats();
+    stats.member = member;
+    stats.totalAttempts = totalAttempts;
+    stats.avgCpm = avgCpm;
+    stats.avgAcc = avgAcc;
+    stats.bestCpm = bestCpm;
+    stats.totalPracticeTimeMin = totalPracticeTimeMin;
+    stats.totalResetCount = totalResetCount;
+    stats.lastPracticedAt = lastPracticedAt;
+    return stats;
+  }
+
+  public void merge(
+      int newAttempts,
+      float newAvgCpm,
+      float newAvgAcc,
+      int newBestCpm,
+      long newPracticeTimeMin,
+      int newResetCount,
+      LocalDateTime newLastPracticedAt) {
+    int mergedAttempts = this.totalAttempts + newAttempts;
+
+    this.avgCpm = (this.avgCpm * this.totalAttempts + newAvgCpm * newAttempts) / mergedAttempts;
+    this.avgAcc = (this.avgAcc * this.totalAttempts + newAvgAcc * newAttempts) / mergedAttempts;
+    this.totalAttempts = mergedAttempts;
+    this.bestCpm = Math.max(this.bestCpm, newBestCpm);
+    this.totalPracticeTimeMin += newPracticeTimeMin;
+    this.totalResetCount += newResetCount;
+
+    if (this.lastPracticedAt == null || newLastPracticedAt.isAfter(this.lastPracticedAt)) {
+      this.lastPracticedAt = newLastPracticedAt;
+    }
+  }
+
+  public void overwrite(
+      int totalAttempts,
+      float avgCpm,
+      float avgAcc,
+      int bestCpm,
+      long totalPracticeTimeMin,
+      int totalResetCount,
+      LocalDateTime lastPracticedAt) {
+    this.totalAttempts = totalAttempts;
+    this.avgCpm = avgCpm;
+    this.avgAcc = avgAcc;
+    this.bestCpm = bestCpm;
+    this.totalPracticeTimeMin = totalPracticeTimeMin;
+    this.totalResetCount = totalResetCount;
+    this.lastPracticedAt = lastPracticedAt;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/MemberTypingAggregation.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/MemberTypingAggregation.java
@@ -1,0 +1,19 @@
+package com.typingpractice.typing_practice_be.typingrecord.statistics.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class MemberTypingAggregation {
+  private Long memberId;
+  private int totalAttempts;
+  private double avgCpm;
+  private double avgAcc;
+  private int bestCpm;
+  private long totalPracticeTimeMin;
+  private int totalResetCount;
+  private LocalDateTime lastPracticedAt;
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberTypingStatsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberTypingStatsRepository.java
@@ -1,0 +1,27 @@
+package com.typingpractice.typing_practice_be.typingrecord.statistics.repository;
+
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberTypingStatsRepository {
+  private final EntityManager em;
+
+  public void save(MemberTypingStats stats) {
+    em.persist(stats);
+  }
+
+  public Optional<MemberTypingStats> findByMemberId(Long memberId) {
+    return em.createQuery(
+            "select s from MemberTypingStats s where s.member.id = :memberId",
+            MemberTypingStats.class)
+        .setParameter("memberId", memberId)
+        .getResultStream()
+        .findFirst();
+  }
+}


### PR DESCRIPTION
- MemberTypingStats 엔티티 (Member @OneToOne, 누적 통계)
  - merge: 가중 평균, bestCpm max, practiceTimeMin/resetCount 합산
  - overwrite: 전체 덮어쓰기
- MemberTypingStatsRepository (save, findByMemberId)
- MemberTypingAggregation DTO
- TypingRecordRepository: memberId별 집계 메서드
  - aggregateByMemberIds (전체)
  - aggregateByMemberIdsBetween (기간 지정)
  - 이상치 포함, practiceTimeMin = charLength/cpm 역산