### PR TITLE
feat: 어드민 문장 조회에 QuoteTypingStats 포함

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
@@ -3,10 +3,7 @@ package com.typingpractice.typing_practice_be.quote.controller;
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
-import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationRequest;
-import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationResponse;
-import com.typingpractice.typing_practice_be.quote.dto.QuoteResponse;
-import com.typingpractice.typing_practice_be.quote.dto.QuoteUpdateRequest;
+import com.typingpractice.typing_practice_be.quote.dto.*;
 import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuoteUpdateQuery;
 import com.typingpractice.typing_practice_be.quote.service.AdminQuoteService;
@@ -21,14 +18,21 @@ public class AdminQuoteController {
   private final AdminQuoteService adminQuoteService;
 
   @GetMapping("/admin/quotes")
-  public ApiResponse<QuotePaginationResponse> getQuotes(
+  public ApiResponse<AdminQuotePaginationResponse> getQuotes(
       @ModelAttribute @Valid QuotePaginationRequest request) {
 
     QuotePaginationQuery query = QuotePaginationQuery.from(request);
 
     PageResult<Quote> result = adminQuoteService.findQuotes(query);
 
-    return ApiResponse.ok(QuotePaginationResponse.from(result));
+    return ApiResponse.ok(AdminQuotePaginationResponse.from(result));
+  }
+
+  @GetMapping("/admin/quotes/{quoteId}")
+  public ApiResponse<AdminQuoteResponse> getQuoteById(@PathVariable Long quoteId) {
+    Quote quote = adminQuoteService.findQuoteByIdWithTypingStats(quoteId);
+
+    return ApiResponse.ok(AdminQuoteResponse.from(quote));
   }
 
   // 승인

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.quote.domain;
 
 import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
 import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.QuoteTypingStats;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -33,6 +34,9 @@ public class Quote extends BaseEntity {
   private Float difficulty;
 
   @Embedded private QuoteProfile profile;
+
+  @OneToOne(mappedBy = "quote", fetch = FetchType.LAZY)
+  private QuoteTypingStats typingStats;
 
   private String sentence;
   private String author;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/AdminQuotePaginationResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/AdminQuotePaginationResponse.java
@@ -1,0 +1,24 @@
+package com.typingpractice.typing_practice_be.quote.dto;
+
+import com.typingpractice.typing_practice_be.common.dto.PageResult;
+import com.typingpractice.typing_practice_be.common.dto.PaginationResponse;
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class AdminQuotePaginationResponse extends PaginationResponse {
+  private List<AdminQuoteResponse> content;
+
+  protected AdminQuotePaginationResponse(int page, int size, boolean hasNext) {
+    super(page, size, hasNext);
+  }
+
+  public static AdminQuotePaginationResponse from(PageResult<Quote> result) {
+    AdminQuotePaginationResponse response =
+        new AdminQuotePaginationResponse(result.getPage(), result.getSize(), result.isHasNext());
+    response.content = result.getContent().stream().map(AdminQuoteResponse::from).toList();
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/AdminQuoteResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/AdminQuoteResponse.java
@@ -1,0 +1,44 @@
+package com.typingpractice.typing_practice_be.quote.dto;
+
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.QuoteTypingStats;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminQuoteResponse extends QuoteResponse {
+  private TypingStatsInfo typingStats;
+
+  public static AdminQuoteResponse from(Quote quote) {
+    AdminQuoteResponse response = new AdminQuoteResponse();
+    response.fillFrom(quote);
+
+    if (quote.getTypingStats() != null) {
+      response.typingStats = TypingStatsInfo.from(quote.getTypingStats());
+    }
+
+    return response;
+  }
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class TypingStatsInfo {
+    private int totalAttemptsCount;
+    private int validAttemptsCount;
+    private float avgCpm;
+    private float avgAcc;
+    private float avgResetCount;
+
+    public static TypingStatsInfo from(QuoteTypingStats stats) {
+      TypingStatsInfo info = new TypingStatsInfo();
+      info.totalAttemptsCount = stats.getTotalAttemptsCount();
+      info.validAttemptsCount = stats.getValidAttemptsCount();
+      info.avgCpm = stats.getAvgCpm();
+      info.avgAcc = stats.getAvgAcc();
+      info.avgResetCount = stats.getAvgResetCount();
+      return info;
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteResponse.java
@@ -22,19 +22,23 @@ public class QuoteResponse {
   private LocalDateTime createdAt;
   private LocalDateTime updatedAt;
 
+  protected void fillFrom(Quote quote) {
+    this.quoteId = quote.getId();
+    this.sentence = quote.getSentence();
+    this.language = quote.getLanguage();
+    this.difficulty = quote.getDifficulty();
+    this.author = quote.getAuthor();
+    this.type = quote.getType();
+    this.status = quote.getStatus();
+    this.reportCount = quote.getReportCount();
+    this.createdAt = quote.getCreatedAt();
+    this.updatedAt = quote.getUpdatedAt();
+  }
+
   public static QuoteResponse from(Quote quote) {
     QuoteResponse response = new QuoteResponse();
 
-    response.quoteId = quote.getId();
-    response.sentence = quote.getSentence();
-    response.language = quote.getLanguage();
-    response.difficulty = quote.getDifficulty();
-    response.author = quote.getAuthor();
-    response.type = quote.getType();
-    response.status = quote.getStatus();
-    response.reportCount = quote.getReportCount();
-    response.createdAt = quote.getCreatedAt();
-    response.updatedAt = quote.getUpdatedAt();
+    response.fillFrom(quote);
 
     return response;
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
@@ -31,9 +31,18 @@ public class QuoteRepository {
 
   public Optional<Quote> findById(Long quoteId) {
     return em.createQuery(
-            "select q from Quote q join fetch q.member m where q.id = :quoteId", Quote.class)
+            "select q from Quote q left join fetch q.member m where q.id = :quoteId", Quote.class)
         .setParameter("quoteId", quoteId)
         .setMaxResults(1)
+        .getResultStream()
+        .findFirst();
+  }
+
+  public Optional<Quote> findByIdWithTypingStats(Long quoteId) {
+    return em.createQuery(
+            "select q from Quote q left join fetch q.typingStats where q.id = :quoteId",
+            Quote.class)
+        .setParameter("quoteId", quoteId)
         .getResultStream()
         .findFirst();
   }
@@ -42,7 +51,7 @@ public class QuoteRepository {
     int page = query.getPage();
     int size = query.getSize();
 
-    String jpql = "select q from Quote q";
+    String jpql = "select q from Quote q left join fetch q.typingStats";
 
     if (query.getStatus() != null && query.getType() != null) {
       jpql += " where q.status = :status and q.type = :type";

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
@@ -100,6 +100,12 @@ public class AdminQuoteService {
     return new PageResult<>(content, query.getPage(), query.getSize(), hasNext);
   }
 
+  public Quote findQuoteByIdWithTypingStats(Long quoteId) {
+    return quoteRepository
+        .findByIdWithTypingStats(quoteId)
+        .orElseThrow(QuoteNotFoundException::new);
+  }
+
   @Transactional
   public Quote hideQuote(Long quoteId) {
     Quote quote = quoteRepository.findById(quoteId).orElseThrow(QuoteNotFoundException::new);


### PR DESCRIPTION
- Quote: QuoteTypingStats 역방향 매핑 추가 (@OneToOne mappedBy, LAZY)
- QuoteRepository: findById를 left join fetch로 변경 (탈퇴 멤버 대응), findAll에 left join fetch q.typingStats 적용, findByIdWithTypingStats 추가
- QuoteResponse: fillFrom() protected 메서드 추출 (상속용)
- AdminQuoteResponse: QuoteResponse 상속, TypingStatsInfo 객체로 통계 포함
- AdminQuotePaginationResponse: 어드민 전용 페이징 응답
- AdminQuoteController: GET /admin/quotes 응답 타입 변경, GET /admin/quotes/{quoteId} 단건 조회 추가
- AdminQuoteService: findQuoteByIdWithTypingStats 추가