### PR TITLE
feat: MemberDailyStats 스케줄러 + 어드민 엔드포인트 추가 (5-4f)

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/DataInitService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/DataInitService.java
@@ -36,8 +36,8 @@ public class DataInitService implements CommandLineRunner {
   @Override
   @Transactional
   public void run(String... args) {
-    //    initGlobalQuoteStatistics();
-    //    initAdmin();
+    initGlobalQuoteStatistics();
+    initAdmin();
     //    List<Member> members = initMembers();
     //    List<Quote> quotes = initQuotes(members);
     //    initReports(members, quotes);

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
@@ -3,16 +3,16 @@ package com.typingpractice.typing_practice_be.statistics.controller;
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsBatchService;
+import com.typingpractice.typing_practice_be.statistics.dto.MemberStatsDayRequest;
+import com.typingpractice.typing_practice_be.statistics.dto.MemberStatsPeriodRequest;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.service.MemberDailyStatsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.MemberTypingStatsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.QuoteTypingStatsBatchService;
+import jakarta.validation.Valid;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import lombok.RequiredArgsConstructor;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,6 +21,7 @@ public class AdminStatisticsController {
   private final GlobalQuoteStatisticsBatchService globalQuoteStatisticsBatchService;
   private final QuoteTypingStatsBatchService quoteTypingStatsBatchService;
   private final MemberTypingStatsBatchService memberTypingStatsBatchService;
+  private final MemberDailyStatsBatchService memberDailyStatsBatchService;
 
   @PostMapping("/global-quote/recalculate")
   public ApiResponse<Void> recalculate() {
@@ -36,16 +37,13 @@ public class AdminStatisticsController {
 
   @PostMapping("/member-typing/recalculate")
   public ApiResponse<Void> recalculateMemberTypingStats(
-      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-          LocalDate startDate,
-      @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-          LocalDate endDate,
-      @RequestParam(defaultValue = TimeUtils.KST_ZONE) String timezone) {
+      @ModelAttribute @Valid MemberStatsPeriodRequest request) {
+
+    LocalDate startDate = request.getStartDate();
+    LocalDate endDate = request.getEndDate();
+    String timezone = request.getTimezone();
 
     if (startDate != null && endDate != null) {
-      if (startDate.isAfter(endDate)) {
-        throw new IllegalArgumentException("startDate는 endDate보다 같거나 이전이어야 합니다.");
-      }
       ZoneId zone = TimeUtils.parseZoneId(timezone);
 
       memberTypingStatsBatchService.runRecalculationForPeriod(
@@ -53,6 +51,16 @@ public class AdminStatisticsController {
     } else {
       memberTypingStatsBatchService.runManualRecalculation();
     }
+
+    return ApiResponse.ok(null);
+  }
+
+  @PostMapping("/member-daily/recalculate")
+  public ApiResponse<Void> recalculateMemberDailyStats(
+      @ModelAttribute @Valid MemberStatsDayRequest request) {
+
+    ZoneId zone = TimeUtils.parseZoneId(request.getTimezone());
+    memberDailyStatsBatchService.runRecalculationForDate(request.getDate(), zone);
 
     return ApiResponse.ok(null);
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/dto/MemberStatsDayRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/dto/MemberStatsDayRequest.java
@@ -1,0 +1,29 @@
+package com.typingpractice.typing_practice_be.statistics.dto;
+
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.format.annotation.DateTimeFormat;
+
+@Getter
+@ToString
+public class MemberStatsDayRequest {
+  @NotNull(message = "date는 필수입니다.")
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+  private final LocalDate date;
+
+  private final String timezone;
+
+  public MemberStatsDayRequest(LocalDate date, String timezone) {
+    this.date = date;
+    this.timezone = timezone != null ? timezone : TimeUtils.KST_ZONE;
+  }
+
+  @AssertTrue(message = "date는 KST 기준 어제 이하여야 합니다.")
+  private boolean isDateValid() {
+    return date == null || !date.isAfter(LocalDate.now(TimeUtils.KST).minusDays(1));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/dto/MemberStatsPeriodRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/dto/MemberStatsPeriodRequest.java
@@ -1,0 +1,42 @@
+package com.typingpractice.typing_practice_be.statistics.dto;
+
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import jakarta.validation.constraints.AssertTrue;
+import lombok.Getter;
+import lombok.ToString;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDate;
+
+@Getter
+@ToString
+public class MemberStatsPeriodRequest {
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+  private final LocalDate startDate;
+
+  @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+  private final LocalDate endDate;
+
+  private final String timezone;
+
+  public MemberStatsPeriodRequest(LocalDate startDate, LocalDate endDate, String timezone) {
+    this.startDate = startDate;
+    this.endDate = endDate;
+    this.timezone = timezone != null ? timezone : TimeUtils.KST_ZONE;
+  }
+
+  @AssertTrue(message = "startDate는 KST 기준 어제 이하여야 합니다.")
+  private boolean isStartDateValid() {
+    return startDate == null || !startDate.isAfter(LocalDate.now(TimeUtils.KST).minusDays(1));
+  }
+
+  @AssertTrue(message = "endDate는 KST 기준 어제 이하여야 합니다.")
+  private boolean isEndDateValid() {
+    return endDate == null || !endDate.isAfter(LocalDate.now(TimeUtils.KST).minusDays(1));
+  }
+
+  @AssertTrue(message = "startDate는 endDate보다 같거나 이전이어야 합니다.")
+  private boolean isDateRangeValid() {
+    return startDate == null || endDate == null || !startDate.isAfter(endDate);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.statistics.scheduler;
 
 import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsBatchService;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.service.MemberDailyStatsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.MemberTypingStatsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.QuoteTypingStatsBatchService;
 import lombok.RequiredArgsConstructor;
@@ -16,12 +17,14 @@ public class StatisticsScheduler {
   private final GlobalQuoteStatisticsBatchService globalQuoteStatisticsBatchService;
   private final QuoteTypingStatsBatchService quoteTypingStatsBatchService;
   private final MemberTypingStatsBatchService memberTypingStatsBatchService;
+  private final MemberDailyStatsBatchService memberDailyStatsBatchService;
 
   @Scheduled(cron = "0 0 3 * * *", zone = TimeUtils.KST_ZONE)
   public void runDailyBatch() {
     log.info("전역 통계 배치 시작");
     quoteTypingStatsBatchService.runScheduledBatch(); // 문장 별 타이핑 통계
     memberTypingStatsBatchService.runScheduledBatch(); // 개인 별 타이핑 통계
+    memberDailyStatsBatchService.runScheduledBatch(); // 개인 일간 타이핑 통계
     globalQuoteStatisticsBatchService.runScheduledBatch(); // 전체 문장의 profile 통계
     log.info("전역 통계 배치 완료");
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberDailyStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberDailyStatsBatchService.java
@@ -10,6 +10,7 @@ import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberD
 import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberDailyStatsRepository;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -44,9 +45,9 @@ public class MemberDailyStatsBatchService {
   }
 
   @Transactional
-  public void runRecalculationForDate(LocalDate date) {
-    LocalDateTime from = TimeUtils.startOfDayKstToUtc(date);
-    LocalDateTime to = TimeUtils.endOfDayKstToUtc(date);
+  public void runRecalculationForDate(LocalDate date, ZoneId zone) {
+    LocalDateTime from = TimeUtils.startOfDayToUtc(date, zone);
+    LocalDateTime to = TimeUtils.endOfDayToUtc(date, zone);
 
     log.info("MemberDailyStats 날짜 재계산 시작 - 날짜: {} (범위: {} ~ {})", date, from, to);
 


### PR DESCRIPTION
- MemberDailyStatsBatchService.runRecalculationForDate ZoneId 파라미터 추가
- MemberStatsPeriodRequest DTO 추가 (startDate, endDate, timezone, KST 기준 검증)
- MemberStatsDayRequest DTO 추가 (date, timezone, KST 기준 검증)
- AdminStatisticsController.recalculateMemberTypingStats @RequestParam → DTO로 리팩토링
- AdminStatisticsController.recalculateMemberDailyStats 엔드포인트 추가
- StatisticsScheduler MemberDailyStats 배치 추가