### PR TITLE
feat: TimeUtils 도입 + 시간대 KST 기준 통일

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/utils/TimeUtils.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/utils/TimeUtils.java
@@ -1,0 +1,43 @@
+package com.typingpractice.typing_practice_be.common.utils;
+
+import java.time.*;
+
+public class TimeUtils {
+  public static final String KST_ZONE = "Asia/Seoul";
+  public static final ZoneId KST = ZoneId.of(KST_ZONE);
+
+  public static ZoneId parseZoneId(String timezone) {
+    try {
+      return ZoneId.of(timezone);
+    } catch (DateTimeException e) {
+      throw new IllegalArgumentException("유효하지 않은 timezone: " + timezone);
+    }
+  }
+
+  // KST 날짜의 시작 시각을 UTC로
+  public static LocalDateTime startOfDayKstToUtc(LocalDate kstDate) {
+    return kstDate.atStartOfDay(KST).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+  }
+
+  // KST 날짜의 끝 시각을 UTC로
+  public static LocalDateTime endOfDayKstToUtc(LocalDate kstDate) {
+    return kstDate
+        .atTime(LocalTime.MAX)
+        .atZone(KST)
+        .withZoneSameInstant(ZoneOffset.UTC)
+        .toLocalDateTime();
+  }
+
+  // 임의 타임존 날짜의 시작 시각을 UTC로
+  public static LocalDateTime startOfDayToUtc(LocalDate date, ZoneId zone) {
+    return date.atStartOfDay(zone).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+  }
+
+  // 임의 타임존 날짜의 끝 시각을 UTC로
+  public static LocalDateTime endOfDayToUtc(LocalDate date, ZoneId zone) {
+    return date.atTime(LocalTime.MAX)
+        .atZone(zone)
+        .withZoneSameInstant(ZoneOffset.UTC)
+        .toLocalDateTime();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/controller/AdminSimilarityRejectController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/reject/controller/AdminSimilarityRejectController.java
@@ -2,12 +2,16 @@ package com.typingpractice.typing_practice_be.quote.reject.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.reject.domain.QuoteSimilarityRejectLog;
 import com.typingpractice.typing_practice_be.quote.reject.dto.RejectSummaryResponse;
 import com.typingpractice.typing_practice_be.quote.reject.repository.QuoteSimilarityRejectLogRepository;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
+
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -26,10 +30,20 @@ public class AdminSimilarityRejectController {
   @GetMapping
   public ApiResponse<PageResult<QuoteSimilarityRejectLog>> getRejects(
       @RequestParam QuoteLanguage language,
-      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
-      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+      @RequestParam(defaultValue = TimeUtils.KST_ZONE) String timezone,
       @RequestParam(defaultValue = "1") int page,
       @RequestParam(defaultValue = "50") int size) {
+
+    if (startDate.isAfter(endDate)) {
+      throw new IllegalArgumentException("startDate는 endDate보다 같거나 이전이어야 합니다.");
+    }
+
+    ZoneId zone = TimeUtils.parseZoneId(timezone);
+    LocalDateTime from = TimeUtils.startOfDayToUtc(startDate, zone);
+    LocalDateTime to = TimeUtils.endOfDayToUtc(endDate, zone);
+
     List<QuoteSimilarityRejectLog> logs =
         rejectLogRepository.findByPeriod(language, from, to, page, size);
 
@@ -42,8 +56,17 @@ public class AdminSimilarityRejectController {
   @GetMapping("/summary")
   public ApiResponse<RejectSummaryResponse> getSummary(
       @RequestParam QuoteLanguage language,
-      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime from,
-      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime to) {
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
+      @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate endDate,
+      @RequestParam(defaultValue = TimeUtils.KST_ZONE) String timezone) {
+    if (startDate.isAfter(endDate)) {
+      throw new IllegalArgumentException("startDate는 endDate보다 같거나 이전이어야 합니다.");
+    }
+
+    ZoneId zone = TimeUtils.parseZoneId(timezone);
+    LocalDateTime from = TimeUtils.startOfDayToUtc(startDate, zone);
+    LocalDateTime to = TimeUtils.endOfDayToUtc(endDate, zone);
+
     long rejectCount = rejectLogRepository.countByPeriod(language, from, to);
     long uploadCount = quoteRepository.countByPeriod(language, from, to);
     long totalAttempts = uploadCount + rejectCount;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
@@ -1,11 +1,12 @@
 package com.typingpractice.typing_practice_be.statistics.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.MemberTypingStatsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.QuoteTypingStatsBatchService;
 import java.time.LocalDate;
-import java.time.LocalTime;
+import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -38,14 +39,17 @@ public class AdminStatisticsController {
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
           LocalDate startDate,
       @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-          LocalDate endDate) {
+          LocalDate endDate,
+      @RequestParam(defaultValue = TimeUtils.KST_ZONE) String timezone) {
 
     if (startDate != null && endDate != null) {
       if (startDate.isAfter(endDate)) {
         throw new IllegalArgumentException("startDate는 endDate보다 같거나 이전이어야 합니다.");
       }
+      ZoneId zone = TimeUtils.parseZoneId(timezone);
+
       memberTypingStatsBatchService.runRecalculationForPeriod(
-          startDate.atStartOfDay(), endDate.atTime(LocalTime.MAX));
+          TimeUtils.startOfDayToUtc(startDate, zone), TimeUtils.endOfDayToUtc(endDate, zone));
     } else {
       memberTypingStatsBatchService.runManualRecalculation();
     }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.statistics.scheduler;
 
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.MemberTypingStatsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.QuoteTypingStatsBatchService;
@@ -16,7 +17,7 @@ public class StatisticsScheduler {
   private final QuoteTypingStatsBatchService quoteTypingStatsBatchService;
   private final MemberTypingStatsBatchService memberTypingStatsBatchService;
 
-  @Scheduled(cron = "0 0 3 * * *")
+  @Scheduled(cron = "0 0 3 * * *", zone = TimeUtils.KST_ZONE)
   public void runDailyBatch() {
     log.info("전역 통계 배치 시작");
     quoteTypingStatsBatchService.runScheduledBatch(); // 문장 별 타이핑 통계

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypingStatsBatchService.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.typingrecord.statistics.service;
 
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
 import com.typingpractice.typing_practice_be.typingrecord.repository.TypingRecordRepository;
@@ -8,7 +9,6 @@ import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberT
 import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypingStatsRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,8 +29,10 @@ public class MemberTypingStatsBatchService {
   // 스케줄 배치: 전날 하루치 증분
   @Transactional
   public void runScheduledBatch() {
-    LocalDateTime from = LocalDate.now().minusDays(1).atStartOfDay(); // 어제 00시
-    LocalDateTime to = LocalDate.now().minusDays(1).atTime(LocalTime.MAX); // 어제 23시 59분
+    LocalDate yesterdayKst = LocalDate.now(TimeUtils.KST).minusDays(1);
+
+    LocalDateTime from = TimeUtils.startOfDayKstToUtc(yesterdayKst);
+    LocalDateTime to = TimeUtils.endOfDayKstToUtc(yesterdayKst);
 
     log.info("MemberTypingStats 증분 배치 시작 - 범위: {} ~ {}", from, to);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/QuoteTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/QuoteTypingStatsBatchService.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.typingrecord.statistics.service;
 
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
@@ -7,17 +8,15 @@ import com.typingpractice.typing_practice_be.typingrecord.repository.TypingRecor
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.QuoteTypingStats;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.QuoteTypingAggregation;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.QuoteTypingStatsRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -33,8 +32,10 @@ public class QuoteTypingStatsBatchService {
   // 스케줄 배치: 전날 하루치 증분 집계
   @Transactional
   public void runScheduledBatch() {
-    LocalDateTime from = LocalDate.now().minusDays(1).atStartOfDay();
-    LocalDateTime to = LocalDate.now().minusDays(1).atTime(LocalTime.MAX);
+    // 한국 기준 어제 날짜
+    LocalDate yesterdayKst = LocalDate.now(TimeUtils.KST).minusDays(1);
+    LocalDateTime from = TimeUtils.startOfDayKstToUtc(yesterdayKst);
+    LocalDateTime to = TimeUtils.endOfDayKstToUtc(yesterdayKst);
 
     log.info("QuoteTypingStats 증분 배치 시작 - 범위: {} ~ {}", from, to);
     int totalProcessed = processPages(from, to, false);

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteServiceTest.java
@@ -34,7 +34,8 @@ class AdminQuoteServiceTest {
 
   private Quote createQuote(QuoteType type, QuoteStatus status) {
     Quote quote =
-        Quote.create(createMember(), "테스트 문장입니다.", "작자", type, QuoteLanguage.KOREAN, null, 0f);
+        Quote.create(
+            createMember(), "테스트 문장입니다.", "작자", type, QuoteLanguage.KOREAN, null, 0f, "hash");
 
     if (type == QuoteType.PUBLIC && status == QuoteStatus.ACTIVE) {
       quote.approvePublish();

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteServiceTest.java
@@ -67,7 +67,8 @@ class QuoteServiceTest {
   }
 
   private Quote createQuote(Member member, QuoteType type, QuoteStatus status) {
-    Quote quote = Quote.create(member, "테스트 문장입니다.", "저자", type, QuoteLanguage.KOREAN, null, 0f);
+    Quote quote =
+        Quote.create(member, "테스트 문장입니다.", "저자", type, QuoteLanguage.KOREAN, null, 0f, "hash");
     if (type == QuoteType.PUBLIC && status == QuoteStatus.ACTIVE) {
       quote.approvePublish();
     }

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/report/service/AdminReportServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/report/service/AdminReportServiceTest.java
@@ -61,7 +61,14 @@ class AdminReportServiceTest {
   private Quote createQuote() {
     Quote quote =
         Quote.create(
-            createMember(99L), "테스트 문장", "저자", QuoteType.PUBLIC, QuoteLanguage.KOREAN, null, 0f);
+            createMember(99L),
+            "테스트 문장",
+            "저자",
+            QuoteType.PUBLIC,
+            QuoteLanguage.KOREAN,
+            null,
+            0f,
+            "hash");
     quote.approvePublish();
     return quote;
   }

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/report/service/ReportServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/report/service/ReportServiceTest.java
@@ -67,7 +67,8 @@ class ReportServiceTest {
 
   private Quote createQuote(QuoteType type, QuoteStatus status) {
     Quote quote =
-        Quote.create(createMember(99L), "테스트 문장", "저자", type, QuoteLanguage.KOREAN, null, 0f);
+        Quote.create(
+            createMember(99L), "테스트 문장", "저자", type, QuoteLanguage.KOREAN, null, 0f, "hash");
     if (type == QuoteType.PUBLIC && status == QuoteStatus.ACTIVE) {
       quote.approvePublish();
     }

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/utils/TimeUtilsTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/utils/TimeUtilsTest.java
@@ -1,0 +1,59 @@
+package com.typingpractice.typing_practice_be.utils;
+
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.TimeZone;
+
+public class TimeUtilsTest {
+  @Test
+  void startOfDayKstToUtc() {
+    TimeZone.setDefault(TimeZone.getTimeZone("UTC"));
+    // given
+    LocalDate kstDate = LocalDate.of(2026, 3, 1);
+    LocalDateTime now = LocalDateTime.now(ZoneId.of("Asia/Seoul"));
+    LocalDateTime now2 = LocalDateTime.now();
+    System.out.println("now = " + now);
+    System.out.println("now2 = " + now2);
+
+    // when
+    LocalDateTime utcDate = TimeUtils.startOfDayKstToUtc(kstDate);
+
+    // then
+    Assertions.assertThat(kstDate.isAfter(utcDate.toLocalDate())).isTrue();
+    System.out.println("kstDate = " + kstDate);
+    System.out.println("utcDate = " + utcDate);
+  }
+
+  @Test
+  void endOfDayKstToUtc() {
+    // given
+    LocalDate kstDate = LocalDate.of(2026, 3, 1);
+
+    // when
+    LocalDateTime utcDate = TimeUtils.endOfDayKstToUtc(kstDate);
+
+    // then
+    // Assertions.assertThat(kstDate.isAfter(utcDate.toLocalDate())).isTrue();
+    System.out.println("kstDate = " + kstDate);
+    System.out.println("utcDate = " + utcDate);
+  }
+
+  @Test
+  void startOfDayToUtc() {
+    // given
+    LocalDate localDate = LocalDate.of(2026, 3, 1);
+
+    // when
+    LocalDateTime utcDate = TimeUtils.startOfDayToUtc(localDate, ZoneId.of("Asia/Shanghai"));
+
+    // then
+    System.out.println("localDate = " + localDate);
+    System.out.println("utcDate = " + utcDate);
+  }
+}


### PR DESCRIPTION
- TimeUtils 유틸: KST 상수, UTC 변환, timezone 검증
- 배치 스케줄러: zone = KST 지정
- QuoteTypingStatsBatchService: KST 전날 기준 UTC 변환
- MemberTypingStatsBatchService: KST 전날 기준 UTC 변환
- AdminStatisticsController: timezone 파라미터 추가
- AdminSimilarityRejectController: LocalDateTime → LocalDate + timezone 변환
  - getRejects, getSummary 모두 통일
  - startDate > endDate 검증 추가