### PR TITLE
feat: 전역 통계 배치에 타이핑 성능 집계 추가

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/statistics/domain/GlobalQuoteStatistics.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/statistics/domain/GlobalQuoteStatistics.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.quote.statistics.domain;
 
 import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.statistics.dto.QuoteProfileAggregation;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -115,31 +116,32 @@ public class GlobalQuoteStatistics extends BaseEntity {
     return stats;
   }
 
-  public static GlobalQuoteStatistics createFromAggregation(QuoteLanguage language, Object[] row) {
+  public static GlobalQuoteStatistics createFromAggregation(
+      QuoteLanguage language, QuoteProfileAggregation agg) {
     GlobalQuoteStatistics stats = new GlobalQuoteStatistics();
     stats.language = language;
 
-    stats.lenMean = toFloat(row[0]);
-    stats.lenStd = toFloat(row[1]);
-    stats.puncMean = toFloat(row[2]);
-    stats.puncStd = toFloat(row[3]);
-    stats.spaceMean = toFloat(row[4]);
-    stats.spaceStd = toFloat(row[5]);
-    stats.digitMean = toFloat(row[6]);
-    stats.digitStd = toFloat(row[7]);
+    stats.lenMean = agg.getLenMean(); // toFloat(row[0]);
+    stats.lenStd = agg.getLenStd(); // toFloat(row[1]);
+    stats.puncMean = agg.getPuncMean(); // toFloat(row[2]);
+    stats.puncStd = agg.getPuncStd(); // toFloat(row[3]);
+    stats.spaceMean = agg.getSpaceMean(); // toFloat(row[4]);
+    stats.spaceStd = agg.getSpaceStd(); // toFloat(row[5]);
+    stats.digitMean = agg.getDigitMean(); // toFloat(row[6]);
+    stats.digitStd = agg.getDigitStd(); // toFloat(row[7]);
 
     if (language == QuoteLanguage.KOREAN) {
-      stats.jamoMean = toFloat(row[8]);
-      stats.jamoStd = toFloat(row[9]);
-      stats.diphthongMean = toFloat(row[10]);
-      stats.diphthongStd = toFloat(row[11]);
-      stats.shiftJamoMean = toFloat(row[12]);
-      stats.shiftJamoStd = toFloat(row[13]);
+      stats.jamoMean = agg.getJamoMean(); // toFloat(row[8]);
+      stats.jamoStd = agg.getJamoStd(); // toFloat(row[9]);
+      stats.diphthongMean = agg.getDiphthongMean(); // toFloat(row[10]);
+      stats.diphthongStd = agg.getDiphthongStd(); // toFloat(row[11]);
+      stats.shiftJamoMean = agg.getShiftJamoMean(); // toFloat(row[12]);
+      stats.shiftJamoStd = agg.getShiftJamoStd(); // toFloat(row[13]);
     } else {
-      stats.caseMean = toFloat(row[14]);
-      stats.caseStd = toFloat(row[15]);
-      stats.wordLenMean = toFloat(row[16]);
-      stats.wordLenStd = toFloat(row[17]);
+      stats.caseMean = agg.getCaseMean(); // toFloat(row[14]);
+      stats.caseStd = agg.getCaseStd(); // toFloat(row[15]);
+      stats.wordLenMean = agg.getWordLenMean(); // toFloat(row[16]);
+      stats.wordLenStd = agg.getWordLenStd(); // toFloat(row[17]);
     }
 
     return stats;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/statistics/dto/QuoteProfileAggregation.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/statistics/dto/QuoteProfileAggregation.java
@@ -1,0 +1,61 @@
+package com.typingpractice.typing_practice_be.quote.statistics.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuoteProfileAggregation {
+  // 공통
+  private float lenMean;
+  private float lenStd;
+  private float puncMean;
+  private float puncStd;
+  private float spaceMean;
+  private float spaceStd;
+  private float digitMean;
+  private float digitStd;
+
+  // 한국어 전용
+  private float jamoMean;
+  private float jamoStd;
+  private float diphthongMean;
+  private float diphthongStd;
+  private float shiftJamoMean;
+  private float shiftJamoStd;
+
+  // 영어 전용
+  private float caseMean;
+  private float caseStd;
+  private float wordLenMean;
+  private float wordLenStd;
+
+  public static QuoteProfileAggregation from(Object[] row) {
+    QuoteProfileAggregation agg = new QuoteProfileAggregation();
+    agg.lenMean = toFloat(row[0]);
+    agg.lenStd = toFloat(row[1]);
+    agg.puncMean = toFloat(row[2]);
+    agg.puncStd = toFloat(row[3]);
+    agg.spaceMean = toFloat(row[4]);
+    agg.spaceStd = toFloat(row[5]);
+    agg.digitMean = toFloat(row[6]);
+    agg.digitStd = toFloat(row[7]);
+    agg.jamoMean = toFloat(row[8]);
+    agg.jamoStd = toFloat(row[9]);
+    agg.diphthongMean = toFloat(row[10]);
+    agg.diphthongStd = toFloat(row[11]);
+    agg.shiftJamoMean = toFloat(row[12]);
+    agg.shiftJamoStd = toFloat(row[13]);
+    agg.caseMean = toFloat(row[14]);
+    agg.caseStd = toFloat(row[15]);
+    agg.wordLenMean = toFloat(row[16]);
+    agg.wordLenStd = toFloat(row[17]);
+    return agg;
+  }
+
+  private static float toFloat(Object value) {
+    if (value == null) return 0f;
+    return ((Number) value).floatValue();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/statistics/repository/GlobalQuoteStatisticsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/statistics/repository/GlobalQuoteStatisticsRepository.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.quote.statistics.repository;
 
 import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.statistics.domain.GlobalQuoteStatistics;
+import com.typingpractice.typing_practice_be.quote.statistics.dto.QuoteProfileAggregation;
 import jakarta.persistence.EntityManager;
 
 import java.util.List;
@@ -36,10 +37,11 @@ public class GlobalQuoteStatisticsRepository {
         .getSingleResult();
   }
 
-  public Object[] aggregateByLanguage(QuoteLanguage language) {
-    return (Object[])
-        em.createNativeQuery(
-                """
+  public QuoteProfileAggregation aggregateByLanguage(QuoteLanguage language) {
+    Object[] row =
+        (Object[])
+            em.createNativeQuery(
+                    """
 								SELECT
 										COALESCE(AVG(length), 0), COALESCE(STDDEV_POP(length), 0),
 										COALESCE(AVG(punc_rate), 0), COALESCE(STDDEV_POP(punc_rate), 0),
@@ -53,7 +55,9 @@ public class GlobalQuoteStatisticsRepository {
 								FROM quote
 								WHERE language = :language AND deleted = false
 								""")
-            .setParameter("language", language.name())
-            .getSingleResult();
+                .setParameter("language", language.name())
+                .getSingleResult();
+
+    return QuoteProfileAggregation.from(row);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/statistics/service/GlobalQuoteStatisticsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/statistics/service/GlobalQuoteStatisticsBatchService.java
@@ -7,7 +7,10 @@ import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
 import com.typingpractice.typing_practice_be.quote.service.DifficultySeedCalculator;
 import com.typingpractice.typing_practice_be.quote.service.QuoteProfileCalculator;
 import com.typingpractice.typing_practice_be.quote.statistics.domain.GlobalQuoteStatistics;
+import com.typingpractice.typing_practice_be.quote.statistics.dto.QuoteProfileAggregation;
 import com.typingpractice.typing_practice_be.quote.statistics.repository.GlobalQuoteStatisticsRepository;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.GlobalTypingPerformance;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.QuoteTypingStatsRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,13 +31,16 @@ public class GlobalQuoteStatisticsBatchService {
 
   private static final float CHANGE_THRESHOLD = 0.05f;
   private static final int PAGE_SIZE = 5000;
+  private final QuoteTypingStatsRepository quoteTypingStatsRepository;
 
   @Transactional
   public void runScheduledBatch() {
     for (QuoteLanguage lang : QuoteLanguage.values()) {
       GlobalQuoteStatistics prev = statsService.getByLanguage(lang);
+      // 일별 전체 문장의 평균 코퍼스, 타이핑 속도, 정확도 계산
       GlobalQuoteStatistics next = recalculateStats(lang);
 
+      // 평균 코퍼스 변화가 클 경우 seed 재계산
       if (shouldRecalculateSeeds(prev, next, lang)) {
         log.info("[{}] 변화율 임계값 초과 -> seed 재계산 시작", lang);
         recalculateAllSeeds(lang, next);
@@ -58,8 +64,15 @@ public class GlobalQuoteStatisticsBatchService {
   }
 
   private GlobalQuoteStatistics recalculateStats(QuoteLanguage lang) {
-    Object[] row = statsRepository.aggregateByLanguage(lang);
-    GlobalQuoteStatistics next = GlobalQuoteStatistics.createFromAggregation(lang, row);
+    QuoteProfileAggregation statsAgg = statsRepository.aggregateByLanguage(lang);
+    GlobalQuoteStatistics next = GlobalQuoteStatistics.createFromAggregation(lang, statsAgg);
+
+    // 전역 타이핑 결과 갱신
+    GlobalTypingPerformance perf = quoteTypingStatsRepository.aggregateGlobalAvgByLanguage(lang);
+    if (!perf.isEmpty()) {
+      next.updateGlobalTypingPerformance(perf.getAvgCpm(), perf.getAvgAcc());
+    }
+
     statsRepository.save(next);
     log.info(
         "[{}] 전역 통계 재계산 완료 - lenMean = {}, puncMean = {}",

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/GlobalTypingPerformance.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/dto/GlobalTypingPerformance.java
@@ -1,0 +1,30 @@
+package com.typingpractice.typing_practice_be.typingrecord.statistics.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GlobalTypingPerformance {
+  private Float avgCpm;
+  private Float avgAcc;
+
+  public static GlobalTypingPerformance of(Float avgCpm, Float avgAcc) {
+    GlobalTypingPerformance perf = new GlobalTypingPerformance();
+    perf.avgCpm = avgCpm;
+    perf.avgAcc = avgAcc;
+
+    return perf;
+  }
+
+  public static GlobalTypingPerformance empty() {
+    return new GlobalTypingPerformance();
+  }
+
+  public boolean isEmpty() {
+    return avgCpm == null || avgAcc == null;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/QuoteTypingStatsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/QuoteTypingStatsRepository.java
@@ -1,6 +1,8 @@
 package com.typingpractice.typing_practice_be.typingrecord.statistics.repository;
 
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.QuoteTypingStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.GlobalTypingPerformance;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -22,5 +24,22 @@ public class QuoteTypingStatsRepository {
         .setParameter("quoteId", quoteId)
         .getResultStream()
         .findFirst();
+  }
+
+  public GlobalTypingPerformance aggregateGlobalAvgByLanguage(QuoteLanguage language) {
+    Object[] row =
+        (Object[])
+            em.createQuery(
+                    "select avg(s.avgCpm), avg(s.avgAcc) from QuoteTypingStats s "
+                        + "where s.language = :language and s.validAttemptsCount > 0")
+                .setParameter("language", language)
+                .getSingleResult();
+
+    if (row[0] == null) {
+      return GlobalTypingPerformance.empty();
+    }
+
+    return GlobalTypingPerformance.of(
+        ((Number) row[0]).floatValue(), ((Number) row[1]).floatValue());
   }
 }


### PR DESCRIPTION
- GlobalQuoteStatistics: globalAvgCpm/globalAvgAcc 필드 추가 (동적 난이도 보정용)
- QuoteTypingStatsRepository: 언어별 avgCpm/avgAcc 전역 평균 집계 메서드 추가
- GlobalQuoteStatisticsBatchService: recalculateStats에서 타이핑 성능 함께 갱신
- QuoteProfileAggregation: 문장 특성 집계 결과 DTO 도입 (Object[] 반환 대체)
- GlobalTypingPerformance: 타이핑 성능 집계 결과 DTO 도입 (Object[] 반환 대체)
- GlobalQuoteStatistics.createFromAggregation: Object[] → QuoteProfileAggregation 파라미터 변경