### PR TITLE
feat: MemberTypoStats/Detail 배치 서비스 및 MongoDB 집계 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/MemberTypoAggregationRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/MemberTypoAggregationRepository.java
@@ -1,0 +1,123 @@
+package com.typingpractice.typing_practice_be.typingrecord.repository;
+
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypoAggregation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.ConditionalOperators;
+import org.springframework.data.mongodb.core.aggregation.Fields;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberTypoAggregationRepository {
+  private final MongoTemplate mongoTemplate;
+
+  public List<MemberTypoAggregation> aggregateByMemberIdsBetween(
+      List<Long> memberIds, LocalDateTime from, LocalDateTime to) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(
+                Criteria.where("memberId")
+                    .in(memberIds)
+                    .and("completedAt")
+                    .gte(from)
+                    .lt(to)
+                    .and("outlier")
+                    .is(false)),
+            Aggregation.unwind("typos"),
+            Aggregation.group(
+                    Fields.fields("memberId")
+                        .and("language")
+                        .and("expected", "typos.expected")
+                        .and("actual", "typos.actual"))
+                .count()
+                .as("count")
+                .sum(
+                    ConditionalOperators.when(Criteria.where("typos.type").is("INITIAL"))
+                        .then(1)
+                        .otherwise(0))
+                .as("initialCount")
+                .sum(
+                    ConditionalOperators.when(Criteria.where("typos.type").is("MEDIAL"))
+                        .then(1)
+                        .otherwise(0))
+                .as("medialCount")
+                .sum(
+                    ConditionalOperators.when(Criteria.where("typos.type").is("FINAL"))
+                        .then(1)
+                        .otherwise(0))
+                .as("finalCount")
+                .sum(
+                    ConditionalOperators.when(Criteria.where("typos.type").is("LETTER"))
+                        .then(1)
+                        .otherwise(0))
+                .as("letterCount"),
+            Aggregation.project()
+                .and("_id.memberId")
+                .as("memberId")
+                .and("_id.language")
+                .as("language")
+                .and("_id.expected")
+                .as("expected")
+                .and("_id.actual")
+                .as("actual")
+                .andInclude("count", "initialCount", "medialCount", "finalCount", "letterCount"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", MemberTypoAggregation.class)
+        .getMappedResults();
+  }
+
+  public List<MemberTypoAggregation> aggregateByMemberIds(List<Long> memberIds) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(Criteria.where("memberId").in(memberIds).and("outlier").is(false)),
+            Aggregation.unwind("typos"),
+            Aggregation.group(
+                    Fields.fields("memberId")
+                        .and("language")
+                        .and("expected", "typos.expected")
+                        .and("actual", "typos.actual"))
+                .count()
+                .as("count")
+                .sum(
+                    ConditionalOperators.when(Criteria.where("typos.type").is("INITIAL"))
+                        .then(1)
+                        .otherwise(0))
+                .as("initialCount")
+                .sum(
+                    ConditionalOperators.when(Criteria.where("typos.type").is("MEDIAL"))
+                        .then(1)
+                        .otherwise(0))
+                .as("medialCount")
+                .sum(
+                    ConditionalOperators.when(Criteria.where("typos.type").is("FINAL"))
+                        .then(1)
+                        .otherwise(0))
+                .as("finalCount")
+                .sum(
+                    ConditionalOperators.when(Criteria.where("typos.type").is("LETTER"))
+                        .then(1)
+                        .otherwise(0))
+                .as("letterCount"),
+            Aggregation.project()
+                .and("_id.memberId")
+                .as("memberId")
+                .and("_id.language")
+                .as("language")
+                .and("_id.expected")
+                .as("expected")
+                .and("_id.actual")
+                .as("actual")
+                .andInclude("count", "initialCount", "medialCount", "finalCount", "letterCount"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", MemberTypoAggregation.class)
+        .getMappedResults();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypoStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypoStatsBatchService.java
@@ -1,0 +1,167 @@
+package com.typingpractice.typing_practice_be.typingrecord.statistics.service;
+
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.typingrecord.repository.MemberTypoAggregationRepository;
+import com.typingpractice.typing_practice_be.typingrecord.repository.TypingRecordRepository;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypoDetailStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypoStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypoAggregation;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypoDetailStatsRepository;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypoStatsRepository;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberTypoStatsBatchService {
+  private final TypingRecordRepository typingRecordRepository;
+  private final MemberTypoAggregationRepository memberTypoAggregationRepository;
+  private final MemberTypoStatsRepository memberTypoStatsRepository;
+  private final MemberTypoDetailStatsRepository memberTypoDetailStatsRepository;
+  private final MemberRepository memberRepository;
+
+  private static final int CHUNK_SIZE = 500;
+
+  // 스케줄 배치: 전날 하루치 증분
+  @Transactional
+  public void runScheduledBatch() {
+    LocalDate yesterdayKst = LocalDate.now(TimeUtils.KST).minusDays(1);
+
+    LocalDateTime from = TimeUtils.startOfDayKstToUtc(yesterdayKst);
+    LocalDateTime to = TimeUtils.endOfDayKstToUtc(yesterdayKst);
+
+    log.info("MemberTypoStats 증분 배치 시작 - 범위: {} ~ {}", from, to);
+
+    List<Long> memberIds = typingRecordRepository.findDistinctMemberIdsBetween(from, to);
+    int totalProcessed = processChunks(memberIds, from, to, false);
+
+    log.info("MemberTypoStats 증분 배치 완료 - {}건 처리", totalProcessed);
+  }
+
+  // 어드민: 전체 재계산
+  @Transactional
+  public void runManualRecalculation() {
+    log.info("MemberTypoSTats 전체 재계산 시작");
+
+    memberTypoDetailStatsRepository.deleteAllInBatch();
+    memberTypoStatsRepository.deleteAllInBatch();
+
+    List<Long> memberIds = typingRecordRepository.findDistinctMemberIds();
+    int totalProcessed = processChunks(memberIds, null, null, true);
+
+    log.info("MemberTypoStats 전체 재계산 완료 - {}건 처리", totalProcessed);
+  }
+
+  private int processChunks(
+      List<Long> memberIds, LocalDateTime from, LocalDateTime to, boolean isManual) {
+    int totalProcessed = 0;
+
+    for (int i = 0; i < memberIds.size(); i += CHUNK_SIZE) {
+      List<Long> chunk = memberIds.subList(i, Math.min(i + CHUNK_SIZE, memberIds.size()));
+
+      List<MemberTypoAggregation> aggregations =
+          isManual
+              ? memberTypoAggregationRepository.aggregateByMemberIds(chunk)
+              : memberTypoAggregationRepository.aggregateByMemberIdsBetween(chunk, from, to);
+
+      for (MemberTypoAggregation agg : aggregations) {
+        upsertDetail(agg, isManual);
+        totalProcessed++;
+      }
+
+      aggregations.stream()
+          .collect(
+              Collectors.groupingBy(
+                  agg -> agg.getMemberId() + "_" + agg.getLanguage() + "_" + agg.getExpected()))
+          .forEach(
+              (key, group) -> {
+                int totalCount = group.stream().mapToInt(MemberTypoAggregation::getCount).sum();
+                MemberTypoAggregation first = group.getFirst();
+                upsertTypoStats(
+                    first.getMemberId(),
+                    first.getLanguage(),
+                    first.getExpected(),
+                    totalCount,
+                    isManual);
+              });
+    }
+
+    return totalProcessed;
+  }
+
+  private Member findMember(Long memberId) {
+    Member member = memberRepository.findById(memberId).orElse(null);
+    if (member == null) {
+      log.warn("Member 미존재, 스킵 - memberId: {}", memberId);
+    }
+    return member;
+  }
+
+  private void upsertDetail(MemberTypoAggregation agg, boolean isManual) {
+    // 기존 정보 merge
+    if (!isManual) {
+      MemberTypoDetailStats stats =
+          memberTypoDetailStatsRepository
+              .findByMemberIdAndLanguageAndExpectedAndActual(
+                  agg.getMemberId(), agg.getLanguage(), agg.getExpected(), agg.getActual())
+              .orElse(null);
+
+      if (stats != null) {
+        stats.merge(
+            agg.getCount(),
+            agg.getInitialCount(),
+            agg.getMedialCount(),
+            agg.getFinalCount(),
+            agg.getLetterCount());
+        return;
+      }
+    }
+
+    // 새로 생성
+    Member member = findMember(agg.getMemberId());
+    if (member == null) return;
+
+    memberTypoDetailStatsRepository.save(
+        MemberTypoDetailStats.create(
+            member,
+            agg.getLanguage(),
+            agg.getExpected(),
+            agg.getActual(),
+            agg.getCount(),
+            agg.getInitialCount(),
+            agg.getMedialCount(),
+            agg.getFinalCount(),
+            agg.getLetterCount()));
+  }
+
+  private void upsertTypoStats(
+      Long memberId, QuoteLanguage language, String expected, int count, boolean isManual) {
+    if (!isManual) {
+      MemberTypoStats stats =
+          memberTypoStatsRepository
+              .findByMemberIdAndLanguageAndExpected(memberId, language, expected)
+              .orElse(null);
+
+      if (stats != null) {
+        stats.merge(count);
+        return;
+      }
+    }
+
+    Member member = findMember(memberId);
+    if (member == null) return;
+
+    memberTypoStatsRepository.save(MemberTypoStats.create(member, language, expected, count));
+  }
+}


### PR DESCRIPTION
- MemberTypoAggregationRepository: 오타 집계 MongoDB aggregation 구현
  - aggregateByMemberIds: 전체 재계산용
  - aggregateByMemberIdsBetween: 증분 배치용 (기간 필터)
  - expected/actual 기준 그룹핑 + TypoType(INITIAL/MEDIAL/FINAL/LETTER) 카운트 분리

- MemberTypoStatsBatchService: 배치 서비스 구현
  - runScheduledBatch: 전날 KST 하루치 증분 처리
  - runManualRecalculation: 전체 deleteAllInBatch 후 재집계
  - upsertDetail: MemberTypoDetailStats merge/create 처리
  - upsertTypoStats: MemberTypoStats merge/create 처리
  - 500건 단위 청크 처리