### PR TITLE
refactor: TypingRecordRepository 집계 메서드 성격별 분리

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/MemberTypingAggregationRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/MemberTypingAggregationRepository.java
@@ -1,0 +1,97 @@
+package com.typingpractice.typing_practice_be.typingrecord.repository;
+
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypingAggregation;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.ArithmeticOperators;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberTypingAggregationRepository {
+  private final MongoTemplate mongoTemplate;
+
+  public List<MemberTypingAggregation> aggregateByMemberIds(List<Long> memberIds) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(Criteria.where("memberId").in(memberIds).and("cpm").gt(0)),
+            Aggregation.group("memberId")
+                .count()
+                .as("totalAttempts")
+                .avg("cpm")
+                .as("avgCpm")
+                .avg("accuracy")
+                .as("avgAcc")
+                .max("cpm")
+                .as("bestCpm")
+                .sum(ArithmeticOperators.valueOf("charLength").divideBy("cpm"))
+                .as("totalPracticeTimeMin")
+                .sum("resetCount")
+                .as("totalResetCount")
+                .max("completedAt")
+                .as("lastPracticedAt"),
+            Aggregation.project()
+                .and("_id")
+                .as("memberId")
+                .andInclude(
+                    "totalAttempts",
+                    "avgCpm",
+                    "avgAcc",
+                    "bestCpm",
+                    "totalPracticeTimeMin",
+                    "totalResetCount",
+                    "lastPracticedAt"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", MemberTypingAggregation.class)
+        .getMappedResults();
+  }
+
+  public List<MemberTypingAggregation> aggregateByMemberIdsBetween(
+      List<Long> memberIds, LocalDateTime from, LocalDateTime to) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(
+                Criteria.where("memberId")
+                    .in(memberIds)
+                    .and("completedAt")
+                    .gte(from)
+                    .lt(to)
+                    .and("cpm")
+                    .gt(0)),
+            Aggregation.group("memberId")
+                .count()
+                .as("totalAttempts")
+                .avg("cpm")
+                .as("avgCpm")
+                .avg("accuracy")
+                .as("avgAcc")
+                .max("cpm")
+                .as("bestCpm")
+                .sum(ArithmeticOperators.valueOf("charLength").divideBy("cpm"))
+                .as("totalPracticeTimeMin")
+                .sum("resetCount")
+                .as("totalResetCount")
+                .max("completedAt")
+                .as("lastPracticedAt"),
+            Aggregation.project()
+                .and("_id")
+                .as("memberId")
+                .andInclude(
+                    "totalAttempts",
+                    "avgCpm",
+                    "avgAcc",
+                    "bestCpm",
+                    "totalPracticeTimeMin",
+                    "totalResetCount",
+                    "lastPracticedAt"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", MemberTypingAggregation.class)
+        .getMappedResults();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/QuoteTypingAggregationRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/QuoteTypingAggregationRepository.java
@@ -1,0 +1,111 @@
+package com.typingpractice.typing_practice_be.typingrecord.repository;
+
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.QuoteTypingAggregation;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class QuoteTypingAggregationRepository {
+  private final MongoTemplate mongoTemplate;
+
+  public Map<Long, Integer> countAllByQuoteIds(List<Long> quoteIds) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(Criteria.where("quoteId").in(quoteIds)),
+            Aggregation.group("quoteId").count().as("count"),
+            Aggregation.project().and("_id").as("quoteId").andInclude("count"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", Document.class)
+        .getMappedResults()
+        .stream()
+        .collect(
+            Collectors.toMap(
+                doc -> ((Number) doc.get("quoteId")).longValue(), doc -> doc.getInteger("count")));
+  }
+
+  public List<QuoteTypingAggregation> aggregateByQuoteIds(List<Long> quoteIds) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(Criteria.where("outlier").is(false).and("quoteId").in(quoteIds)),
+            Aggregation.group("quoteId")
+                .first("language")
+                .as("language")
+                .count()
+                .as("validAttemptsCount")
+                .avg("cpm")
+                .as("avgCpm")
+                .avg("accuracy")
+                .as("avgAcc")
+                .avg("resetCount")
+                .as("avgResetCount"),
+            Aggregation.project()
+                .and("_id")
+                .as("quoteId")
+                .andInclude("language", "validAttemptsCount", "avgCpm", "avgAcc", "avgResetCount"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", QuoteTypingAggregation.class)
+        .getMappedResults();
+  }
+
+  public Map<Long, Integer> countAllByQuoteIdsBetween(
+      List<Long> quoteIds, LocalDateTime from, LocalDateTime to) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(
+                Criteria.where("quoteId").in(quoteIds).and("completedAt").gte(from).lt(to)),
+            Aggregation.group("quoteId").count().as("count"),
+            Aggregation.project().and("_id").as("quoteId").andInclude("count"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", Document.class)
+        .getMappedResults()
+        .stream()
+        .collect(
+            Collectors.toMap(
+                doc -> ((Number) doc.get("quoteId")).longValue(), doc -> doc.getInteger("count")));
+  }
+
+  public List<QuoteTypingAggregation> aggregateByQuoteIdsBetween(
+      List<Long> quoteIds, LocalDateTime from, LocalDateTime to) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(
+                Criteria.where("outlier")
+                    .is(false)
+                    .and("quoteId")
+                    .in(quoteIds)
+                    .and("completedAt")
+                    .gte(from)
+                    .lt(to)),
+            Aggregation.group("quoteId")
+                .first("language")
+                .as("language")
+                .count()
+                .as("validAttemptsCount")
+                .avg("cpm")
+                .as("avgCpm")
+                .avg("accuracy")
+                .as("avgAcc")
+                .avg("resetCount")
+                .as("avgResetCount"),
+            Aggregation.project()
+                .and("_id")
+                .as("quoteId")
+                .andInclude("language", "validAttemptsCount", "avgCpm", "avgAcc", "avgResetCount"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", QuoteTypingAggregation.class)
+        .getMappedResults();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
@@ -1,19 +1,15 @@
 package com.typingpractice.typing_practice_be.typingrecord.repository;
 
 import com.typingpractice.typing_practice_be.typingrecord.domain.TypingRecord;
-import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypingAggregation;
-import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.QuoteTypingAggregation;
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.bson.Document;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
-import org.springframework.data.mongodb.core.aggregation.ArithmeticOperators;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -24,103 +20,10 @@ public class TypingRecordRepository {
     return mongoTemplate.save(record);
   }
 
-  public Map<Long, Integer> countAllByQuoteIds(List<Long> quoteIds) {
+  public List<Long> findDistinctMemberIds() {
     Aggregation aggregation =
         Aggregation.newAggregation(
-            Aggregation.match(Criteria.where("quoteId").in(quoteIds)),
-            Aggregation.group("quoteId").count().as("count"),
-            Aggregation.project().and("_id").as("quoteId").andInclude("count"));
-
-    return mongoTemplate
-        .aggregate(aggregation, "typingRecord", Document.class)
-        .getMappedResults()
-        .stream()
-        .collect(
-            Collectors.toMap(
-                doc -> ((Number) doc.get("quoteId")).longValue(), doc -> doc.getInteger("count")));
-  }
-
-  public List<QuoteTypingAggregation> aggregateByQuoteIds(List<Long> quoteIds) {
-    Aggregation aggregation =
-        Aggregation.newAggregation(
-            Aggregation.match(Criteria.where("outlier").is(false).and("quoteId").in(quoteIds)),
-            Aggregation.group("quoteId")
-                .first("language")
-                .as("language")
-                .count()
-                .as("validAttemptsCount")
-                .avg("cpm")
-                .as("avgCpm")
-                .avg("accuracy")
-                .as("avgAcc")
-                .avg("resetCount")
-                .as("avgResetCount"),
-            Aggregation.project()
-                .and("_id")
-                .as("quoteId")
-                .andInclude("language", "validAttemptsCount", "avgCpm", "avgAcc", "avgResetCount"));
-
-    return mongoTemplate
-        .aggregate(aggregation, "typingRecord", QuoteTypingAggregation.class)
-        .getMappedResults();
-  }
-
-  public Map<Long, Integer> countAllByQuoteIdsBetween(
-      List<Long> quoteIds, LocalDateTime from, LocalDateTime to) {
-    Aggregation aggregation =
-        Aggregation.newAggregation(
-            Aggregation.match(
-                Criteria.where("quoteId").in(quoteIds).and("completedAt").gte(from).lt(to)),
-            Aggregation.group("quoteId").count().as("count"),
-            Aggregation.project().and("_id").as("quoteId").andInclude("count"));
-
-    return mongoTemplate
-        .aggregate(aggregation, "typingRecord", Document.class)
-        .getMappedResults()
-        .stream()
-        .collect(
-            Collectors.toMap(
-                doc -> ((Number) doc.get("quoteId")).longValue(), doc -> doc.getInteger("count")));
-  }
-
-  public List<QuoteTypingAggregation> aggregateByQuoteIdsBetween(
-      List<Long> quoteIds, LocalDateTime from, LocalDateTime to) {
-    Aggregation aggregation =
-        Aggregation.newAggregation(
-            Aggregation.match(
-                Criteria.where("outlier")
-                    .is(false)
-                    .and("quoteId")
-                    .in(quoteIds)
-                    .and("completedAt")
-                    .gte(from)
-                    .lt(to)),
-            Aggregation.group("quoteId")
-                .first("language")
-                .as("language")
-                .count()
-                .as("validAttemptsCount")
-                .avg("cpm")
-                .as("avgCpm")
-                .avg("accuracy")
-                .as("avgAcc")
-                .avg("resetCount")
-                .as("avgResetCount"),
-            Aggregation.project()
-                .and("_id")
-                .as("quoteId")
-                .andInclude("language", "validAttemptsCount", "avgCpm", "avgAcc", "avgResetCount"));
-
-    return mongoTemplate
-        .aggregate(aggregation, "typingRecord", QuoteTypingAggregation.class)
-        .getMappedResults();
-  }
-
-  public List<Long> findDistinctMemberIdsBetween(LocalDateTime from, LocalDateTime to) {
-    Aggregation aggregation =
-        Aggregation.newAggregation(
-            Aggregation.match(
-                Criteria.where("memberId").ne(null).and("completedAt").gte(from).lt(to)),
+            Aggregation.match(Criteria.where("memberId").ne(null)),
             Aggregation.group("memberId"),
             Aggregation.project().and("_id").as("memberId"));
 
@@ -132,90 +35,11 @@ public class TypingRecordRepository {
         .toList();
   }
 
-  public List<MemberTypingAggregation> aggregateByMemberIds(List<Long> memberIds) {
-    Aggregation aggregation =
-        Aggregation.newAggregation(
-            Aggregation.match(Criteria.where("memberId").in(memberIds).and("cpm").gt(0)),
-            Aggregation.group("memberId")
-                .count()
-                .as("totalAttempts")
-                .avg("cpm")
-                .as("avgCpm")
-                .avg("accuracy")
-                .as("avgAcc")
-                .max("cpm")
-                .as("bestCpm")
-                .sum(ArithmeticOperators.valueOf("charLength").divideBy("cpm"))
-                .as("totalPracticeTimeMin")
-                .sum("resetCount")
-                .as("totalResetCount")
-                .max("completedAt")
-                .as("lastPracticedAt"),
-            Aggregation.project()
-                .and("_id")
-                .as("memberId")
-                .andInclude(
-                    "totalAttempts",
-                    "avgCpm",
-                    "avgAcc",
-                    "bestCpm",
-                    "totalPracticeTimeMin",
-                    "totalResetCount",
-                    "lastPracticedAt"));
-
-    return mongoTemplate
-        .aggregate(aggregation, "typingRecord", MemberTypingAggregation.class)
-        .getMappedResults();
-  }
-
-  public List<MemberTypingAggregation> aggregateByMemberIdsBetween(
-      List<Long> memberIds, LocalDateTime from, LocalDateTime to) {
+  public List<Long> findDistinctMemberIdsBetween(LocalDateTime from, LocalDateTime to) {
     Aggregation aggregation =
         Aggregation.newAggregation(
             Aggregation.match(
-                Criteria.where("memberId")
-                    .in(memberIds)
-                    .and("completedAt")
-                    .gte(from)
-                    .lt(to)
-                    .and("cpm")
-                    .gt(0)),
-            Aggregation.group("memberId")
-                .count()
-                .as("totalAttempts")
-                .avg("cpm")
-                .as("avgCpm")
-                .avg("accuracy")
-                .as("avgAcc")
-                .max("cpm")
-                .as("bestCpm")
-                .sum(ArithmeticOperators.valueOf("charLength").divideBy("cpm"))
-                .as("totalPracticeTimeMin")
-                .sum("resetCount")
-                .as("totalResetCount")
-                .max("completedAt")
-                .as("lastPracticedAt"),
-            Aggregation.project()
-                .and("_id")
-                .as("memberId")
-                .andInclude(
-                    "totalAttempts",
-                    "avgCpm",
-                    "avgAcc",
-                    "bestCpm",
-                    "totalPracticeTimeMin",
-                    "totalResetCount",
-                    "lastPracticedAt"));
-
-    return mongoTemplate
-        .aggregate(aggregation, "typingRecord", MemberTypingAggregation.class)
-        .getMappedResults();
-  }
-
-  public List<Long> findDistinctMemberIds() {
-    Aggregation aggregation =
-        Aggregation.newAggregation(
-            Aggregation.match(Criteria.where("memberId").ne(null)),
+                Criteria.where("memberId").ne(null).and("completedAt").gte(from).lt(to)),
             Aggregation.group("memberId"),
             Aggregation.project().and("_id").as("memberId"));
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypingStatsBatchService.java
@@ -3,6 +3,7 @@ package com.typingpractice.typing_practice_be.typingrecord.statistics.service;
 import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
+import com.typingpractice.typing_practice_be.typingrecord.repository.MemberTypingAggregationRepository;
 import com.typingpractice.typing_practice_be.typingrecord.repository.TypingRecordRepository;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypingAggregation;
@@ -22,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MemberTypingStatsBatchService {
   private final MemberRepository memberRepository;
   private final TypingRecordRepository typingRecordRepository;
+  private final MemberTypingAggregationRepository typingAggregationRepository;
   private final MemberTypingStatsRepository memberTypingStatsRepository;
 
   private static final int CHUNK_SIZE = 500;
@@ -73,8 +75,8 @@ public class MemberTypingStatsBatchService {
 
       List<MemberTypingAggregation> aggregations =
           overwrite
-              ? typingRecordRepository.aggregateByMemberIds(chunk)
-              : typingRecordRepository.aggregateByMemberIdsBetween(chunk, from, to);
+              ? typingAggregationRepository.aggregateByMemberIds(chunk)
+              : typingAggregationRepository.aggregateByMemberIdsBetween(chunk, from, to);
 
       for (MemberTypingAggregation agg : aggregations) {
         upsert(agg.getMemberId(), agg, overwrite);

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/QuoteTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/QuoteTypingStatsBatchService.java
@@ -4,7 +4,7 @@ import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
-import com.typingpractice.typing_practice_be.typingrecord.repository.TypingRecordRepository;
+import com.typingpractice.typing_practice_be.typingrecord.repository.QuoteTypingAggregationRepository;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.QuoteTypingStats;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.QuoteTypingAggregation;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.QuoteTypingStatsRepository;
@@ -24,7 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class QuoteTypingStatsBatchService {
   private final QuoteRepository quoteRepository;
-  private final TypingRecordRepository typingRecordRepository;
+  private final QuoteTypingAggregationRepository typingAggregationRepository;
   private final QuoteTypingStatsRepository quoteTypingStatsRepository;
 
   private static final int PAGE_SIZE = 1000;
@@ -69,13 +69,13 @@ public class QuoteTypingStatsBatchService {
         // 타이핑 기록 통계값
         List<QuoteTypingAggregation> aggregations =
             overwrite
-                ? typingRecordRepository.aggregateByQuoteIds(quoteIds)
-                : typingRecordRepository.aggregateByQuoteIdsBetween(quoteIds, from, to);
+                ? typingAggregationRepository.aggregateByQuoteIds(quoteIds)
+                : typingAggregationRepository.aggregateByQuoteIdsBetween(quoteIds, from, to);
 
         Map<Long, Integer> totalAttemptsCount =
             overwrite
-                ? typingRecordRepository.countAllByQuoteIds(quoteIds)
-                : typingRecordRepository.countAllByQuoteIdsBetween(quoteIds, from, to);
+                ? typingAggregationRepository.countAllByQuoteIds(quoteIds)
+                : typingAggregationRepository.countAllByQuoteIdsBetween(quoteIds, from, to);
 
         // {quoteId: 타이핑 통계값} map 변환
         Map<Long, QuoteTypingAggregation> aggMap =


### PR DESCRIPTION
- QuoteTypingAggregationRepository, MemberTypingAggregationRepository, MemberDailyAggregationRepository로 분리
- findDistinctMemberIds/Between은 TypingRecordRepository에 유지
- MemberTypingStatsBatchService, QuoteTypingStatsBatchService 참조 변경