### PR TITLE
feat: 오늘 Typo 통계 Redis 캐시 레이어 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/event/TypingRecordEventListener.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/event/TypingRecordEventListener.java
@@ -16,6 +16,7 @@ public class TypingRecordEventListener {
   public void handleTypingRecordSaved(TypingRecordSavedEvent event) {
     try {
       todayTypingStatsRedisService.incrementTyping(event);
+      todayTypingStatsRedisService.incrementTypo(event);
     } catch (Exception e) {
       log.error("Redis 오늘 통계 증분 실패 - memberId: {}", event.getMemberId());
     }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/TodayTypoSnapshot.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/TodayTypoSnapshot.java
@@ -1,0 +1,36 @@
+package com.typingpractice.typing_practice_be.typingrecord.statistics.dto;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class TodayTypoSnapshot {
+  private Map<String, Integer> typoCountMap;
+
+  public static TodayTypoSnapshot create(Map<String, Integer> typoCountMap) {
+    TodayTypoSnapshot snapshot = new TodayTypoSnapshot();
+    snapshot.typoCountMap = new HashMap<>(typoCountMap);
+    return snapshot;
+  }
+
+  public static TodayTypoSnapshot empty() {
+    TodayTypoSnapshot snapshot = new TodayTypoSnapshot();
+    snapshot.typoCountMap = new HashMap<>();
+    return snapshot;
+  }
+
+  public void increment(QuoteLanguage language, String expected) {
+    String key = language + ":" + expected;
+    typoCountMap.merge(key, 1, Integer::sum);
+  }
+
+  public static String toKey(QuoteLanguage language, String expected) {
+    return language + ":" + expected;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/TodayTypingStatsRedisService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/TodayTypingStatsRedisService.java
@@ -3,10 +3,14 @@ package com.typingpractice.typing_practice_be.typingrecord.statistics.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.typingrecord.domain.Typo;
 import com.typingpractice.typing_practice_be.typingrecord.event.TypingRecordSavedEvent;
 import com.typingpractice.typing_practice_be.typingrecord.repository.MemberTypingAggregationRepository;
+import com.typingpractice.typing_practice_be.typingrecord.repository.MemberTypoAggregationRepository;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypingAggregation;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypoAggregation;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypingSnapshot;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypoSnapshot;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -16,7 +20,9 @@ import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Slf4j
 @Service
@@ -25,12 +31,19 @@ public class TodayTypingStatsRedisService {
   private final StringRedisTemplate redisTemplate;
   private final ObjectMapper objectMapper;
   private final MemberTypingAggregationRepository memberTypingAggregationRepository;
+  private final MemberTypoAggregationRepository memberTypoAggregationRepository;
 
   private static final String TYPING_KEY_PREFIX = "today:typing:";
+  private static final String TYPO_KEY_PREFIX = "today:typo:";
 
   private String typingKey(Long memberId) {
     // today:typing:1234
     return TYPING_KEY_PREFIX + memberId;
+  }
+
+  private String typoKey(Long memberId) {
+    // today:typo:1234
+    return TYPO_KEY_PREFIX + memberId;
   }
 
   private Duration ttlUntilMidnightKst() {
@@ -50,6 +63,20 @@ public class TodayTypingStatsRedisService {
     setSnapshot(key, snapshot);
   }
 
+  public void incrementTypo(TypingRecordSavedEvent event) {
+    if (event.isOutlier()) return;
+    if (event.getTypos() == null || event.getTypos().isEmpty()) return;
+
+    String key = typoKey(event.getMemberId());
+
+    TodayTypoSnapshot snapshot = getTypoSnapshotOrEmpty(key);
+    for (Typo typo : event.getTypos()) {
+      snapshot.increment(event.getLanguage(), typo.getExpected());
+    }
+
+    setTypoSnapshot(key, snapshot);
+  }
+
   // 오늘 통계 조회
   public TodayTypingSnapshot getTyping(Long memberId) {
     String key = typingKey(memberId);
@@ -62,8 +89,23 @@ public class TodayTypingStatsRedisService {
     return fallbackTyping(memberId);
   }
 
+  public TodayTypoSnapshot getTypo(Long memberId) {
+    String key = typoKey(memberId);
+    String json = redisTemplate.opsForValue().get(key);
+
+    if (json != null) {
+      return deserialize(json, TodayTypoSnapshot.class);
+    }
+
+    return fallbackTypo(memberId);
+  }
+
   public void invalidateTyping(Long memberId) {
     redisTemplate.delete(typingKey(memberId));
+  }
+
+  public void invalidateTypo(Long memberId) {
+    redisTemplate.delete(typoKey(memberId));
   }
 
   private TodayTypingSnapshot getSnapshotOrEmpty(String key) {
@@ -74,7 +116,21 @@ public class TodayTypingStatsRedisService {
     return TodayTypingSnapshot.empty();
   }
 
+  private TodayTypoSnapshot getTypoSnapshotOrEmpty(String key) {
+    String json = redisTemplate.opsForValue().get(key);
+    if (json != null) {
+      return deserialize(json, TodayTypoSnapshot.class);
+    }
+
+    return TodayTypoSnapshot.empty();
+  }
+
   private void setSnapshot(String key, TodayTypingSnapshot snapshot) {
+    String json = serialize(snapshot);
+    redisTemplate.opsForValue().set(key, json, ttlUntilMidnightKst());
+  }
+
+  private void setTypoSnapshot(String key, TodayTypoSnapshot snapshot) {
     String json = serialize(snapshot);
     redisTemplate.opsForValue().set(key, json, ttlUntilMidnightKst());
   }
@@ -102,6 +158,30 @@ public class TodayTypingStatsRedisService {
             agg.getTotalResetCount());
 
     setSnapshot(typingKey(memberId), snapshot);
+    return snapshot;
+  }
+
+  private TodayTypoSnapshot fallbackTypo(Long memberId) {
+    LocalDate todayKst = LocalDate.now(TimeUtils.KST);
+    LocalDateTime from = TimeUtils.startOfDayKstToUtc(todayKst);
+    LocalDateTime to = TimeUtils.endOfDayKstToUtc(todayKst);
+
+    List<MemberTypoAggregation> results =
+        memberTypoAggregationRepository.aggregateByMemberIdsBetween(List.of(memberId), from, to);
+
+    if (results.isEmpty()) {
+      return TodayTypoSnapshot.empty();
+    }
+
+    Map<String, Integer> map = new HashMap<>();
+    for (MemberTypoAggregation agg : results) {
+      String key = TodayTypoSnapshot.toKey(agg.getLanguage(), agg.getExpected());
+      map.merge(key, agg.getCount(), Integer::sum);
+    }
+
+    TodayTypoSnapshot snapshot = TodayTypoSnapshot.create(map);
+    setTypoSnapshot(typoKey(memberId), snapshot);
+
     return snapshot;
   }
 


### PR DESCRIPTION
- TodayTypoSnapshot: expected 단위 오타 카운트 Map (language:expected → count)
- TodayTypingStatsRedisService: Typo 증분/조회/무효화 추가
  - incrementTypo: outlier 제외, typos 순회하여 expected별 카운트 증분
  - getTypo: 캐시 미스 시 MongoDB fallback
  - invalidateTypo: 리프레시용 키 삭제
- TypingRecordEventListener: incrementTypo 호출 추가