### PR TITLE
feat: MemberTypingStats 배치 집계 + 유저 새로고침

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.statistics.scheduler;
 
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsBatchService;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.service.MemberTypingStatsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.QuoteTypingStatsBatchService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,11 +14,13 @@ import org.springframework.stereotype.Component;
 public class StatisticsScheduler {
   private final GlobalQuoteStatisticsBatchService globalQuoteStatisticsBatchService;
   private final QuoteTypingStatsBatchService quoteTypingStatsBatchService;
+  private final MemberTypingStatsBatchService memberTypingStatsBatchService;
 
   @Scheduled(cron = "0 0 3 * * *")
   public void runDailyBatch() {
     log.info("전역 통계 배치 시작");
     quoteTypingStatsBatchService.runScheduledBatch(); // 문장 별 타이핑 통계
+    memberTypingStatsBatchService.runScheduledBatch(); // 개인 별 타이핑 통계
     globalQuoteStatisticsBatchService.runScheduledBatch(); // 전체 문장의 profile 통계
     log.info("전역 통계 배치 완료");
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
@@ -112,10 +112,26 @@ public class TypingRecordRepository {
         .getMappedResults();
   }
 
+  public List<Long> findDistinctMemberIdsBetween(LocalDateTime from, LocalDateTime to) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(
+                Criteria.where("memberId").ne(null).and("completedAt").gte(from).lt(to)),
+            Aggregation.group("memberId"),
+            Aggregation.project().and("_id").as("memberId"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", Document.class)
+        .getMappedResults()
+        .stream()
+        .map(doc -> doc.getLong("memberId"))
+        .toList();
+  }
+
   public List<MemberTypingAggregation> aggregateByMemberIds(List<Long> memberIds) {
     Aggregation aggregation =
         Aggregation.newAggregation(
-            Aggregation.match(Criteria.where("memberId").in(memberIds)),
+            Aggregation.match(Criteria.where("memberId").in(memberIds).and("cpm").gt(0)),
             Aggregation.group("memberId")
                 .count()
                 .as("totalAttempts")
@@ -153,7 +169,13 @@ public class TypingRecordRepository {
     Aggregation aggregation =
         Aggregation.newAggregation(
             Aggregation.match(
-                Criteria.where("memberId").in(memberIds).and("completedAt").gte(from).lt(to)),
+                Criteria.where("memberId")
+                    .in(memberIds)
+                    .and("completedAt")
+                    .gte(from)
+                    .lt(to)
+                    .and("cpm")
+                    .gt(0)),
             Aggregation.group("memberId")
                 .count()
                 .as("totalAttempts")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypingStatsBatchService.java
@@ -1,0 +1,111 @@
+package com.typingpractice.typing_practice_be.typingrecord.statistics.service;
+
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
+import com.typingpractice.typing_practice_be.typingrecord.repository.TypingRecordRepository;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypingAggregation;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypingStatsRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberTypingStatsBatchService {
+  private final MemberRepository memberRepository;
+  private final TypingRecordRepository typingRecordRepository;
+  private final MemberTypingStatsRepository memberTypingStatsRepository;
+
+  private static final int CHUNK_SIZE = 500;
+
+  @Transactional
+  public void runScheduledBatch() {
+    LocalDateTime from = LocalDate.now().minusDays(1).atStartOfDay(); // 어제 00시
+    LocalDateTime to = LocalDate.now().minusDays(1).atTime(LocalTime.MAX); // 어제 23시 59분
+
+    log.info("MemberTypingStats 증분 배치 시작 - 범위: {} ~ {}", from, to);
+
+    List<Long> memberIds = typingRecordRepository.findDistinctMemberIdsBetween(from, to);
+    int totalProcessed = processChunks(memberIds, from, to);
+
+    log.info("MemberTypingStats 증분 배치 완료 - {}건 처리", totalProcessed);
+  }
+
+  @Transactional
+  public void refreshForMember(Long memberId) {
+    LocalDateTime from = LocalDate.now().atStartOfDay(); // 오늘 00시
+    LocalDateTime to = LocalDateTime.now(); // 지금
+
+    List<MemberTypingAggregation> aggregations =
+        typingRecordRepository.aggregateByMemberIdsBetween(List.of(memberId), from, to);
+
+    if (aggregations.isEmpty()) return;
+
+    MemberTypingAggregation agg = aggregations.getFirst();
+    upsert(memberId, agg);
+
+    log.info("MemberTypingStats 유저 새로고침 완료 - memberId: {}", memberId);
+  }
+
+  private int processChunks(List<Long> memberIds, LocalDateTime from, LocalDateTime to) {
+    int totalProcessed = 0;
+
+    // CHUNK_SIZE 만큼 잘라서 배치 처리
+    for (int i = 0; i < memberIds.size(); i += CHUNK_SIZE) {
+      List<Long> chunk = memberIds.subList(i, Math.min(i + CHUNK_SIZE, memberIds.size()));
+
+      List<MemberTypingAggregation> aggregations =
+          typingRecordRepository.aggregateByMemberIdsBetween(chunk, from, to);
+
+      for (MemberTypingAggregation agg : aggregations) {
+        upsert(agg.getMemberId(), agg);
+        totalProcessed++;
+      }
+    }
+
+    return totalProcessed;
+  }
+
+  private void upsert(Long memberId, MemberTypingAggregation agg) {
+    MemberTypingStats stats = memberTypingStatsRepository.findByMemberId(memberId).orElse(null);
+
+    if (stats == null) {
+      Member member = memberRepository.findById(memberId).orElse(null);
+
+      if (member == null) {
+        log.warn("Member 미존재, 스킵 - memberId: {}", memberId);
+        return;
+      }
+
+      stats =
+          MemberTypingStats.create(
+              member,
+              agg.getTotalAttempts(),
+              (float) agg.getAvgCpm(),
+              (float) agg.getAvgAcc(),
+              agg.getBestCpm(),
+              agg.getTotalPracticeTimeMin(),
+              agg.getTotalResetCount(),
+              agg.getLastPracticedAt());
+      memberTypingStatsRepository.save(stats);
+
+    } else {
+      stats.merge(
+          agg.getTotalAttempts(),
+          (float) agg.getAvgCpm(),
+          (float) agg.getAvgAcc(),
+          agg.getBestCpm(),
+          agg.getTotalPracticeTimeMin(),
+          agg.getTotalResetCount(),
+          agg.getLastPracticedAt());
+    }
+  }
+}


### PR DESCRIPTION
- MemberTypingStats 엔티티 (Member @OneToOne, 누적 통계)
  - merge: 가중 평균, bestCpm max, practiceTimeMin/resetCount 합산
  - overwrite: 전체 덮어쓰기
- MemberTypingStatsRepository (save, findByMemberId)
- MemberTypingAggregation DTO
- TypingRecordRepository: memberId별 집계 메서드
  - aggregateByMemberIds / aggregateByMemberIdsBetween
  - findDistinctMemberIdsBetween (배치 대상 추출)
  - 이상치 포함, cpm > 0 필터, practiceTimeMin = charLength/cpm 역산
- MemberTypingStatsBatchService
  - 스케줄 배치: 전날 하루치 증분 (distinct memberId → chunk 처리)
  - 유저 새로고침: 오늘 하루치 증분
  - 탈퇴 회원 방어 처리 (로그 + 스킵)
- StatisticsScheduler에 MemberTypingStats 배치 추가