### PR TITLE
feat: 동적 난이도 보정 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/config/DifficultyProperties.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/config/DifficultyProperties.java
@@ -1,0 +1,14 @@
+package com.typingpractice.typing_practice_be.quote.config;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties(prefix = "quote.difficulty")
+public class DifficultyProperties {
+  private final int coldStartK;
+
+  public DifficultyProperties(int coldStartK) {
+    this.coldStartK = coldStartK;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -109,9 +109,13 @@ public class Quote extends BaseEntity {
     this.profile = profile;
   }
 
-  public void updateDifficulty(float seed) {
+  public void updateDifficultySeed(float seed) {
     this.profile.setDifficultySeed(seed);
     this.difficulty = seed;
+  }
+
+  public void updateDynamicDifficulty(float difficulty) {
+    this.difficulty = difficulty;
   }
 
   public void updateStatus(QuoteStatus quoteStatus) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/DifficultyBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/DifficultyBatchService.java
@@ -1,0 +1,67 @@
+package com.typingpractice.typing_practice_be.quote.service;
+
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.statistics.domain.GlobalQuoteStatistics;
+import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsService;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.QuoteTypingStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.QuoteTypingStatsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DifficultyBatchService {
+  private final QuoteTypingStatsRepository quoteTypingStatsRepository; // 각 문장 별 타이핑 기록
+  private final GlobalQuoteStatisticsService
+      globalQuoteStatisticsService; // 일별 전체 문장 코퍼스, 속도, 정확도 기록
+  private final DynamicDifficultyCalculator dynamicDifficultyCalculator; // 동적난이도 계산기
+
+  private static final int PAGE_SIZE = 500;
+
+  @Transactional
+  public void runDynamicDifficultyBatch() {
+    for (QuoteLanguage lang : QuoteLanguage.values()) {
+      GlobalQuoteStatistics globalStats = globalQuoteStatisticsService.getByLanguage(lang);
+
+      if (globalStats.getGlobalAvgCpm() == null || globalStats.getGlobalAvgAcc() == null) {
+        log.info("[{}] 전역 타이핑 기록 없음 -> 동적 보정 스킵", lang);
+        continue;
+      }
+
+      int totalUpdated = recalculateByLanguage(lang, globalStats);
+      log.info("[{}] 동적 난이도 보정 완료 - {}건 갱신", lang, totalUpdated);
+    }
+  }
+
+  private int recalculateByLanguage(QuoteLanguage lang, GlobalQuoteStatistics globalStats) {
+    int totalUpdated = 0;
+    int page = 0;
+
+    while (true) {
+      List<QuoteTypingStats> statsList =
+          quoteTypingStatsRepository.findByLanguageWithQuote(lang, page, PAGE_SIZE);
+
+      if (statsList.isEmpty()) break;
+
+      for (QuoteTypingStats stats : statsList) {
+        Quote quote = stats.getQuote();
+        float seed = quote.getProfile().getDifficultySeed();
+
+        float difficulty = dynamicDifficultyCalculator.calculate(stats, globalStats, seed);
+        quote.updateDynamicDifficulty(difficulty);
+      }
+
+      totalUpdated += statsList.size();
+      page++;
+    }
+
+    return totalUpdated;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/DynamicDifficultyCalculator.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/DynamicDifficultyCalculator.java
@@ -1,0 +1,36 @@
+package com.typingpractice.typing_practice_be.quote.service;
+
+import com.typingpractice.typing_practice_be.quote.config.DifficultyProperties;
+import com.typingpractice.typing_practice_be.quote.statistics.domain.GlobalQuoteStatistics;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.QuoteTypingStats;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DynamicDifficultyCalculator {
+  private static final float PERF_COEFFICIENT = 1.5f;
+
+  private final DifficultyProperties difficultyProperties;
+
+  public float calculate(
+      QuoteTypingStats stats, GlobalQuoteStatistics globalStats, float difficultySeed) {
+    int n = stats.getValidAttemptsCount();
+    int k = difficultyProperties.getColdStartK();
+
+    float cpmDrop = 1 - stats.getAvgCpm() / globalStats.getGlobalAvgCpm();
+    float accDrop = 1 - stats.getAvgAcc() / globalStats.getGlobalAvgAcc();
+
+    float perf = clip(PERF_COEFFICIENT * (cpmDrop + accDrop), -1f, 1f);
+    float perfNormalized = (perf + 1f) / 2f;
+
+    float difficulty =
+        ((float) n / (n + k)) * perfNormalized + ((float) k / (n + k)) * (difficultySeed / 100f);
+
+    return Math.round(100 * difficulty);
+  }
+
+  private float clip(float value, float min, float max) {
+    return Math.max(min, Math.min(max, value));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/statistics/service/GlobalQuoteStatisticsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/statistics/service/GlobalQuoteStatisticsBatchService.java
@@ -28,10 +28,10 @@ public class GlobalQuoteStatisticsBatchService {
   private final QuoteRepository quoteRepository;
   private final DifficultySeedCalculator seedCalculator;
   private final QuoteProfileCalculator quoteProfileCalculator;
+  private final QuoteTypingStatsRepository quoteTypingStatsRepository;
 
   private static final float CHANGE_THRESHOLD = 0.05f;
   private static final int PAGE_SIZE = 5000;
-  private final QuoteTypingStatsRepository quoteTypingStatsRepository;
 
   @Transactional
   public void runScheduledBatch() {
@@ -133,7 +133,7 @@ public class GlobalQuoteStatisticsBatchService {
         }
 
         float seed = seedCalculator.calculate(quote.getProfile(), stats, lang);
-        quote.updateDifficulty(seed);
+        quote.updateDifficultySeed(seed);
       }
 
       totalUpdated += quotes.size();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.statistics.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.quote.service.DifficultyBatchService;
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsBatchService;
 import com.typingpractice.typing_practice_be.statistics.dto.MemberStatsDayRequest;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.MemberDailyStatsBatchService;
@@ -20,6 +21,7 @@ public class AdminStatisticsController {
   private final MemberTypingStatsBatchService memberTypingStatsBatchService;
   private final MemberDailyStatsBatchService memberDailyStatsBatchService;
   private final MemberTypoStatsBatchService memberTypoStatsBatchService;
+  private final DifficultyBatchService difficultyBatchService;
 
   @PostMapping("/global-quote/recalculate")
   public ApiResponse<Void> recalculate() {
@@ -30,6 +32,14 @@ public class AdminStatisticsController {
   @PostMapping("/quote-typing/recalculate")
   public ApiResponse<Void> recalculateQuoteTypingStats() {
     quoteTypingStatsBatchService.runManualRecalculation();
+    return ApiResponse.ok(null);
+  }
+
+  @PostMapping("/difficulty/recalculate")
+  public ApiResponse<Void> recalculateDynamicDifficulty() {
+    quoteTypingStatsBatchService.runManualRecalculation();
+    globalQuoteStatisticsBatchService.runManualRecalculation();
+    difficultyBatchService.runDynamicDifficultyBatch();
     return ApiResponse.ok(null);
   }
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.statistics.scheduler;
 
 import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.quote.service.DifficultyBatchService;
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.MemberDailyStatsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.MemberTypingStatsBatchService;
@@ -20,15 +21,17 @@ public class StatisticsScheduler {
   private final MemberTypingStatsBatchService memberTypingStatsBatchService;
   private final MemberDailyStatsBatchService memberDailyStatsBatchService;
   private final MemberTypoStatsBatchService memberTypoStatsBatchService;
+  private final DifficultyBatchService difficultyBatchService;
 
   @Scheduled(cron = "0 0 3 * * *", zone = TimeUtils.KST_ZONE)
   public void runDailyBatch() {
     log.info("전역 통계 배치 시작");
-    quoteTypingStatsBatchService.runScheduledBatch(); // 문장 별 타이핑 통계
-    memberTypingStatsBatchService.runScheduledBatch(); // 개인 별 타이핑 통계
-    memberDailyStatsBatchService.runScheduledBatch(); // 개인 일간 타이핑 통계
+    quoteTypingStatsBatchService.runScheduledBatch(); // 문장별 타이핑 통계
+    globalQuoteStatisticsBatchService.runScheduledBatch(); // 전역 통계 (문장 특성 + 타이핑 성능)
+    difficultyBatchService.runDynamicDifficultyBatch(); // 동적 난이도 보정
+    memberTypingStatsBatchService.runScheduledBatch(); // 개인 타이핑 통계
+    memberDailyStatsBatchService.runScheduledBatch(); // 개인 일간 통계
     memberTypoStatsBatchService.runScheduledBatch(); // 개인 오타 통계
-    globalQuoteStatisticsBatchService.runScheduledBatch(); // 전체 문장의 profile 통계
     log.info("전역 통계 배치 완료");
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/QuoteTypingStatsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/QuoteTypingStatsRepository.java
@@ -7,6 +7,7 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -41,5 +42,17 @@ public class QuoteTypingStatsRepository {
 
     return GlobalTypingPerformance.of(
         ((Number) row[0]).floatValue(), ((Number) row[1]).floatValue());
+  }
+
+  public List<QuoteTypingStats> findByLanguageWithQuote(
+      QuoteLanguage language, int page, int size) {
+    return em.createQuery(
+            "select s from QuoteTypingStats s join fetch s.quote "
+                + "where s.language = :language and s.validAttemptsCount > 0",
+            QuoteTypingStats.class)
+        .setParameter("language", language)
+        .setFirstResult(page * size)
+        .setMaxResults(size)
+        .getResultList();
   }
 }

--- a/typing-practice-be/src/main/resources/application.yaml
+++ b/typing-practice-be/src/main/resources/application.yaml
@@ -27,6 +27,8 @@ google:
   token-uri: https://oauth2.googleapis.com/token
 
 quote:
+  difficulty:
+    cold-start-k: 20
   similarity-threshold:
     korean: 0.5
     english: 0.5


### PR DESCRIPTION
- DynamicDifficultyCalculator: 설계서 8절 공식 구현 (cpmDrop → accDrop → perf → perfNormalized → difficulty)
- DifficultyProperties: cold-start-k yml 설정 (기본값 20)
- DifficultyBatchService: 언어별 QuoteTypingStats 순회 → 동적 보정 → Quote.difficulty 갱신
- Quote: updateDifficultySeed/updateDynamicDifficulty 분리 (seed 유지, difficulty만 보정)
- QuoteTypingStatsRepository: findByLanguageWithQuote 페이징 조회 추가
- StatisticsScheduler: 배치 순서 변경 (QuoteTypingStats → GlobalQuoteStats → 동적 보정 → Member 통계)
- AdminStatisticsController: POST /admin/stats/difficulty/recalculate 추가 (의존 배치 포함 실행)