### PR TITLE
feat: MemberTypoDetailStats 조회 API 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberStatisticsController.java
@@ -6,6 +6,7 @@ import com.typingpractice.typing_practice_be.statistics.dto.MemberDailyStatsRequ
 import com.typingpractice.typing_practice_be.statistics.service.MemberStatisticsService;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberDailyStatsResponse;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypingStatsResponse;
+import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypoDetailStatsResponse;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypoStatsResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -37,6 +38,13 @@ public class MemberStatisticsController {
   public ApiResponse<MemberTypoStatsResponse> getTypoStats(@RequestParam QuoteLanguage language) {
     Long memberId = getAuthenticatedMemberId();
     return ApiResponse.ok(memberStatisticsService.getTypoStats(memberId, language));
+  }
+
+  @GetMapping("/typos/detail")
+  public ApiResponse<MemberTypoDetailStatsResponse> getTypoDetailStats(
+      @RequestParam QuoteLanguage language, @RequestParam String expected) {
+    Long memberId = getAuthenticatedMemberId();
+    return ApiResponse.ok(memberStatisticsService.getTypoDetailStats(memberId, language, expected));
   }
 
   @PostMapping("/refresh")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
@@ -5,14 +5,18 @@ import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.statistics.exception.RefreshCooldownException;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberDailyStatsResponse;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypingStatsResponse;
+import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypoDetailStatsResponse;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypoStatsResponse;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberDailyStats;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypoDetailStats;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypoStats;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypingSnapshot;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypoDetailSnapshot;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypoSnapshot;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberDailyStatsRepository;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypingStatsRepository;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypoDetailStatsRepository;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypoStatsRepository;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.TodayTypingStatsRedisService;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +35,7 @@ public class MemberStatisticsService {
   private final MemberTypingStatsRepository memberTypingStatsRepository;
   private final MemberDailyStatsRepository memberDailyStatsRepository;
   private final MemberTypoStatsRepository memberTypoStatsRepository;
+  private final MemberTypoDetailStatsRepository memberTypoDetailStatsRepository;
 
   private final TodayTypingStatsRedisService todayTypingStatsRedisService;
   private final StringRedisTemplate redisTemplate;
@@ -77,6 +82,19 @@ public class MemberStatisticsService {
     TodayTypoSnapshot today = todayTypingStatsRedisService.getTypoByLanguage(memberId, language);
 
     return MemberTypoStatsResponse.of(language, pgList, today);
+  }
+
+  public MemberTypoDetailStatsResponse getTypoDetailStats(
+      Long memberId, QuoteLanguage language, String expected) {
+    List<MemberTypoDetailStats> pgList =
+        memberTypoDetailStatsRepository.findByMemberIdAndLanguageAndExpected(
+            memberId, language, expected);
+
+    TodayTypoDetailSnapshot todayFiltered =
+        todayTypingStatsRedisService.getTypoDetailByLanguageAndExpected(
+            memberId, language, expected);
+
+    return MemberTypoDetailStatsResponse.of(language, expected, pgList, todayFiltered);
   }
 
   public MemberTypingStatsResponse refreshStats(Long memberId, QuoteLanguage language) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberTypoDetailStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberTypoDetailStatsResponse.java
@@ -1,0 +1,108 @@
+package com.typingpractice.typing_practice_be.typingrecord.dto;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypoDetailStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypoDetailEntry;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypoDetailSnapshot;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberTypoDetailStatsResponse {
+  private List<DetailEntry> content;
+
+  public static MemberTypoDetailStatsResponse of(
+      QuoteLanguage language,
+      String expected,
+      List<MemberTypoDetailStats> pgList,
+      TodayTypoDetailSnapshot todayFiltered) {
+
+    // language:expected:actual → DetailEntry
+    Map<String, DetailEntry> mergedMap = new HashMap<>();
+
+    for (MemberTypoDetailStats stats : pgList) {
+      String key =
+          TodayTypoDetailSnapshot.toKey(
+              stats.getLanguage(), stats.getExpected(), stats.getActual());
+      mergedMap.put(key, DetailEntry.from(stats));
+    }
+
+    for (Map.Entry<String, TodayTypoDetailEntry> entry : todayFiltered.getDetailMap().entrySet()) {
+      mergedMap.merge(
+          entry.getKey(),
+          DetailEntry.fromToday(language, expected, entry.getKey(), entry.getValue()),
+          DetailEntry::merge);
+    }
+
+    MemberTypoDetailStatsResponse response = new MemberTypoDetailStatsResponse();
+    response.content =
+        mergedMap.values().stream()
+            .sorted((a, b) -> Integer.compare(b.getTypoCount(), a.getTypoCount()))
+            .toList();
+
+    return response;
+  }
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class DetailEntry {
+    private QuoteLanguage language;
+    private String expected;
+    private String actual;
+    private int typoCount;
+    private int initialCount;
+    private int medialCount;
+    private int finalCount;
+    private int letterCount;
+
+    public static DetailEntry from(MemberTypoDetailStats stats) {
+      DetailEntry entry = new DetailEntry();
+      entry.language = stats.getLanguage();
+      entry.expected = stats.getExpected();
+      entry.actual = stats.getActual();
+      entry.typoCount = stats.getTypoCount();
+      entry.initialCount = stats.getInitialCount();
+      entry.medialCount = stats.getMedialCount();
+      entry.finalCount = stats.getFinalCount();
+      entry.letterCount = stats.getLetterCount();
+      return entry;
+    }
+
+    public static DetailEntry fromToday(
+        QuoteLanguage language, String expected, String hashKey, TodayTypoDetailEntry today) {
+      // hashKey: "{language}:{expected}:{actual}"
+      String prefix = language + ":" + expected + ":";
+      String actual = hashKey.substring(prefix.length());
+
+      DetailEntry entry = new DetailEntry();
+      entry.language = language;
+      entry.expected = expected;
+      entry.actual = actual;
+      entry.typoCount = today.getCount();
+      entry.initialCount = today.getInitialCount();
+      entry.medialCount = today.getMedialCount();
+      entry.finalCount = today.getFinalCount();
+      entry.letterCount = today.getLetterCount();
+      return entry;
+    }
+
+    public static DetailEntry merge(DetailEntry existing, DetailEntry today) {
+      DetailEntry merged = new DetailEntry();
+      merged.language = existing.language;
+      merged.expected = existing.expected;
+      merged.actual = existing.actual;
+      merged.typoCount = existing.typoCount + today.typoCount;
+      merged.initialCount = existing.initialCount + today.initialCount;
+      merged.medialCount = existing.medialCount + today.medialCount;
+      merged.finalCount = existing.finalCount + today.finalCount;
+      merged.letterCount = existing.letterCount + today.letterCount;
+      return merged;
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberTypoDetailStatsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberTypoDetailStatsRepository.java
@@ -6,6 +6,7 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -32,6 +33,21 @@ public class MemberTypoDetailStatsRepository {
         .setParameter("actual", actual)
         .getResultStream()
         .findFirst();
+  }
+
+  public List<MemberTypoDetailStats> findByMemberIdAndLanguageAndExpected(
+      Long memberId, QuoteLanguage language, String expected) {
+    return em.createQuery(
+            "select s from MemberTypoDetailStats s "
+                + "where s.member.id = :memberId "
+                + "and s.language = :language "
+                + "and s.expected = :expected "
+                + "order by s.typoCount desc",
+            MemberTypoDetailStats.class)
+        .setParameter("memberId", memberId)
+        .setParameter("language", language)
+        .setParameter("expected", expected)
+        .getResultList();
   }
 
   public void deleteAllInBatch() {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/TodayTypingStatsRedisService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/TodayTypingStatsRedisService.java
@@ -146,6 +146,22 @@ public class TodayTypingStatsRedisService {
     return fallbackTypoDetail(memberId);
   }
 
+  public TodayTypoDetailSnapshot getTypoDetailByLanguageAndExpected(
+      Long memberId, QuoteLanguage language, String expected) {
+    TodayTypoDetailSnapshot snapshot = getTypoDetail(memberId);
+    String prefix = language + ":" + expected + ":";
+
+    Map<String, TodayTypoDetailEntry> filtered = new HashMap<>();
+
+    for (Map.Entry<String, TodayTypoDetailEntry> entry : snapshot.getDetailMap().entrySet()) {
+      if (entry.getKey().startsWith(prefix)) {
+        filtered.put(entry.getKey(), entry.getValue());
+      }
+    }
+
+    return TodayTypoDetailSnapshot.create(filtered);
+  }
+
   public void invalidateTyping(Long memberId, QuoteLanguage language) {
     redisTemplate.delete(typingKey(memberId, language));
   }


### PR DESCRIPTION
- GET /members/me/stats/typos/detail?language=KOREAN&expected=ㅔ: 특정 expected의 actual별 오타 상세 조회
- MemberTypoDetailStatsResponse: PostgreSQL + Redis 오늘치 합산, typoCount 내림차순 정렬
- TodayTypingStatsRedisService.getTypoDetailByLanguageAndExpected: language+expected 필터링 조회
- MemberTypoDetailStatsRepository.findByMemberIdAndLanguageAndExpected: 목록 조회 추가