### PR TITLE
MemberTypingStats / MemberDailyStats 언어별 구분 추가

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberStatisticsController.java
@@ -19,16 +19,18 @@ public class MemberStatisticsController {
   private final MemberStatisticsService memberStatisticsService;
 
   @GetMapping("/typing")
-  public ApiResponse<MemberTypingStatsResponse> getTypingStats() {
+  public ApiResponse<MemberTypingStatsResponse> getTypingStats(
+      @RequestParam QuoteLanguage language) {
     Long memberId = getAuthenticatedMemberId();
-    return ApiResponse.ok(memberStatisticsService.getTypingStats(memberId));
+    return ApiResponse.ok(memberStatisticsService.getTypingStats(memberId, language));
   }
 
   @GetMapping("/daily")
   public ApiResponse<MemberDailyStatsResponse> getDailyStats(
       @ModelAttribute @Valid MemberDailyStatsRequest request) {
     Long memberId = getAuthenticatedMemberId();
-    return ApiResponse.ok(memberStatisticsService.getDailyStats(memberId, request.getDays()));
+    return ApiResponse.ok(
+        memberStatisticsService.getDailyStats(memberId, request.getLanguage(), request.getDays()));
   }
 
   @GetMapping("/typos")
@@ -38,9 +40,9 @@ public class MemberStatisticsController {
   }
 
   @PostMapping("/refresh")
-  public ApiResponse<MemberTypingStatsResponse> refreshStats() {
+  public ApiResponse<MemberTypingStatsResponse> refreshStats(@RequestParam QuoteLanguage language) {
     Long memberId = getAuthenticatedMemberId();
-    return ApiResponse.ok(memberStatisticsService.refreshStats(memberId));
+    return ApiResponse.ok(memberStatisticsService.refreshStats(memberId, language));
   }
 
   private Long getAuthenticatedMemberId() {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/dto/MemberDailyStatsRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/dto/MemberDailyStatsRequest.java
@@ -1,7 +1,9 @@
 package com.typingpractice.typing_practice_be.statistics.dto;
 
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -12,7 +14,10 @@ public class MemberDailyStatsRequest {
   @Max(value = 90, message = "days는 최대 90입니다.")
   private final int days;
 
-  public MemberDailyStatsRequest(Integer days) {
+  @NotNull private final QuoteLanguage language;
+
+  public MemberDailyStatsRequest(Integer days, QuoteLanguage language) {
     this.days = days != null ? days : 7;
+    this.language = language;
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
@@ -62,7 +62,8 @@ public class MemberStatisticsService {
     LocalDate yesterday = todayKst.minusDays(1);
 
     List<MemberDailyStats> pgList =
-        memberDailyStatsRepository.findByMemberIdAndDateBetween(memberId, from, yesterday);
+        memberDailyStatsRepository.findByMemberIdAndLanguageAndDateBetween(
+            memberId, language, from, yesterday);
 
     TodayTypingSnapshot today = todayTypingStatsRedisService.getTyping(memberId, language);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
@@ -38,9 +38,10 @@ public class MemberStatisticsService {
   private static final String COOLDOWN_KEY_PREFIX = "cooldown:refresh:";
   private static final Duration COOLDOWN_DURATION = Duration.ofMinutes(1);
 
-  public MemberTypingStatsResponse getTypingStats(Long memberId) {
-    MemberTypingStats pg = memberTypingStatsRepository.findByMemberId(memberId).orElse(null);
-    TodayTypingSnapshot today = todayTypingStatsRedisService.getTyping(memberId);
+  public MemberTypingStatsResponse getTypingStats(Long memberId, QuoteLanguage language) {
+    MemberTypingStats pg =
+        memberTypingStatsRepository.findByMemberIdAndLanguage(memberId, language).orElse(null);
+    TodayTypingSnapshot today = todayTypingStatsRedisService.getTyping(memberId, language);
 
     if (pg == null && today.getTotalAttempts() == 0) {
       return MemberTypingStatsResponse.empty();
@@ -55,7 +56,7 @@ public class MemberStatisticsService {
     return MemberTypingStatsResponse.merge(pg, today);
   }
 
-  public MemberDailyStatsResponse getDailyStats(Long memberId, int days) {
+  public MemberDailyStatsResponse getDailyStats(Long memberId, QuoteLanguage language, int days) {
     LocalDate todayKst = LocalDate.now(TimeUtils.KST);
     LocalDate from = todayKst.minusDays(days - 1);
     LocalDate yesterday = todayKst.minusDays(1);
@@ -63,7 +64,7 @@ public class MemberStatisticsService {
     List<MemberDailyStats> pgList =
         memberDailyStatsRepository.findByMemberIdAndDateBetween(memberId, from, yesterday);
 
-    TodayTypingSnapshot today = todayTypingStatsRedisService.getTyping(memberId);
+    TodayTypingSnapshot today = todayTypingStatsRedisService.getTyping(memberId, language);
 
     return MemberDailyStatsResponse.of(days, pgList, today, todayKst);
   }
@@ -77,16 +78,19 @@ public class MemberStatisticsService {
     return MemberTypoStatsResponse.of(language, pgList, today);
   }
 
-  public MemberTypingStatsResponse refreshStats(Long memberId) {
+  public MemberTypingStatsResponse refreshStats(Long memberId, QuoteLanguage language) {
     checkCooldown(memberId);
 
-    todayTypingStatsRedisService.invalidateTyping(memberId);
+    for (QuoteLanguage lang : QuoteLanguage.values()) {
+      todayTypingStatsRedisService.invalidateTyping(memberId, lang);
+    }
+
     todayTypingStatsRedisService.invalidateTypo(memberId);
     todayTypingStatsRedisService.invalidateTypoDetail(memberId);
 
     setCooldown(memberId);
 
-    return getTypingStats(memberId);
+    return getTypingStats(memberId, language);
   }
 
   private void checkCooldown(Long memberId) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/MemberDailyAggregationRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/MemberDailyAggregationRepository.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.typingrecord.repository;
 
 import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberDailyAggregation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -38,7 +39,7 @@ public class MemberDailyAggregationRepository {
                         .withTimezone(DateOperators.Timezone.valueOf(TimeUtils.KST_OFFSET))
                         .toString("%Y-%m-%d"))
                 .build(),
-            Aggregation.group(Fields.fields("memberId").and("date"))
+            Aggregation.group(Fields.fields("memberId").and("date").and("language"))
                 .count()
                 .as("attempts")
                 .avg("cpm")
@@ -56,6 +57,57 @@ public class MemberDailyAggregationRepository {
                 .as("memberId")
                 .and("_id.date")
                 .as("date")
+                .and("_id.language")
+                .as("language")
+                .andInclude(
+                    "attempts", "avgCpm", "avgAcc", "bestCpm", "resetCount", "practiceTimeMin"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", MemberDailyAggregation.class)
+        .getMappedResults();
+  }
+
+  public List<MemberDailyAggregation> aggregateByMemberIdsAndLanguageBetween(
+      List<Long> memberIds, QuoteLanguage language, LocalDateTime from, LocalDateTime to) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(
+                Criteria.where("memberId")
+                    .in(memberIds)
+                    .and("language")
+                    .is(language.name())
+                    .and("completedAt")
+                    .gte(from)
+                    .lt(to)
+                    .and("cpm")
+                    .gt(0)),
+            Aggregation.addFields()
+                .addFieldWithValue(
+                    "date",
+                    DateOperators.dateOf("completedAt")
+                        .withTimezone(DateOperators.Timezone.valueOf(TimeUtils.KST_OFFSET))
+                        .toString("%Y-%m-%d"))
+                .build(),
+            Aggregation.group(Fields.fields("memberId").and("date").and("language"))
+                .count()
+                .as("attempts")
+                .avg("cpm")
+                .as("avgCpm")
+                .avg("accuracy")
+                .as("avgAcc")
+                .max("cpm")
+                .as("bestCpm")
+                .sum("resetCount")
+                .as("resetCount")
+                .sum(ArithmeticOperators.valueOf("charLength").divideBy("cpm"))
+                .as("practiceTimeMin"),
+            Aggregation.project()
+                .and("_id.memberId")
+                .as("memberId")
+                .and("_id.date")
+                .as("date")
+                .and("_id.language")
+                .as("language")
                 .andInclude(
                     "attempts", "avgCpm", "avgAcc", "bestCpm", "resetCount", "practiceTimeMin"));
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/MemberTypingAggregationRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/MemberTypingAggregationRepository.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.typingrecord.repository;
 
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypingAggregation;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,7 +20,7 @@ public class MemberTypingAggregationRepository {
     Aggregation aggregation =
         Aggregation.newAggregation(
             Aggregation.match(Criteria.where("memberId").in(memberIds).and("cpm").gt(0)),
-            Aggregation.group("memberId")
+            Aggregation.group("memberId", "language")
                 .count()
                 .as("totalAttempts")
                 .avg("cpm")
@@ -35,8 +36,10 @@ public class MemberTypingAggregationRepository {
                 .max("completedAt")
                 .as("lastPracticedAt"),
             Aggregation.project()
-                .and("_id")
+                .and("_id.memberId")
                 .as("memberId")
+                .and("_id.language")
+                .as("language")
                 .andInclude(
                     "totalAttempts",
                     "avgCpm",
@@ -63,7 +66,7 @@ public class MemberTypingAggregationRepository {
                     .lt(to)
                     .and("cpm")
                     .gt(0)),
-            Aggregation.group("memberId")
+            Aggregation.group("memberId", "language")
                 .count()
                 .as("totalAttempts")
                 .avg("cpm")
@@ -79,8 +82,103 @@ public class MemberTypingAggregationRepository {
                 .max("completedAt")
                 .as("lastPracticedAt"),
             Aggregation.project()
-                .and("_id")
+                .and("_id.memberId")
                 .as("memberId")
+                .and("_id.language")
+                .as("language")
+                .andInclude(
+                    "totalAttempts",
+                    "avgCpm",
+                    "avgAcc",
+                    "bestCpm",
+                    "totalPracticeTimeMin",
+                    "totalResetCount",
+                    "lastPracticedAt"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", MemberTypingAggregation.class)
+        .getMappedResults();
+  }
+
+  public List<MemberTypingAggregation> aggregateByMemberIdsAndLanguage(
+      List<Long> memberIds, QuoteLanguage language) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(
+                Criteria.where("memberId")
+                    .in(memberIds)
+                    .and("language")
+                    .is(language.name())
+                    .and("cpm")
+                    .gt(0)),
+            Aggregation.group("memberId", "language")
+                .count()
+                .as("totalAttempts")
+                .avg("cpm")
+                .as("avgCpm")
+                .avg("accuracy")
+                .as("avgAcc")
+                .max("cpm")
+                .as("bestCpm")
+                .sum(ArithmeticOperators.valueOf("charLength").divideBy("cpm"))
+                .as("totalPracticeTimeMin")
+                .sum("resetCount")
+                .as("totalResetCount")
+                .max("completedAt")
+                .as("lastPracticedAt"),
+            Aggregation.project()
+                .and("_id.memberId")
+                .as("memberId")
+                .and("_id.language")
+                .as("language")
+                .andInclude(
+                    "totalAttempts",
+                    "avgCpm",
+                    "avgAcc",
+                    "bestCpm",
+                    "totalPracticeTimeMin",
+                    "totalResetCount",
+                    "lastPracticedAt"));
+
+    return mongoTemplate
+        .aggregate(aggregation, "typingRecord", MemberTypingAggregation.class)
+        .getMappedResults();
+  }
+
+  public List<MemberTypingAggregation> aggregateByMemberIdsAndLanguageBetween(
+      List<Long> memberId, QuoteLanguage language, LocalDateTime from, LocalDateTime to) {
+    Aggregation aggregation =
+        Aggregation.newAggregation(
+            Aggregation.match(
+                Criteria.where("memberId")
+                    .in(memberId)
+                    .and("language")
+                    .is(language.name())
+                    .and("completedAt")
+                    .gte(from)
+                    .lt(to)
+                    .and("cpm")
+                    .gt(0)),
+            Aggregation.group("memberId", "language")
+                .count()
+                .as("totalAttempts")
+                .avg("cpm")
+                .as("avgCpm")
+                .avg("accuracy")
+                .as("avgAcc")
+                .max("cpm")
+                .as("bestCpm")
+                .sum(ArithmeticOperators.valueOf("charLength").divideBy("cpm"))
+                .as("totalPracticeTimeMin")
+                .sum("resetCount")
+                .as("totalResetCount")
+                .max("completedAt")
+                .as("lastPracticedAt"),
+            Aggregation.project()
+                .and("_id.memberId")
+                .as("memberId")
+                .and("_id.language")
+                .as("language")
                 .andInclude(
                     "totalAttempts",
                     "avgCpm",

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberDailyStats.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberDailyStats.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.typingrecord.statistics.domain;
 
 import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
 import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -16,7 +17,7 @@ import java.time.LocalDate;
     uniqueConstraints =
         @UniqueConstraint(
             name = "uq_member_daily_stats_member_date",
-            columnNames = {"member_id", "date"}))
+            columnNames = {"member_id", "date", "language"}))
 public class MemberDailyStats extends BaseEntity {
   @Id
   @GeneratedValue
@@ -26,6 +27,9 @@ public class MemberDailyStats extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "member_id")
   private Member member;
+
+  @Enumerated(EnumType.STRING)
+  private QuoteLanguage language;
 
   private LocalDate date; // KST 날짜
 
@@ -39,6 +43,7 @@ public class MemberDailyStats extends BaseEntity {
   public static MemberDailyStats create(
       Member member,
       LocalDate date,
+      QuoteLanguage language,
       int attempts,
       float avgCpm,
       float avgAcc,
@@ -49,6 +54,7 @@ public class MemberDailyStats extends BaseEntity {
 
     stats.member = member;
     stats.date = date;
+    stats.language = language;
 
     stats.attempts = attempts;
     stats.avgCpm = avgCpm;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberTypingStats.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberTypingStats.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.typingrecord.statistics.domain;
 
 import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
 import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -12,15 +13,23 @@ import java.time.LocalDateTime;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_member_typing_stats",
+            columnNames = {"member_id", "language"}))
 public class MemberTypingStats extends BaseEntity {
   @Id
   @GeneratedValue
   @Column(name = "member_typing_stats_id")
   private Long id;
 
-  @OneToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "member_id", unique = true)
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
   private Member member;
+
+  @Enumerated(value = EnumType.STRING)
+  private QuoteLanguage language;
 
   private int totalAttempts;
   private float avgCpm;
@@ -34,6 +43,7 @@ public class MemberTypingStats extends BaseEntity {
 
   public static MemberTypingStats create(
       Member member,
+      QuoteLanguage language,
       int totalAttempts,
       float avgCpm,
       float avgAcc,
@@ -43,6 +53,7 @@ public class MemberTypingStats extends BaseEntity {
       LocalDateTime lastPracticedAt) {
     MemberTypingStats stats = new MemberTypingStats();
     stats.member = member;
+    stats.language = language;
     stats.totalAttempts = totalAttempts;
     stats.avgCpm = avgCpm;
     stats.avgAcc = avgAcc;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/MemberDailyAggregation.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/MemberDailyAggregation.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.typingrecord.statistics.dto;
 
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -10,6 +11,7 @@ import java.time.LocalDate;
 public class MemberDailyAggregation {
   private Long memberId;
   private String date; // MongoDB에서 "%Y-%m-%d" 포맷으로 수신
+  private QuoteLanguage language;
   private int attempts;
   private float avgCpm;
   private float avgAcc;
@@ -24,6 +26,7 @@ public class MemberDailyAggregation {
   public static MemberDailyAggregation create(
       Long memberId,
       String date,
+      QuoteLanguage language,
       int attempts,
       float avgCpm,
       float avgAcc,
@@ -33,6 +36,7 @@ public class MemberDailyAggregation {
     MemberDailyAggregation agg = new MemberDailyAggregation();
     agg.memberId = memberId;
     agg.date = date;
+    agg.language = language;
     agg.attempts = attempts;
     agg.avgCpm = avgCpm;
     agg.avgAcc = avgAcc;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/MemberTypingAggregation.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/MemberTypingAggregation.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.typingrecord.statistics.dto;
 
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -9,6 +10,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class MemberTypingAggregation {
   private Long memberId;
+  private QuoteLanguage language;
   private int totalAttempts;
   private float avgCpm;
   private float avgAcc;
@@ -19,6 +21,7 @@ public class MemberTypingAggregation {
 
   public static MemberTypingAggregation create(
       Long memberId,
+      QuoteLanguage language,
       int attempts,
       float avgCpm,
       float avgAcc,
@@ -28,6 +31,7 @@ public class MemberTypingAggregation {
       LocalDateTime lastPracticedAt) {
     MemberTypingAggregation agg = new MemberTypingAggregation();
     agg.memberId = memberId;
+    agg.language = language;
     agg.totalAttempts = attempts;
     agg.avgCpm = avgCpm;
     agg.avgAcc = avgAcc;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberDailyStatsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberDailyStatsRepository.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.typingrecord.statistics.repository;
 
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberDailyStats;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -28,6 +29,20 @@ public class MemberDailyStatsRepository {
         .findFirst();
   }
 
+  public Optional<MemberDailyStats> findByMemberIdAndDateAndLanguage(
+      Long memberId, LocalDate date, QuoteLanguage language) {
+    return em.createQuery(
+            "select s from MemberDailyStats s where s.member.id = :memberId "
+                + "and s.date = :date "
+                + "and s.language = :language",
+            MemberDailyStats.class)
+        .setParameter("memberId", memberId)
+        .setParameter("date", date)
+        .setParameter("language", language)
+        .getResultStream()
+        .findFirst();
+  }
+
   public List<MemberDailyStats> findByMemberIdAndDateBetween(
       Long memberId, LocalDate from, LocalDate to) {
     return em.createQuery(
@@ -36,6 +51,22 @@ public class MemberDailyStatsRepository {
                 + "order by s.date asc",
             MemberDailyStats.class)
         .setParameter("memberId", memberId)
+        .setParameter("from", from)
+        .setParameter("to", to)
+        .getResultList();
+  }
+
+  public List<MemberDailyStats> findByMemberIdAndLanguageAndDateBetween(
+      Long memberId, QuoteLanguage language, LocalDate from, LocalDate to) {
+    return em.createQuery(
+            "select s from MemberDailyStats s "
+                + "where s.member.id = :memberId "
+                + "and s.language = :language "
+                + "and s.date between :from and :to "
+                + "order by s.date asc",
+            MemberDailyStats.class)
+        .setParameter("memberId", memberId)
+        .setParameter("language", language)
         .setParameter("from", from)
         .setParameter("to", to)
         .getResultList();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberTypingStatsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberTypingStatsRepository.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.typingrecord.statistics.repository;
 
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -16,11 +17,14 @@ public class MemberTypingStatsRepository {
     em.persist(stats);
   }
 
-  public Optional<MemberTypingStats> findByMemberId(Long memberId) {
+  public Optional<MemberTypingStats> findByMemberIdAndLanguage(
+      Long memberId, QuoteLanguage language) {
     return em.createQuery(
-            "select s from MemberTypingStats s where s.member.id = :memberId",
+            "select s from MemberTypingStats s where s.member.id = :memberId "
+                + "and s.language = :language",
             MemberTypingStats.class)
         .setParameter("memberId", memberId)
+        .setParameter("language", language)
         .getResultStream()
         .findFirst();
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberDailyStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberDailyStatsBatchService.java
@@ -77,7 +77,9 @@ public class MemberDailyStatsBatchService {
   private void upsert(MemberDailyAggregation agg) {
     LocalDate date = agg.getDateAsLocalDate();
     MemberDailyStats stats =
-        memberDailyStatsRepository.findByMemberIdAndDate(agg.getMemberId(), date).orElse(null);
+        memberDailyStatsRepository
+            .findByMemberIdAndDateAndLanguage(agg.getMemberId(), date, agg.getLanguage())
+            .orElse(null);
 
     if (stats == null) {
       Member member = memberRepository.findById(agg.getMemberId()).orElse(null);
@@ -89,9 +91,10 @@ public class MemberDailyStatsBatchService {
           MemberDailyStats.create(
               member,
               date,
+              agg.getLanguage(),
               agg.getAttempts(),
-              (float) agg.getAvgCpm(),
-              (float) agg.getAvgAcc(),
+              agg.getAvgCpm(),
+              agg.getAvgAcc(),
               agg.getBestCpm(),
               agg.getResetCount(),
               agg.getPracticeTimeMin());
@@ -99,8 +102,8 @@ public class MemberDailyStatsBatchService {
     } else {
       stats.overwrite(
           agg.getAttempts(),
-          (float) agg.getAvgCpm(),
-          (float) agg.getAvgAcc(),
+          agg.getAvgCpm(),
+          agg.getAvgAcc(),
           agg.getBestCpm(),
           agg.getResetCount(),
           agg.getPracticeTimeMin());

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/MemberTypingStatsBatchService.java
@@ -88,7 +88,10 @@ public class MemberTypingStatsBatchService {
   }
 
   private void upsert(Long memberId, MemberTypingAggregation agg, boolean overwrite) {
-    MemberTypingStats stats = memberTypingStatsRepository.findByMemberId(memberId).orElse(null);
+    MemberTypingStats stats =
+        memberTypingStatsRepository
+            .findByMemberIdAndLanguage(memberId, agg.getLanguage())
+            .orElse(null);
 
     if (stats == null) {
       Member member = memberRepository.findById(memberId).orElse(null);
@@ -100,9 +103,10 @@ public class MemberTypingStatsBatchService {
       stats =
           MemberTypingStats.create(
               member,
+              agg.getLanguage(),
               agg.getTotalAttempts(),
-              (float) agg.getAvgCpm(),
-              (float) agg.getAvgAcc(),
+              agg.getAvgCpm(),
+              agg.getAvgAcc(),
               agg.getBestCpm(),
               agg.getTotalPracticeTimeMin(),
               agg.getTotalResetCount(),
@@ -111,8 +115,8 @@ public class MemberTypingStatsBatchService {
     } else if (overwrite) {
       stats.overwrite(
           agg.getTotalAttempts(),
-          (float) agg.getAvgCpm(),
-          (float) agg.getAvgAcc(),
+          agg.getAvgCpm(),
+          agg.getAvgAcc(),
           agg.getBestCpm(),
           agg.getTotalPracticeTimeMin(),
           agg.getTotalResetCount(),
@@ -120,8 +124,8 @@ public class MemberTypingStatsBatchService {
     } else {
       stats.merge(
           agg.getTotalAttempts(),
-          (float) agg.getAvgCpm(),
-          (float) agg.getAvgAcc(),
+          agg.getAvgCpm(),
+          agg.getAvgAcc(),
           agg.getBestCpm(),
           agg.getTotalPracticeTimeMin(),
           agg.getTotalResetCount(),

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/TodayTypingStatsRedisService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/TodayTypingStatsRedisService.java
@@ -35,9 +35,9 @@ public class TodayTypingStatsRedisService {
   private static final String TYPO_KEY_PREFIX = "today:typo:";
   private static final String TYPO_DETAIL_KEY_PREFIX = "today:typo-detail:";
 
-  private String typingKey(Long memberId) {
-    // today:typing:1234
-    return TYPING_KEY_PREFIX + memberId;
+  private String typingKey(Long memberId, QuoteLanguage language) {
+    // today:typing:1234:KOREAN
+    return TYPING_KEY_PREFIX + memberId + ":" + language;
   }
 
   private String typoKey(Long memberId) {
@@ -58,7 +58,7 @@ public class TodayTypingStatsRedisService {
 
   // 이벤트 수신 후 오늘 통계 업데이트
   public void incrementTyping(TypingRecordSavedEvent event) {
-    String key = typingKey(event.getMemberId());
+    String key = typingKey(event.getMemberId(), event.getLanguage());
 
     TodayTypingSnapshot snapshot = getSnapshotOrEmpty(key);
     snapshot.increment(
@@ -93,15 +93,15 @@ public class TodayTypingStatsRedisService {
   }
 
   // 오늘 통계 조회
-  public TodayTypingSnapshot getTyping(Long memberId) {
-    String key = typingKey(memberId);
+  public TodayTypingSnapshot getTyping(Long memberId, QuoteLanguage language) {
+    String key = typingKey(memberId, language);
     String json = redisTemplate.opsForValue().get(key);
 
     if (json != null) {
       return deserialize(json, TodayTypingSnapshot.class);
     }
 
-    return fallbackTyping(memberId);
+    return fallbackTyping(memberId, language);
   }
 
   public TodayTypoSnapshot getTypo(Long memberId) {
@@ -146,8 +146,8 @@ public class TodayTypingStatsRedisService {
     return fallbackTypoDetail(memberId);
   }
 
-  public void invalidateTyping(Long memberId) {
-    redisTemplate.delete(typingKey(memberId));
+  public void invalidateTyping(Long memberId, QuoteLanguage language) {
+    redisTemplate.delete(typingKey(memberId, language));
   }
 
   public void invalidateTypo(Long memberId) {
@@ -205,13 +205,14 @@ public class TodayTypingStatsRedisService {
     }
   }
 
-  private TodayTypingSnapshot fallbackTyping(Long memberId) {
+  private TodayTypingSnapshot fallbackTyping(Long memberId, QuoteLanguage language) {
     LocalDate todayKst = LocalDate.now(TimeUtils.KST);
     LocalDateTime from = TimeUtils.startOfDayKstToUtc(todayKst);
     LocalDateTime to = TimeUtils.endOfDayKstToUtc(todayKst);
 
     List<MemberTypingAggregation> results =
-        memberTypingAggregationRepository.aggregateByMemberIdsBetween(List.of(memberId), from, to);
+        memberTypingAggregationRepository.aggregateByMemberIdsAndLanguageBetween(
+            List.of(memberId), language, from, to);
 
     if (results.isEmpty()) {
       return TodayTypingSnapshot.empty();
@@ -227,7 +228,7 @@ public class TodayTypingStatsRedisService {
             agg.getTotalPracticeTimeMin(),
             agg.getTotalResetCount());
 
-    setSnapshot(typingKey(memberId), snapshot);
+    setSnapshot(typingKey(memberId, language), snapshot);
     return snapshot;
   }
 


### PR DESCRIPTION
### 배경

기존 MemberTypingStats, MemberDailyStats가 언어 구분 없이 한국어/영어 기록을 합산하여 통계를 관리하고 있었습니다.
타이핑 특성이 언어별로 다르기 때문에(CPM 기준, 정확도 패턴 등) 통계를 분리해야 의미 있는 데이터를 제공할 수 있습니다.

### 변경 내용

**MemberTypingStats**
- `language` 필드 추가, `@OneToOne` → `@ManyToOne`, unique 제약 `(member_id, language)`
- MongoDB aggregation group by에 `language` 추가
- language 필터 aggregation 메서드 추가 (Redis fallback용)
- Redis 키 `today:typing:{memberId}:{language}`로 분리
- 조회/리프레시 API에 `language` 파라미터 추가

**MemberDailyStats**
- `language` 필드 추가, unique 제약 `(member_id, date, language)`
- MongoDB aggregation group by에 `language` 추가
- language 필터 aggregation 메서드 추가
- Repository 조회 메서드에 language 조건 추가
- 배치 서비스 language별 upsert

**공통**
- 배치 서비스: 기존 데이터와 호환, aggregation이 language별로 분리되어 나오므로 upsert 로직은 language를 포함한 조회로 변경
- 조회 API: `GET /members/me/stats/typing?language=KOREAN`, `GET /members/me/stats/daily?language=KOREAN&days=7`
- `MemberDailyStatsRequest`에 `@NotNull language` 파라미터 추가