### PR TITLE
feat: MemberTypoStats 조회 API 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberStatisticsController.java
@@ -1,10 +1,12 @@
 package com.typingpractice.typing_practice_be.statistics.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.statistics.dto.MemberDailyStatsRequest;
 import com.typingpractice.typing_practice_be.statistics.service.MemberStatisticsService;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberDailyStatsResponse;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypingStatsResponse;
+import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypoStatsResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -27,6 +29,12 @@ public class MemberStatisticsController {
       @ModelAttribute @Valid MemberDailyStatsRequest request) {
     Long memberId = getAuthenticatedMemberId();
     return ApiResponse.ok(memberStatisticsService.getDailyStats(memberId, request.getDays()));
+  }
+
+  @GetMapping("/typos")
+  public ApiResponse<MemberTypoStatsResponse> getTypoStats(@RequestParam QuoteLanguage language) {
+    Long memberId = getAuthenticatedMemberId();
+    return ApiResponse.ok(memberStatisticsService.getTypoStats(memberId, language));
   }
 
   @PostMapping("/refresh")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
@@ -1,14 +1,19 @@
 package com.typingpractice.typing_practice_be.statistics.service;
 
 import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.statistics.exception.RefreshCooldownException;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberDailyStatsResponse;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypingStatsResponse;
+import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypoStatsResponse;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberDailyStats;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypoStats;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypingSnapshot;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypoSnapshot;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberDailyStatsRepository;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypingStatsRepository;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypoStatsRepository;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.TodayTypingStatsRedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -25,6 +30,8 @@ import java.util.List;
 public class MemberStatisticsService {
   private final MemberTypingStatsRepository memberTypingStatsRepository;
   private final MemberDailyStatsRepository memberDailyStatsRepository;
+  private final MemberTypoStatsRepository memberTypoStatsRepository;
+
   private final TodayTypingStatsRedisService todayTypingStatsRedisService;
   private final StringRedisTemplate redisTemplate;
 
@@ -59,6 +66,15 @@ public class MemberStatisticsService {
     TodayTypingSnapshot today = todayTypingStatsRedisService.getTyping(memberId);
 
     return MemberDailyStatsResponse.of(days, pgList, today, todayKst);
+  }
+
+  public MemberTypoStatsResponse getTypoStats(Long memberId, QuoteLanguage language) {
+    List<MemberTypoStats> pgList =
+        memberTypoStatsRepository.findTop10ByMemberIdAndLanguage(memberId, language);
+
+    TodayTypoSnapshot today = todayTypingStatsRedisService.getTypoByLanguage(memberId, language);
+
+    return MemberTypoStatsResponse.of(language, pgList, today);
   }
 
   public MemberTypingStatsResponse refreshStats(Long memberId) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberTypoStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberTypoStatsResponse.java
@@ -1,0 +1,66 @@
+package com.typingpractice.typing_practice_be.typingrecord.dto;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypoStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypoSnapshot;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberTypoStatsResponse {
+  private List<TypoEntry> content;
+
+  public static MemberTypoStatsResponse of(
+      QuoteLanguage language, List<MemberTypoStats> pgList, TodayTypoSnapshot today) {
+    Map<String, Integer> mergedMap = new HashMap<>();
+
+    for (MemberTypoStats stats : pgList) {
+      String key = TodayTypoSnapshot.toKey(stats.getLanguage(), stats.getExpected());
+      mergedMap.put(key, stats.getTypoCount());
+    }
+
+    for (Map.Entry<String, Integer> entry : today.getTypoCountMap().entrySet()) {
+      mergedMap.merge(entry.getKey(), entry.getValue(), Integer::sum);
+    }
+
+    String prefix = language + ":";
+    MemberTypoStatsResponse response = new MemberTypoStatsResponse();
+    response.content =
+        mergedMap.entrySet().stream()
+            .map(
+                e -> {
+                  String expected = e.getKey().substring(prefix.length());
+                  return TypoEntry.create(language, expected, e.getValue());
+                })
+            .sorted((a, b) -> Integer.compare(b.getCount(), a.getCount()))
+            .limit(10)
+            .toList();
+
+    return response;
+  }
+
+  @Getter
+  @ToString
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class TypoEntry {
+    private QuoteLanguage language;
+    private String expected;
+    private int count;
+
+    public static TypoEntry create(QuoteLanguage language, String expected, int count) {
+      TypoEntry entry = new TypoEntry();
+      entry.language = language;
+      entry.expected = expected;
+      entry.count = count;
+      return entry;
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberTypoDetailStats.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberTypoDetailStats.java
@@ -31,7 +31,7 @@ public class MemberTypoDetailStats extends BaseEntity {
 
   private String expected;
   private String actual;
-  private int count;
+  private int typoCount;
   private int initialCount;
   private int medialCount;
   private int finalCount;
@@ -52,7 +52,7 @@ public class MemberTypoDetailStats extends BaseEntity {
     stats.language = language;
     stats.expected = expected;
     stats.actual = actual;
-    stats.count = count;
+    stats.typoCount = count;
     stats.initialCount = initialCount;
     stats.medialCount = medialCount;
     stats.finalCount = finalCount;
@@ -61,7 +61,7 @@ public class MemberTypoDetailStats extends BaseEntity {
   }
 
   public void merge(int count, int initialCount, int medialCount, int finalCount, int letterCount) {
-    this.count += count;
+    this.typoCount += count;
     this.initialCount += initialCount;
     this.medialCount += medialCount;
     this.finalCount += finalCount;
@@ -70,7 +70,7 @@ public class MemberTypoDetailStats extends BaseEntity {
 
   public void overwrite(
       int count, int initialCount, int medialCount, int finalCount, int letterCount) {
-    this.count = count;
+    this.typoCount = count;
     this.initialCount = initialCount;
     this.medialCount = medialCount;
     this.finalCount = finalCount;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberTypoStats.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberTypoStats.java
@@ -30,7 +30,7 @@ public class MemberTypoStats extends BaseEntity {
   private QuoteLanguage language;
 
   private String expected;
-  private int count;
+  private int typoCount;
 
   public static MemberTypoStats create(
       Member member, QuoteLanguage language, String expected, int count) {
@@ -38,15 +38,15 @@ public class MemberTypoStats extends BaseEntity {
     stats.member = member;
     stats.language = language;
     stats.expected = expected;
-    stats.count = count;
+    stats.typoCount = count;
     return stats;
   }
 
   public void merge(int count) {
-    this.count += count;
+    this.typoCount += count;
   }
 
   public void overwrite(int count) {
-    this.count = count;
+    this.typoCount = count;
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberTypoStatsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberTypoStatsRepository.java
@@ -6,6 +6,7 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -30,6 +31,20 @@ public class MemberTypoStatsRepository {
         .setParameter("expected", expected)
         .getResultStream()
         .findFirst();
+  }
+
+  public List<MemberTypoStats> findTop10ByMemberIdAndLanguage(
+      Long memberId, QuoteLanguage language) {
+    return em.createQuery(
+            "select s from MemberTypoStats s "
+                + "where s.member.id = :memberId "
+                + "and s.language = :language "
+                + "order by s.typoCount desc",
+            MemberTypoStats.class)
+        .setParameter("memberId", memberId)
+        .setParameter("language", language)
+        .setMaxResults(10)
+        .getResultList();
   }
 
   public void deleteAllInBatch() {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/TodayTypingStatsRedisService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/TodayTypingStatsRedisService.java
@@ -3,6 +3,7 @@ package com.typingpractice.typing_practice_be.typingrecord.statistics.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.typingrecord.domain.Typo;
 import com.typingpractice.typing_practice_be.typingrecord.event.TypingRecordSavedEvent;
 import com.typingpractice.typing_practice_be.typingrecord.repository.MemberTypingAggregationRepository;
@@ -112,6 +113,20 @@ public class TodayTypingStatsRedisService {
     }
 
     return fallbackTypo(memberId);
+  }
+
+  public TodayTypoSnapshot getTypoByLanguage(Long memberId, QuoteLanguage language) {
+    TodayTypoSnapshot snapshot = getTypo(memberId);
+    String prefix = language + ":";
+    Map<String, Integer> filtered = new HashMap<>();
+
+    for (Map.Entry<String, Integer> entry : snapshot.getTypoCountMap().entrySet()) {
+      if (entry.getKey().startsWith(prefix)) {
+        filtered.put(entry.getKey(), entry.getValue());
+      }
+    }
+
+    return TodayTypoSnapshot.create(filtered);
   }
 
   public TodayTypoDetailSnapshot getTypoDetail(Long memberId) {


### PR DESCRIPTION
- GET /members/me/stats/typos?language=KOREAN: PostgreSQL(top 10) + Redis(오늘) 합산, 상위 10개 반환
- MemberTypoStatsResponse: pgList + todayFiltered 합산 → 정렬 → limit 10
- TodayTypingStatsRedisService.getTypoByLanguage: language 필터링 조회
- MemberTypoStatsRepository.findTop10ByMemberIdAndLanguage: count 내림차순 상위 10개 조회
- MemberTypoStats/DetailStats: count → typoCount 필드명 변경 (JPQL 예약어 회피)