### PR TITLE
feat: 오늘 타이핑 통계 Redis 캐시 레이어 + 이벤트 리스너 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/event/TypingRecordEventListener.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/event/TypingRecordEventListener.java
@@ -1,0 +1,23 @@
+package com.typingpractice.typing_practice_be.typingrecord.event;
+
+import com.typingpractice.typing_practice_be.typingrecord.statistics.service.TodayTypingStatsRedisService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class TypingRecordEventListener {
+  private final TodayTypingStatsRedisService todayTypingStatsRedisService;
+
+  @EventListener
+  public void handleTypingRecordSaved(TypingRecordSavedEvent event) {
+    try {
+      todayTypingStatsRedisService.incrementTyping(event);
+    } catch (Exception e) {
+      log.error("Redis 오늘 통계 증분 실패 - memberId: {}", event.getMemberId());
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/MemberDailyAggregation.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/MemberDailyAggregation.java
@@ -11,13 +11,35 @@ public class MemberDailyAggregation {
   private Long memberId;
   private String date; // MongoDB에서 "%Y-%m-%d" 포맷으로 수신
   private int attempts;
-  private double avgCpm;
-  private double avgAcc;
+  private float avgCpm;
+  private float avgAcc;
   private int bestCpm;
   private int resetCount;
   private float practiceTimeMin;
 
   public LocalDate getDateAsLocalDate() {
     return LocalDate.parse(date);
+  }
+
+  public static MemberDailyAggregation create(
+      Long memberId,
+      String date,
+      int attempts,
+      float avgCpm,
+      float avgAcc,
+      int bestCpm,
+      int resetCount,
+      float practiceTimeMin) {
+    MemberDailyAggregation agg = new MemberDailyAggregation();
+    agg.memberId = memberId;
+    agg.date = date;
+    agg.attempts = attempts;
+    agg.avgCpm = avgCpm;
+    agg.avgAcc = avgAcc;
+    agg.bestCpm = bestCpm;
+    agg.resetCount = resetCount;
+    agg.practiceTimeMin = practiceTimeMin;
+
+    return agg;
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/MemberTypingAggregation.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/MemberTypingAggregation.java
@@ -10,10 +10,32 @@ import java.time.LocalDateTime;
 public class MemberTypingAggregation {
   private Long memberId;
   private int totalAttempts;
-  private double avgCpm;
-  private double avgAcc;
+  private float avgCpm;
+  private float avgAcc;
   private int bestCpm;
   private float totalPracticeTimeMin;
   private int totalResetCount;
   private LocalDateTime lastPracticedAt;
+
+  public static MemberTypingAggregation create(
+      Long memberId,
+      int attempts,
+      float avgCpm,
+      float avgAcc,
+      int bestCpm,
+      int resetCount,
+      float practiceTimeMin,
+      LocalDateTime lastPracticedAt) {
+    MemberTypingAggregation agg = new MemberTypingAggregation();
+    agg.memberId = memberId;
+    agg.totalAttempts = attempts;
+    agg.avgCpm = avgCpm;
+    agg.avgAcc = avgAcc;
+    agg.bestCpm = bestCpm;
+    agg.totalResetCount = resetCount;
+    agg.totalPracticeTimeMin = practiceTimeMin;
+    agg.lastPracticedAt = lastPracticedAt;
+
+    return agg;
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/TodayTypingSnapshot.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/TodayTypingSnapshot.java
@@ -1,0 +1,49 @@
+package com.typingpractice.typing_practice_be.typingrecord.statistics.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TodayTypingSnapshot {
+  private int totalAttempts;
+  private float avgCpm;
+  private float avgAcc;
+  private int bestCpm;
+  private float totalPracticeTimeMin;
+  private int totalResetCount;
+
+  public static TodayTypingSnapshot create(
+      int totalAttempts,
+      float avgCpm,
+      float avgAcc,
+      int bestCpm,
+      float totalPracticeTimeMin,
+      int totalResetCount) {
+    TodayTypingSnapshot snapshot = new TodayTypingSnapshot();
+    snapshot.totalAttempts = totalAttempts;
+    snapshot.avgCpm = avgCpm;
+    snapshot.avgAcc = avgAcc;
+    snapshot.bestCpm = bestCpm;
+    snapshot.totalPracticeTimeMin = totalPracticeTimeMin;
+    snapshot.totalResetCount = totalResetCount;
+    return snapshot;
+  }
+
+  public static TodayTypingSnapshot empty() {
+    return new TodayTypingSnapshot();
+  }
+
+  public void increment(int cpm, float accuracy, int charLength, int resetCount) {
+    int newTotal = this.totalAttempts + 1;
+    this.avgCpm = (this.avgCpm * this.totalAttempts + cpm) / newTotal;
+    this.avgAcc = (this.avgAcc * this.totalAttempts + accuracy) / newTotal;
+    this.totalAttempts = newTotal;
+    this.bestCpm = Math.max(this.bestCpm, cpm);
+    if (cpm > 0) {
+      this.totalPracticeTimeMin += (float) charLength / cpm;
+    }
+    this.totalResetCount += resetCount;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/TodayTypingStatsRedisService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/TodayTypingStatsRedisService.java
@@ -1,0 +1,123 @@
+package com.typingpractice.typing_practice_be.typingrecord.statistics.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.typingrecord.event.TypingRecordSavedEvent;
+import com.typingpractice.typing_practice_be.typingrecord.repository.MemberTypingAggregationRepository;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypingAggregation;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypingSnapshot;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class TodayTypingStatsRedisService {
+  private final StringRedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
+  private final MemberTypingAggregationRepository memberTypingAggregationRepository;
+
+  private static final String TYPING_KEY_PREFIX = "today:typing:";
+
+  private String typingKey(Long memberId) {
+    // today:typing:1234
+    return TYPING_KEY_PREFIX + memberId;
+  }
+
+  private Duration ttlUntilMidnightKst() {
+    LocalDateTime nowKst = LocalDateTime.now(TimeUtils.KST);
+    LocalDateTime midnightKst = LocalDateTime.of(nowKst.toLocalDate(), LocalTime.MAX);
+    return Duration.between(nowKst, midnightKst);
+  }
+
+  // 이벤트 수신 후 오늘 통계 업데이트
+  public void incrementTyping(TypingRecordSavedEvent event) {
+    String key = typingKey(event.getMemberId());
+
+    TodayTypingSnapshot snapshot = getSnapshotOrEmpty(key);
+    snapshot.increment(
+        event.getCpm(), event.getAccuracy(), event.getCharLength(), event.getResetCount());
+
+    setSnapshot(key, snapshot);
+  }
+
+  // 오늘 통계 조회
+  public TodayTypingSnapshot getTyping(Long memberId) {
+    String key = typingKey(memberId);
+    String json = redisTemplate.opsForValue().get(key);
+
+    if (json != null) {
+      return deserialize(json, TodayTypingSnapshot.class);
+    }
+
+    return fallbackTyping(memberId);
+  }
+
+  public void invalidateTyping(Long memberId) {
+    redisTemplate.delete(typingKey(memberId));
+  }
+
+  private TodayTypingSnapshot getSnapshotOrEmpty(String key) {
+    String json = redisTemplate.opsForValue().get(key);
+    if (json != null) {
+      return deserialize(json, TodayTypingSnapshot.class);
+    }
+    return TodayTypingSnapshot.empty();
+  }
+
+  private void setSnapshot(String key, TodayTypingSnapshot snapshot) {
+    String json = serialize(snapshot);
+    redisTemplate.opsForValue().set(key, json, ttlUntilMidnightKst());
+  }
+
+  private TodayTypingSnapshot fallbackTyping(Long memberId) {
+    LocalDate todayKst = LocalDate.now(TimeUtils.KST);
+    LocalDateTime from = TimeUtils.startOfDayKstToUtc(todayKst);
+    LocalDateTime to = TimeUtils.endOfDayKstToUtc(todayKst);
+
+    List<MemberTypingAggregation> results =
+        memberTypingAggregationRepository.aggregateByMemberIdsBetween(List.of(memberId), from, to);
+
+    if (results.isEmpty()) {
+      return TodayTypingSnapshot.empty();
+    }
+
+    MemberTypingAggregation agg = results.getFirst();
+    TodayTypingSnapshot snapshot =
+        TodayTypingSnapshot.create(
+            agg.getTotalAttempts(),
+            agg.getAvgCpm(),
+            agg.getAvgAcc(),
+            agg.getBestCpm(),
+            agg.getTotalPracticeTimeMin(),
+            agg.getTotalResetCount());
+
+    setSnapshot(typingKey(memberId), snapshot);
+    return snapshot;
+  }
+
+  private String serialize(Object obj) {
+    try {
+      return objectMapper.writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Redis 직렬화 실패", e);
+    }
+  }
+
+  private <T> T deserialize(String json, Class<T> clazz) {
+    try {
+      return objectMapper.readValue(json, clazz);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Redis 역직렬화 실패", e);
+    }
+  }
+}


### PR DESCRIPTION
- TodayTypingSnapshot: Redis에 저장되는 오늘 타이핑 통계 DTO
- TodayTypingStatsRedisService: 증분 갱신, 조회(캐시 미스 시 MongoDB fallback), 무효화
- TypingRecordEventListener: 이벤트 수신 후 Redis 증분, 실패 시 로그만 남김
- MemberTypingAggregation, MemberDailyAggregation: avgCpm/avgAcc double → float 통일