### PR TITLE
feat: MemberTypingStats 조회 + 리프레시 API 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -16,6 +16,8 @@ public enum ErrorCode {
 
   AUTH_INVALID_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
 
+  REFRESH_COOLDOWN(HttpStatus.TOO_MANY_REQUESTS, "잠시 후 다시 시도해주세요."),
+
   MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "회원 정보를 찾을 수 없습니다."),
   MEMBER_NOT_PROCESSABLE(HttpStatus.BAD_REQUEST, "처리할 수 없는 회원입니다."),
   MEMBER_DUPLICATE_NICKNAME(HttpStatus.CONFLICT, "중복된 닉네임입니다."),

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberStatisticsController.java
@@ -1,0 +1,34 @@
+package com.typingpractice.typing_practice_be.statistics.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.statistics.service.MemberStatisticsService;
+import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypingStatsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members/me/stats")
+@RequiredArgsConstructor
+public class MemberStatisticsController {
+  private final MemberStatisticsService memberStatisticsService;
+
+  @GetMapping("/typing")
+  public ApiResponse<MemberTypingStatsResponse> getTypingStats() {
+    Long memberId = getAuthenticatedMemberId();
+    return ApiResponse.ok(memberStatisticsService.getTypingStats(memberId));
+  }
+
+  @PostMapping("/refresh")
+  public ApiResponse<MemberTypingStatsResponse> refreshStats() {
+    Long memberId = getAuthenticatedMemberId();
+    return ApiResponse.ok(memberStatisticsService.refreshStats(memberId));
+  }
+
+  private Long getAuthenticatedMemberId() {
+    return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/exception/RefreshCooldownException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/exception/RefreshCooldownException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.statistics.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class RefreshCooldownException extends BusinessException {
+  public RefreshCooldownException() {
+    super(ErrorCode.REFRESH_COOLDOWN);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
@@ -1,0 +1,67 @@
+package com.typingpractice.typing_practice_be.statistics.service;
+
+import com.typingpractice.typing_practice_be.statistics.exception.RefreshCooldownException;
+import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypingStatsResponse;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypingSnapshot;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypingStatsRepository;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.service.TodayTypingStatsRedisService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberStatisticsService {
+  private final MemberTypingStatsRepository memberTypingStatsRepository;
+  private final TodayTypingStatsRedisService todayTypingStatsRedisService;
+  private final StringRedisTemplate redisTemplate;
+
+  private static final String COOLDOWN_KEY_PREFIX = "cooldown:refresh:";
+  private static final Duration COOLDOWN_DURATION = Duration.ofMinutes(1);
+
+  public MemberTypingStatsResponse getTypingStats(Long memberId) {
+    MemberTypingStats pg = memberTypingStatsRepository.findByMemberId(memberId).orElse(null);
+    TodayTypingSnapshot today = todayTypingStatsRedisService.getTyping(memberId);
+
+    if (pg == null && today.getTotalAttempts() == 0) {
+      return MemberTypingStatsResponse.empty();
+    }
+    if (pg == null) {
+      return MemberTypingStatsResponse.from(today);
+    }
+    if (today.getTotalAttempts() == 0) {
+      return MemberTypingStatsResponse.from(pg);
+    }
+
+    return MemberTypingStatsResponse.merge(pg, today);
+  }
+
+  public MemberTypingStatsResponse refreshStats(Long memberId) {
+    checkCooldown(memberId);
+
+    todayTypingStatsRedisService.invalidateTyping(memberId);
+    todayTypingStatsRedisService.invalidateTypo(memberId);
+    todayTypingStatsRedisService.invalidateTypoDetail(memberId);
+
+    setCooldown(memberId);
+
+    return getTypingStats(memberId);
+  }
+
+  private void checkCooldown(Long memberId) {
+    String key = COOLDOWN_KEY_PREFIX + memberId;
+    if (redisTemplate.hasKey(key)) {
+      throw new RefreshCooldownException();
+    }
+  }
+
+  private void setCooldown(Long memberId) {
+    String key = COOLDOWN_KEY_PREFIX + memberId;
+    redisTemplate.opsForValue().set(key, "1", COOLDOWN_DURATION);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberTypingStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberTypingStatsResponse.java
@@ -1,0 +1,76 @@
+package com.typingpractice.typing_practice_be.typingrecord.dto;
+
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypingSnapshot;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class MemberTypingStatsResponse {
+  private int totalAttempts;
+  private float avgCpm;
+  private float avgAcc;
+  private int bestCpm;
+  private float totalPracticeTimeMin;
+  private int totalResetCount;
+
+  public static MemberTypingStatsResponse create(
+      int totalAttempts,
+      float avgCpm,
+      float avgAcc,
+      int bestCpm,
+      float totalPracticeTimeMin,
+      int totalResetCount) {
+    MemberTypingStatsResponse response = new MemberTypingStatsResponse();
+    response.totalAttempts = totalAttempts;
+    response.avgCpm = avgCpm;
+    response.avgAcc = avgAcc;
+    response.bestCpm = bestCpm;
+    response.totalPracticeTimeMin = totalPracticeTimeMin;
+    response.totalResetCount = totalResetCount;
+    return response;
+  }
+
+  public static MemberTypingStatsResponse empty() {
+    return new MemberTypingStatsResponse();
+  }
+
+  public static MemberTypingStatsResponse from(MemberTypingStats stats) {
+    return create(
+        stats.getTotalAttempts(),
+        stats.getAvgCpm(),
+        stats.getAvgAcc(),
+        stats.getBestCpm(),
+        stats.getTotalPracticeTimeMin(),
+        stats.getTotalResetCount());
+  }
+
+  public static MemberTypingStatsResponse from(TodayTypingSnapshot today) {
+    return create(
+        today.getTotalAttempts(),
+        today.getAvgCpm(),
+        today.getAvgAcc(),
+        today.getBestCpm(),
+        today.getTotalPracticeTimeMin(),
+        today.getTotalResetCount());
+  }
+
+  public static MemberTypingStatsResponse merge(MemberTypingStats pg, TodayTypingSnapshot today) {
+    int mergedAttempts = pg.getTotalAttempts() + today.getTotalAttempts();
+    float mergedAvgCpm =
+        (pg.getAvgCpm() * pg.getTotalAttempts() + today.getAvgCpm() * today.getTotalAttempts())
+            / mergedAttempts;
+    float mergedAvgAcc =
+        (pg.getAvgAcc() * pg.getTotalAttempts() + today.getAvgAcc() * today.getTotalAttempts())
+            / mergedAttempts;
+
+    return create(
+        mergedAttempts,
+        mergedAvgCpm,
+        mergedAvgAcc,
+        Math.max(pg.getBestCpm(), today.getBestCpm()),
+        pg.getTotalPracticeTimeMin() + today.getTotalPracticeTimeMin(),
+        pg.getTotalResetCount() + today.getTotalResetCount());
+  }
+}


### PR DESCRIPTION
- GET /members/me/stats/typing: PostgreSQL(확정) + Redis(오늘) 합산하여 응답
- POST /members/me/stats/refresh: 오늘 통계 무효화 + 재계산 (1분 쿨다운)
- MemberStatisticsService: 합산 로직, 쿨다운 체크/설정
- MemberTypingStatsResponse: 합산 팩토리 메서드 (from, merge, empty)
- RefreshCooldownException + ErrorCode.REFRESH_COOLDOWN (429)