### PR TITLE
refactor: MemberTypingStats 배치 전용 + 어드민 재계산

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
@@ -2,10 +2,15 @@ package com.typingpractice.typing_practice_be.statistics.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsBatchService;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.service.MemberTypingStatsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.QuoteTypingStatsBatchService;
+import java.time.LocalDate;
+import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -14,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class AdminStatisticsController {
   private final GlobalQuoteStatisticsBatchService globalQuoteStatisticsBatchService;
   private final QuoteTypingStatsBatchService quoteTypingStatsBatchService;
+  private final MemberTypingStatsBatchService memberTypingStatsBatchService;
 
   @PostMapping("/global-quote/recalculate")
   public ApiResponse<Void> recalculate() {
@@ -24,6 +30,26 @@ public class AdminStatisticsController {
   @PostMapping("/quote-typing/recalculate")
   public ApiResponse<Void> recalculateQuoteTypingStats() {
     quoteTypingStatsBatchService.runManualRecalculation();
+    return ApiResponse.ok(null);
+  }
+
+  @PostMapping("/member-typing/recalculate")
+  public ApiResponse<Void> recalculateMemberTypingStats(
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate startDate,
+      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+          LocalDate endDate) {
+
+    if (startDate != null && endDate != null) {
+      if (startDate.isAfter(endDate)) {
+        throw new IllegalArgumentException("startDate는 endDate보다 같거나 이전이어야 합니다.");
+      }
+      memberTypingStatsBatchService.runRecalculationForPeriod(
+          startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX));
+    } else {
+      memberTypingStatsBatchService.runManualRecalculation();
+    }
+
     return ApiResponse.ok(null);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
@@ -211,4 +211,19 @@ public class TypingRecordRepository {
         .aggregate(aggregation, "typingRecord", MemberTypingAggregation.class)
         .getMappedResults();
   }
+
+  public List<Long> findDistinctMemberIds() {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(Criteria.where("memberId").ne(null)),
+            Aggregation.group("memberId"),
+            Aggregation.project().and("_id").as("memberId"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", Document.class)
+        .getMappedResults()
+        .stream()
+        .map(doc -> ((Number) doc.get("memberId")).longValue())
+        .toList();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypingStatsBatchService.java
@@ -26,6 +26,7 @@ public class MemberTypingStatsBatchService {
 
   private static final int CHUNK_SIZE = 500;
 
+  // 스케줄 배치: 전날 하루치 증분
   @Transactional
   public void runScheduledBatch() {
     LocalDateTime from = LocalDate.now().minusDays(1).atStartOfDay(); // 어제 00시
@@ -34,48 +35,47 @@ public class MemberTypingStatsBatchService {
     log.info("MemberTypingStats 증분 배치 시작 - 범위: {} ~ {}", from, to);
 
     List<Long> memberIds = typingRecordRepository.findDistinctMemberIdsBetween(from, to);
-    int totalProcessed = processChunks(memberIds, from, to);
+    int totalProcessed = processChunks(memberIds, from, to, false);
 
     log.info("MemberTypingStats 증분 배치 완료 - {}건 처리", totalProcessed);
   }
 
+  // 어드민: 전체 재계산
   @Transactional
-  public void refreshForMember(Long memberId) {
-    MemberTypingStats typingStats =
-        memberTypingStatsRepository.findByMemberId(memberId).orElse(null);
+  public void runManualRecalculation() {
+    log.info("MemberTypingStats 전체 재계산 시작");
 
-    LocalDateTime from =
-        typingStats == null
-                || typingStats
-                    .getUpdatedAt()
-                    .isBefore(LocalDate.now().atStartOfDay()) // stats 의 업데이트가 배치 처리한 것만 있는 경우
-            ? LocalDate.now().atStartOfDay()
-            : typingStats.getUpdatedAt(); // 오늘 00시 or 마지막 업데이트
-    LocalDateTime to = LocalDateTime.now(); // 지금
+    List<Long> memberIds = typingRecordRepository.findDistinctMemberIds();
+    int totalProcessed = processChunks(memberIds, null, null, true);
 
-    List<MemberTypingAggregation> aggregations =
-        typingRecordRepository.aggregateByMemberIdsBetween(List.of(memberId), from, to);
-
-    if (aggregations.isEmpty()) return;
-
-    MemberTypingAggregation agg = aggregations.getFirst();
-    upsert(memberId, agg);
-
-    log.info("MemberTypingStats 유저 새로고침 완료 - memberId: {}", memberId);
+    log.info("MemberTypingStats 전체 재계산 완료 - {}건 처리", totalProcessed);
   }
 
-  private int processChunks(List<Long> memberIds, LocalDateTime from, LocalDateTime to) {
+  // 어드민: 날짜 범위 재실행
+  @Transactional
+  public void runRecalculationForPeriod(LocalDateTime from, LocalDateTime to) {
+    log.info("MemberTypingStats 기간 재계산 시작 - 범위: {} - {}", from, to);
+
+    List<Long> memberIds = typingRecordRepository.findDistinctMemberIdsBetween(from, to);
+    int totalProcessed = processChunks(memberIds, from, to, false);
+
+    log.info("MemberTypingStats 기간 재계산 완료 - {}건 처리", totalProcessed);
+  }
+
+  private int processChunks(
+      List<Long> memberIds, LocalDateTime from, LocalDateTime to, boolean overwrite) {
     int totalProcessed = 0;
 
-    // CHUNK_SIZE 만큼 잘라서 배치 처리
     for (int i = 0; i < memberIds.size(); i += CHUNK_SIZE) {
       List<Long> chunk = memberIds.subList(i, Math.min(i + CHUNK_SIZE, memberIds.size()));
 
       List<MemberTypingAggregation> aggregations =
-          typingRecordRepository.aggregateByMemberIdsBetween(chunk, from, to);
+          overwrite
+              ? typingRecordRepository.aggregateByMemberIds(chunk)
+              : typingRecordRepository.aggregateByMemberIdsBetween(chunk, from, to);
 
       for (MemberTypingAggregation agg : aggregations) {
-        upsert(agg.getMemberId(), agg);
+        upsert(agg.getMemberId(), agg, overwrite);
         totalProcessed++;
       }
     }
@@ -83,12 +83,11 @@ public class MemberTypingStatsBatchService {
     return totalProcessed;
   }
 
-  private void upsert(Long memberId, MemberTypingAggregation agg) {
+  private void upsert(Long memberId, MemberTypingAggregation agg, boolean overwrite) {
     MemberTypingStats stats = memberTypingStatsRepository.findByMemberId(memberId).orElse(null);
 
     if (stats == null) {
       Member member = memberRepository.findById(memberId).orElse(null);
-
       if (member == null) {
         log.warn("Member 미존재, 스킵 - memberId: {}", memberId);
         return;
@@ -105,7 +104,15 @@ public class MemberTypingStatsBatchService {
               agg.getTotalResetCount(),
               agg.getLastPracticedAt());
       memberTypingStatsRepository.save(stats);
-
+    } else if (overwrite) {
+      stats.overwrite(
+          agg.getTotalAttempts(),
+          (float) agg.getAvgCpm(),
+          (float) agg.getAvgAcc(),
+          agg.getBestCpm(),
+          agg.getTotalPracticeTimeMin(),
+          agg.getTotalResetCount(),
+          agg.getLastPracticedAt());
     } else {
       stats.merge(
           agg.getTotalAttempts(),


### PR DESCRIPTION
- refreshForMember 제거 (Redis 캐시 방식으로 전환 예정)
- 어드민 수동 재계산 추가
  - POST /admin/stats/member-typing/recalculate (전체 overwrite)
  - POST /admin/stats/member-typing/recalculate?startDate&endDate (기간 merge)
  - startDate > endDate 검증
- findDistinctMemberIds 집계 메서드 추가 (전체 재계산용)
- processChunks에 overwrite 파라미터 추가