### PR TITLE
refactor: UTC 시간대 통일 + MemberTypingStats 개선

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/TypingPracticeBeApplication.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/TypingPracticeBeApplication.java
@@ -6,6 +6,8 @@ import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+import java.util.TimeZone;
+
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
@@ -13,7 +15,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 public class TypingPracticeBeApplication {
 
   public static void main(String[] args) {
-
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
     SpringApplication.run(TypingPracticeBeApplication.class, args);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/domain/BaseEntity.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/domain/BaseEntity.java
@@ -1,22 +1,28 @@
 package com.typingpractice.typing_practice_be.common.domain;
 
+import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.time.LocalDateTime;
-
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 @Getter
 public abstract class BaseEntity {
-  @CreatedDate private LocalDateTime createdAt;
+  @CreatedDate
+  @Column(columnDefinition = "timestamp with time zone")
+  private LocalDateTime createdAt;
 
-  @LastModifiedDate private LocalDateTime updatedAt;
+  @LastModifiedDate
+  @Column(columnDefinition = "timestamp with time zone")
+  private LocalDateTime updatedAt;
 
   private boolean deleted = false;
+
+  @Column(columnDefinition = "timestamp with time zone")
   private LocalDateTime deletedAt;
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/domain/QuoteSimilarityRejectLog.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/domain/QuoteSimilarityRejectLog.java
@@ -1,8 +1,8 @@
 package com.typingpractice.typing_practice_be.quote.reject.domain;
 
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import jakarta.persistence.*;
-import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class QuoteSimilarityRejectLog {
+public class QuoteSimilarityRejectLog extends BaseEntity {
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
@@ -28,8 +28,6 @@ public class QuoteSimilarityRejectLog {
   @Enumerated(EnumType.STRING)
   private QuoteLanguage language;
 
-  private LocalDateTime createdAt;
-
   public static QuoteSimilarityRejectLog create(
       Long memberId,
       String inputSentence,
@@ -42,7 +40,7 @@ public class QuoteSimilarityRejectLog {
     log.similarSentence = similarSentence;
     log.similarity = similarity;
     log.language = language;
-    log.createdAt = LocalDateTime.now();
+
     return log;
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
@@ -35,7 +35,9 @@ public class TypingRecordRepository {
         .aggregate(aggregation, "typingRecord", Document.class)
         .getMappedResults()
         .stream()
-        .collect(Collectors.toMap(doc -> doc.getLong("quoteId"), doc -> doc.getInteger("count")));
+        .collect(
+            Collectors.toMap(
+                doc -> ((Number) doc.get("quoteId")).longValue(), doc -> doc.getInteger("count")));
   }
 
   public List<QuoteTypingAggregation> aggregateByQuoteIds(List<Long> quoteIds) {
@@ -76,7 +78,9 @@ public class TypingRecordRepository {
         .aggregate(aggregation, "typingRecord", Document.class)
         .getMappedResults()
         .stream()
-        .collect(Collectors.toMap(doc -> doc.getLong("quoteId"), doc -> doc.getInteger("count")));
+        .collect(
+            Collectors.toMap(
+                doc -> ((Number) doc.get("quoteId")).longValue(), doc -> doc.getInteger("count")));
   }
 
   public List<QuoteTypingAggregation> aggregateByQuoteIdsBetween(
@@ -124,7 +128,7 @@ public class TypingRecordRepository {
         .aggregate(aggregation, "typingRecord", Document.class)
         .getMappedResults()
         .stream()
-        .map(doc -> doc.getLong("memberId"))
+        .map(doc -> ((Number) doc.get("memberId")).longValue())
         .toList();
   }
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberTypingStats.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberTypingStats.java
@@ -26,8 +26,10 @@ public class MemberTypingStats extends BaseEntity {
   private float avgCpm;
   private float avgAcc;
   private int bestCpm;
-  private long totalPracticeTimeMin;
+  private float totalPracticeTimeMin;
   private int totalResetCount;
+
+  @Column(columnDefinition = "timestamp with time zone")
   private LocalDateTime lastPracticedAt;
 
   public static MemberTypingStats create(
@@ -36,7 +38,7 @@ public class MemberTypingStats extends BaseEntity {
       float avgCpm,
       float avgAcc,
       int bestCpm,
-      long totalPracticeTimeMin,
+      float totalPracticeTimeMin,
       int totalResetCount,
       LocalDateTime lastPracticedAt) {
     MemberTypingStats stats = new MemberTypingStats();
@@ -56,7 +58,7 @@ public class MemberTypingStats extends BaseEntity {
       float newAvgCpm,
       float newAvgAcc,
       int newBestCpm,
-      long newPracticeTimeMin,
+      float newPracticeTimeMin,
       int newResetCount,
       LocalDateTime newLastPracticedAt) {
     int mergedAttempts = this.totalAttempts + newAttempts;
@@ -78,7 +80,7 @@ public class MemberTypingStats extends BaseEntity {
       float avgCpm,
       float avgAcc,
       int bestCpm,
-      long totalPracticeTimeMin,
+      float totalPracticeTimeMin,
       int totalResetCount,
       LocalDateTime lastPracticedAt) {
     this.totalAttempts = totalAttempts;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/MemberTypingAggregation.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/MemberTypingAggregation.java
@@ -13,7 +13,7 @@ public class MemberTypingAggregation {
   private double avgCpm;
   private double avgAcc;
   private int bestCpm;
-  private long totalPracticeTimeMin;
+  private float totalPracticeTimeMin;
   private int totalResetCount;
   private LocalDateTime lastPracticedAt;
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypingStatsBatchService.java
@@ -41,7 +41,16 @@ public class MemberTypingStatsBatchService {
 
   @Transactional
   public void refreshForMember(Long memberId) {
-    LocalDateTime from = LocalDate.now().atStartOfDay(); // 오늘 00시
+    MemberTypingStats typingStats =
+        memberTypingStatsRepository.findByMemberId(memberId).orElse(null);
+
+    LocalDateTime from =
+        typingStats == null
+                || typingStats
+                    .getUpdatedAt()
+                    .isBefore(LocalDate.now().atStartOfDay()) // stats 의 업데이트가 배치 처리한 것만 있는 경우
+            ? LocalDate.now().atStartOfDay()
+            : typingStats.getUpdatedAt(); // 오늘 00시 or 마지막 업데이트
     LocalDateTime to = LocalDateTime.now(); // 지금
 
     List<MemberTypingAggregation> aggregations =


### PR DESCRIPTION
- JVM 타임존 UTC 설정 (TypingPracticeBeApplication)
- BaseEntity, MemberTypingStats, QuoteSimilarityRejectLog의 LocalDateTime 컬럼에 timestamp with time zone 적용
- MemberTypingStats.totalPracticeTimeMin long → float 변경
- MemberTypingAggregation.totalPracticeTimeMin long → float 변경
- refreshForMember 중복 merge 방지
  - updatedAt 기반으로 마지막 갱신 이후 기록만 집계
- countAllByQuoteIds Number 타입 캐스팅 방어