### PR TITLE
feat: MemberDailyStats 조회 API 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberStatisticsController.java
@@ -1,14 +1,14 @@
 package com.typingpractice.typing_practice_be.statistics.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.statistics.dto.MemberDailyStatsRequest;
 import com.typingpractice.typing_practice_be.statistics.service.MemberStatisticsService;
+import com.typingpractice.typing_practice_be.typingrecord.dto.MemberDailyStatsResponse;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypingStatsResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/members/me/stats")
@@ -20,6 +20,13 @@ public class MemberStatisticsController {
   public ApiResponse<MemberTypingStatsResponse> getTypingStats() {
     Long memberId = getAuthenticatedMemberId();
     return ApiResponse.ok(memberStatisticsService.getTypingStats(memberId));
+  }
+
+  @GetMapping("/daily")
+  public ApiResponse<MemberDailyStatsResponse> getDailyStats(
+      @ModelAttribute @Valid MemberDailyStatsRequest request) {
+    Long memberId = getAuthenticatedMemberId();
+    return ApiResponse.ok(memberStatisticsService.getDailyStats(memberId, request.getDays()));
   }
 
   @PostMapping("/refresh")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/dto/MemberDailyStatsRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/dto/MemberDailyStatsRequest.java
@@ -1,0 +1,18 @@
+package com.typingpractice.typing_practice_be.statistics.dto;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class MemberDailyStatsRequest {
+  @Min(value = 7, message = "days는 최소 7입니다.")
+  @Max(value = 90, message = "days는 최대 90입니다.")
+  private final int days;
+
+  public MemberDailyStatsRequest(Integer days) {
+    this.days = days != null ? days : 7;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
@@ -1,9 +1,13 @@
 package com.typingpractice.typing_practice_be.statistics.service;
 
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.statistics.exception.RefreshCooldownException;
+import com.typingpractice.typing_practice_be.typingrecord.dto.MemberDailyStatsResponse;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypingStatsResponse;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberDailyStats;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypingSnapshot;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberDailyStatsRepository;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypingStatsRepository;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.TodayTypingStatsRedisService;
 import lombok.RequiredArgsConstructor;
@@ -12,12 +16,15 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberStatisticsService {
   private final MemberTypingStatsRepository memberTypingStatsRepository;
+  private final MemberDailyStatsRepository memberDailyStatsRepository;
   private final TodayTypingStatsRedisService todayTypingStatsRedisService;
   private final StringRedisTemplate redisTemplate;
 
@@ -39,6 +46,19 @@ public class MemberStatisticsService {
     }
 
     return MemberTypingStatsResponse.merge(pg, today);
+  }
+
+  public MemberDailyStatsResponse getDailyStats(Long memberId, int days) {
+    LocalDate todayKst = LocalDate.now(TimeUtils.KST);
+    LocalDate from = todayKst.minusDays(days - 1);
+    LocalDate yesterday = todayKst.minusDays(1);
+
+    List<MemberDailyStats> pgList =
+        memberDailyStatsRepository.findByMemberIdAndDateBetween(memberId, from, yesterday);
+
+    TodayTypingSnapshot today = todayTypingStatsRedisService.getTyping(memberId);
+
+    return MemberDailyStatsResponse.of(days, pgList, today, todayKst);
   }
 
   public MemberTypingStatsResponse refreshStats(Long memberId) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberDailyStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberDailyStatsResponse.java
@@ -1,0 +1,78 @@
+package com.typingpractice.typing_practice_be.typingrecord.dto;
+
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberDailyStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypingSnapshot;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberDailyStatsResponse {
+  private int days;
+  private List<DayEntry> content;
+
+  public static MemberDailyStatsResponse create(int days, List<DayEntry> content) {
+    MemberDailyStatsResponse response = new MemberDailyStatsResponse();
+    response.days = days;
+    response.content = content;
+    return response;
+  }
+
+  public static MemberDailyStatsResponse of(
+      int days, List<MemberDailyStats> pgList, TodayTypingSnapshot today, LocalDate todayDate) {
+    List<DayEntry> content = new ArrayList<>();
+
+    for (MemberDailyStats stats : pgList) {
+      content.add(DayEntry.from(stats));
+    }
+
+    if (today.getTotalAttempts() > 0) {
+      content.add(DayEntry.fromToday(today, todayDate));
+    }
+
+    return create(days, content);
+  }
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class DayEntry {
+    private LocalDate date;
+    private int attempts;
+    private float avgCpm;
+    private float avgAcc;
+    private int bestCpm;
+    private int resetCount;
+    private float practiceTimeMin;
+
+    public static DayEntry from(MemberDailyStats stats) {
+      DayEntry entry = new DayEntry();
+      entry.date = stats.getDate();
+      entry.attempts = stats.getAttempts();
+      entry.avgCpm = stats.getAvgCpm();
+      entry.avgAcc = stats.getAvgAcc();
+      entry.bestCpm = stats.getBestCpm();
+      entry.resetCount = stats.getResetCount();
+      entry.practiceTimeMin = stats.getPracticeTimeMin();
+      return entry;
+    }
+
+    public static DayEntry fromToday(TodayTypingSnapshot today, LocalDate date) {
+      DayEntry entry = new DayEntry();
+      entry.date = date;
+      entry.attempts = today.getTotalAttempts();
+      entry.avgCpm = today.getAvgCpm();
+      entry.avgAcc = today.getAvgAcc();
+      entry.bestCpm = today.getBestCpm();
+      entry.resetCount = today.getTotalResetCount();
+      entry.practiceTimeMin = today.getTotalPracticeTimeMin();
+      return entry;
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberDailyStatsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberDailyStatsRepository.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -25,5 +26,18 @@ public class MemberDailyStatsRepository {
         .setParameter("date", date)
         .getResultStream()
         .findFirst();
+  }
+
+  public List<MemberDailyStats> findByMemberIdAndDateBetween(
+      Long memberId, LocalDate from, LocalDate to) {
+    return em.createQuery(
+            "select s from MemberDailyStats s where s.member.id = :memberId "
+                + "and s.date between :from and :to "
+                + "order by s.date asc",
+            MemberDailyStats.class)
+        .setParameter("memberId", memberId)
+        .setParameter("from", from)
+        .setParameter("to", to)
+        .getResultList();
   }
 }


### PR DESCRIPTION
- GET /members/me/stats/daily: PostgreSQL(과거 일별) + Redis(오늘) 결합하여 응답
- MemberDailyStatsRequest: days 파라미터 검증 (7~90, 기본값 7)
- MemberDailyStatsResponse: days + content(DayEntry 리스트)
- MemberDailyStatsRepository: findByMemberIdAndDateBetween 기간 조회 추가