### PR TITLE
refactor: 타이핑 채점 색상 표시 방식 개선

### DIFF
--- a/tp-react/src/components/Quote/InputDisplay/InputDisplay.css
+++ b/tp-react/src/components/Quote/InputDisplay/InputDisplay.css
@@ -32,6 +32,10 @@
     color: #d4d4d4;
 }
 
+.input-char-composing {
+    color: transparent;
+}
+
 /* Default 모드 스타일 - InputDisplay 숨김 */
 .default-mode .input-display {
     display: none;

--- a/tp-react/src/components/Quote/InputDisplay/InputDisplay.jsx
+++ b/tp-react/src/components/Quote/InputDisplay/InputDisplay.jsx
@@ -20,13 +20,10 @@ const InputDisplay = ({input}) => {
                 const status = inputCheck[index];
                 let className = "";
 
-                if (status === "correct") {
-                    className = isDark ? "input-char-correct dark" : "input-char-correct";
-                } else if (status === "incorrect") {
+                if (status === "incorrect") {
                     className = "input-char-incorrect";
                 } else {
-                    // none 상태 - 입력 중인 글자는 회색으로 표시
-                    className = isDark ? "input-char-none dark" : "input-char-none";
+                    className = isDark ? "input-char-correct dark" : "input-char-correct";
                 }
 
 

--- a/tp-react/src/components/Quote/Sentence/Sentence.jsx
+++ b/tp-react/src/components/Quote/Sentence/Sentence.jsx
@@ -16,12 +16,17 @@ const Sentence = ({ inputLength, inputValue }) => {
     if (!sentence) {
       return "";
     }
-    
+
+    // 일반 모드: 원본 문장 유지 (글자색만 변경)
+    if (!isCompactMode) {
+      return sentence;
+    }
+
     if (!inputValue || inputValue.length === 0) {
       return sentence;
     }
 
-    // 입력된 부분(inputValue) + 남은 원본 문장 부분
+    // 컴팩트 모드: 입력된 부분(inputValue) + 남은 원본 문장 부분
     const remainingSentence = sentence.slice(inputLength);
     return inputValue + remainingSentence;
   };
@@ -32,16 +37,14 @@ const Sentence = ({ inputLength, inputValue }) => {
     
     if (index < inputLength) {
       if (isCompactMode) {
-        // Compact 모드: 입력된 글자는 투명
+        // Compact 모드: 입력된 글자는 투명 (InputDisplay가 색상 담당)
         className += " character-typed";
       } else {
-        // Default 모드: 채점 결과에 따라 색상 표시
+        // Default 모드: 채점 완료된 글자만 색상 표시 (입력 중이면 원래 색 유지)
         if (inputCheck[index] === "correct") {
           className += " character-correct-visible";
         } else if (inputCheck[index] === "incorrect") {
           className += " character-incorrect-visible";
-        } else {
-          className += " character-typing";
         }
       }
     }

--- a/tp-react/src/data/updateHistory.js
+++ b/tp-react/src/data/updateHistory.js
@@ -1,5 +1,14 @@
 export const updateHistory = [
     {
+        version: "1.1.2",
+        date: "2026년 3월 23일",
+        showPopup: true,
+        hidden: false,
+        improvements: [
+            "일반 모드에서 입력 시 예문이 변경되지 않고 원본 유지되도록 개선"
+        ]
+    },
+    {
         version: "1.1.1",
         date: "2025년 12월 10일",
         showPopup: false,


### PR DESCRIPTION
- 일반 모드에서 입력 시 예문 원본 유지 (입력값으로 대체되지 않음)
- 채점 완료 시에만 정답/오답 색상 적용, 입력 중에는 기본 색상 유지
- 컴팩트 모드에서 입력 중인 글자는 정답 색상, 오답 시에만 오답 색상 적용
- v1.1.2 업데이트 내역 추가