### PR TITLE
feat: 타이핑 기록 저장 API 연동 (POST /typing-records)

### DIFF
--- a/tp-react/src/Context/QuoteContext.tsx
+++ b/tp-react/src/Context/QuoteContext.tsx
@@ -124,6 +124,11 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
             const content = data.content || [];
 
             if (reset) {
+                if (content.length === 0 && source === QUOTE_SOURCE.ALL) {
+                    // 서버 응답은 왔지만 공개 문장이 없는 경우 로컬 문장 사용
+                    loadFallbackQuotes();
+                    return;
+                }
                 setQuotes(content);
                 setQuotesIndex(0);
             } else {

--- a/tp-react/src/Context/ScoreContext.tsx
+++ b/tp-react/src/Context/ScoreContext.tsx
@@ -46,6 +46,8 @@ interface ScoreContextType {
     setCpmList: Dispatch<SetStateAction<number[]>>;
     accList: number[];
     setAccList: Dispatch<SetStateAction<number[]>>;
+    resetCount: number;
+    setResetCount: Dispatch<SetStateAction<number>>;
 }
 
 export const ScoreContext = createContext<ScoreContextType | null>(null);
@@ -90,6 +92,7 @@ export const ScoreContextProvider = ({children}: ScoreContextProviderProps) => {
 
     const [cpmList, setCpmList] = useState<number[]>([]);
     const [accList, setAccList] = useState<number[]>([]);
+    const [resetCount, setResetCount] = useState<number>(0);
 
     return (
         <ScoreContext.Provider
@@ -106,6 +109,7 @@ export const ScoreContextProvider = ({children}: ScoreContextProviderProps) => {
                 popupData, setPopupData,
                 cpmList, setCpmList,
                 accList, setAccList,
+                resetCount, setResetCount,
             }}
         >
             {children}

--- a/tp-react/src/const/config.const.ts
+++ b/tp-react/src/const/config.const.ts
@@ -12,3 +12,6 @@ export const Storage_Refresh_Token = "Typing-Practice-refreshToken" as const;
 export const MIN_SENTENCE_LENGTH = 5 as const;
 export const MAX_SENTENCE_LENGTH = 100 as const;
 export const MAX_AUTHOR_LENGTH = 20 as const;
+
+// Typing Record 관련 상수
+export const RESET_COUNT_THRESHOLD_RATIO = 0.3 as const;

--- a/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
+++ b/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
@@ -13,7 +13,11 @@ import {
     KEY_COMMANDS,
     KEY_ESC,
 } from "@/const/key.const.js";
+import {RESET_COUNT_THRESHOLD_RATIO} from "@/const/config.const.ts";
 import {koreanSeparator} from "@/utils/koreanSeparator.ts";
+import {createTypoEntry} from "@/utils/typoUtils.ts";
+import {saveTypingRecord} from "@/utils/typingRecordApi.ts";
+import {areJamoEqual, calculateAccuracy, sum, average, max} from "./InputUtils";
 
 const Input = ({onInputChange: onInputChangeCallback}) => {
     const {isDark} = useTheme();
@@ -38,8 +42,10 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
         showPopup,
         setShowPopup,
         setPopupData,
+        resetCount,
+        setResetCount,
     } = useScore();
-    const {sentence, setQuotesIndex} = useQuote(); // 예문, 예문의 인덱스
+    const {sentence, currentQuote, setQuotesIndex} = useQuote(); // 예문, 예문의 인덱스
     const {resultPeriod, fontSize, isCompactMode} = useSetting();
     const [input, setInput] = useState(""); // 사용자 입력값
     const speedInterval = useRef(null); // setInterval 을 참조하기 위함
@@ -48,6 +54,36 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
     const separatedSentence = useRef(null); // 예문 자모 분리값
     const separatedInput = useRef([]); // 입력값 자모 분리값
     const typedCharCount = useRef([]); // 타이핑한 character 수
+    const maxInputLengthRef = useRef(0); // 현재 시도에서 도달한 최대 입력 길이
+    const typosRef = useRef([]); // 오타 누적 배열
+    const lastResetTimeRef = useRef(0); // resetCount 중복 증가 방지용 타임스탬프
+
+    // resetCount를 안전하게 증가시키는 함수 (50ms 이내 중복 호출 무시)
+    const incrementResetCount = () => {
+        const now = Date.now();
+        if (now - lastResetTimeRef.current < 50) return;
+        lastResetTimeRef.current = now;
+        setResetCount((prev) => prev + 1);
+    };
+
+    // 오답 처리 + typo 기록
+    const markIncorrect = (prevCheck, charIndex, sentenceSeparated, inputSeparated) => {
+        prevCheck[charIndex] = "incorrect";
+        setIncorrectCount((prev) => prev + 1);
+        typosRef.current.push(createTypoEntry(
+            sentence[charIndex], sentenceSeparated, inputSeparated, charIndex,
+        ));
+    };
+
+    // 문장 이동 (화살표 키)
+    const navigateQuote = (direction) => {
+        clearInput();
+        setResetCount(0);
+        typosRef.current = [];
+        setTimeout(() => {
+            setQuotesIndex((prev) => prev + direction);
+        }, 0);
+    };
 
     const textareaRef = useRef(null); // DOM 요소 접근용
 
@@ -106,6 +142,8 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
         clearInterval(speedInterval.current);
         setSpeedCheck(true);
 
+        // 최대 입력 길이 리셋
+        maxInputLengthRef.current = 0;
 
         if (isSubmit) {
             return;
@@ -145,27 +183,20 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
                 return;
             }
 
+            if (input.length > 0) {
+                incrementResetCount();
+            }
             clearInput();
             return;
         }
 
         if (e.key === KEY_ARROW_UP || e.key === KEY_ARROW_RIGHT) {
-            // 먼저 입력 초기화
-            clearInput();
-            // 상태 업데이트 후 문장 변경
-            setTimeout(() => {
-                setQuotesIndex((prev) => prev + 1);
-            }, 0);
+            navigateQuote(1);
             return;
         }
 
         if (e.key === KEY_ARROW_DOWN || e.key === KEY_ARROW_LEFT) {
-            // 먼저 입력 초기화
-            clearInput();
-            // 상태 업데이트 후 문장 변경
-            setTimeout(() => {
-                setQuotesIndex((prev) => prev - 1);
-            }, 0);
+            navigateQuote(-1);
         }
     };
 
@@ -222,7 +253,25 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
         clearInterval(speedInterval.current);
         setSpeedCheck(true);
 
+        // 타이핑 기록 저장 API 호출 (fire-and-forget)
+        const quoteId = currentQuote?.quoteId;
+        if (quoteId) {
+            const accuracy = (correctCount + (isLastCharCorrect ? 1 : 0))
+                / (correctCount + incorrectCount + 1);
 
+            saveTypingRecord({
+                quoteId,
+                cpm: currentCpm,
+                accuracy: Math.round(accuracy * 1000) / 1000,
+                charLength: sentence.length,
+                resetCount,
+                typos: typosRef.current,
+            }).catch((error) => console.error('타이핑 기록 저장 실패:', error));
+        }
+
+        // typos, resetCount 초기화
+        typosRef.current = [];
+        setResetCount(0);
     };
 
     const onInputChange = (e) => {
@@ -244,9 +293,17 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
         }
 
         if (newValue.length === 0) {
+            // 30% 이상 입력했었으면 resetCount 증가 (ESC와의 중복은 incrementResetCount에서 방지)
+            const threshold = Math.round(sentence.length * RESET_COUNT_THRESHOLD_RATIO);
+            if (maxInputLengthRef.current >= threshold) {
+                incrementResetCount();
+            }
             clearInput();
             return;
         }
+
+        // 최대 입력 길이 추적
+        maxInputLengthRef.current = Math.max(maxInputLengthRef.current, newValue.length);
 
         // 입력값 길이가 문장보다 길 경우 (입력 완료)
         if (newValue.length > sentence.length) {
@@ -257,15 +314,6 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
             // 입력 초기화
             clearInput(true);
 
-            return;
-        }
-
-        // 입력 길이가 문장 길이와 같아지면 더 이상 입력 불가
-        if (newValue.length === sentence.length) {
-            // 마지막 글자까지 입력했으므로 입력값 설정은 하되
-            // 추가 입력은 막음
-            setInput(newValue);
-            processInput(newValue);
             return;
         }
 
@@ -302,28 +350,15 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
 
                 if (!isChecked) {
                     // 채점되지 않은 경우 오답 처리
-                    prevCheck[prevCharIndex] = "incorrect";
-                    setIncorrectCount((prev) => prev + 1);
+                    markIncorrect(prevCheck, prevCharIndex, prevSentenceSeparated, prevInputSeparated);
                 } else {
                     // 이미 채점된 경우 재채점 (받침 변화 등으로 인한 최종 확정)
-                    let isFinalCorrect = false;
-
-                    // 길이가 같고 모든 자모가 일치하는지 확인
-                    if (prevInputSeparated.length === prevSentenceSeparated.length) {
-                        isFinalCorrect = true;
-                        for (let i = 0; i < prevSentenceSeparated.length; i++) {
-                            if (prevInputSeparated[i] !== prevSentenceSeparated[i]) {
-                                isFinalCorrect = false;
-                                break;
-                            }
-                        }
-                    }
+                    const isFinalCorrect = areJamoEqual(prevInputSeparated, prevSentenceSeparated);
 
                     // 이전에 정답이었는데 최종적으로 오답인 경우
                     if (prevCheck[prevCharIndex] === "correct" && !isFinalCorrect) {
-                        prevCheck[prevCharIndex] = "incorrect";
                         setCorrectCount((prev) => prev - 1);
-                        setIncorrectCount((prev) => prev + 1);
+                        markIncorrect(prevCheck, prevCharIndex, prevSentenceSeparated, prevInputSeparated);
                     }
                     // 이전에 오답이었는데 최종적으로 정답인 경우 (거의 없지만 안전장치)
                     else if (prevCheck[prevCharIndex] === "incorrect" && isFinalCorrect) {
@@ -340,49 +375,34 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
 
             // 입력한 자모 수가 예문의 자모 수와 같거나 많을 경우 (글자 완성)
             if (currentInputSeparated.length >= currentSentenceSeparated.length) {
-                let isCorrect = true;
-
-                // 모든 자모가 일치하는지 확인
-                for (let i = 0; i < currentSentenceSeparated.length; i++) {
-                    if (currentInputSeparated[i] !== currentSentenceSeparated[i]) {
-                        isCorrect = false;
-                        break;
-                    }
-                }
+                // 예문 자모 길이만큼만 비교 (입력이 더 긴 경우에도 앞부분만 일치하면 정답)
+                const isCorrect = areJamoEqual(
+                    currentInputSeparated.slice(0, currentSentenceSeparated.length),
+                    currentSentenceSeparated,
+                );
 
                 if (isCorrect) {
-                    // 정답으로 채점 (단, 다음 글자로 넘어갈 때 재확인됨)
                     if (prevCheck[lastCharIndex] !== "correct") {
                         prevCheck[lastCharIndex] = "correct";
                         setCorrectCount((prev) => prev + 1);
                     }
                 } else {
-                    // 오답으로 채점
                     if (prevCheck[lastCharIndex] !== "incorrect") {
-                        prevCheck[lastCharIndex] = "incorrect";
-                        setIncorrectCount((prev) => prev + 1);
+                        markIncorrect(prevCheck, lastCharIndex, currentSentenceSeparated, currentInputSeparated);
                     }
                 }
             } else {
                 // 입력한 자모 수가 예문보다 적을 경우 (글자 입력 중)
-                let isPartialCorrect = true;
-
-                // 지금까지 입력한 자모가 모두 맞는지 확인
-                for (let i = 0; i < currentInputSeparated.length; i++) {
-                    if (currentInputSeparated[i] !== currentSentenceSeparated[i]) {
-                        isPartialCorrect = false;
-                        break;
-                    }
-                }
+                const isPartialCorrect = areJamoEqual(
+                    currentInputSeparated,
+                    currentSentenceSeparated.slice(0, currentInputSeparated.length),
+                );
 
                 if (!isPartialCorrect) {
-                    // 중간 과정이지만 이미 틀렸으면 오답 처리
                     if (prevCheck[lastCharIndex] !== "incorrect") {
-                        prevCheck[lastCharIndex] = "incorrect";
-                        setIncorrectCount((prev) => prev + 1);
+                        markIncorrect(prevCheck, lastCharIndex, currentSentenceSeparated, currentInputSeparated);
                     }
                 } else {
-                    // 중간 과정이고 지금까지는 맞음 -> "none" 유지 (아직 채점 안 함)
                     prevCheck[lastCharIndex] = "none";
                 }
             }
@@ -425,23 +445,3 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
 };
 
 export default Input;
-
-const calculateAccuracy = (isCorrect, correctCount, incorrectCount) => {
-    const totalChecked = correctCount + incorrectCount + 1;
-    const newCorrectCount = correctCount + (isCorrect ? 1 : 0);
-    return (newCorrectCount / totalChecked) * 100;
-};
-
-const sum = (array) => {
-    return array.reduce((prev, curr) => prev + curr, 0);
-};
-
-const average = (array) => {
-    if (array.length === 0) return 0;
-    return sum(array) / array.length;
-};
-
-const max = (array) => {
-    if (array.length === 0) return 0;
-    return Math.max(...array);
-};

--- a/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
+++ b/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
@@ -375,11 +375,39 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
 
             // 입력한 자모 수가 예문의 자모 수와 같거나 많을 경우 (글자 완성)
             if (currentInputSeparated.length >= currentSentenceSeparated.length) {
-                // 예문 자모 길이만큼만 비교 (입력이 더 긴 경우에도 앞부분만 일치하면 정답)
-                const isCorrect = areJamoEqual(
+                // 예문 자모 길이만큼 비교
+                let isCorrect = areJamoEqual(
                     currentInputSeparated.slice(0, currentSentenceSeparated.length),
                     currentSentenceSeparated,
                 );
+
+                // 입력 자모가 예문보다 많을 경우, 추가 자모가 다음 글자의 시작과 일치하는지 확인
+                let isExtraJamoMismatch = false;
+                let extraJamoMismatchInfo = null;
+
+                if (isCorrect && currentInputSeparated.length > currentSentenceSeparated.length) {
+                    const extraJamo = currentInputSeparated.slice(currentSentenceSeparated.length);
+                    const nextCharIndex = lastCharIndex + 1;
+
+                    if (nextCharIndex < sentence.length) {
+                        const nextSentenceSeparated = separatedSentence.current[nextCharIndex];
+                        isCorrect = areJamoEqual(
+                            extraJamo,
+                            nextSentenceSeparated.slice(0, extraJamo.length),
+                        );
+                        if (!isCorrect) {
+                            isExtraJamoMismatch = true;
+                            extraJamoMismatchInfo = {
+                                nextCharIndex,
+                                nextSentenceSeparated,
+                                extraJamo,
+                            };
+                        }
+                    } else {
+                        // 마지막 글자인데 추가 자모가 있으면 오답
+                        isCorrect = false;
+                    }
+                }
 
                 if (isCorrect) {
                     if (prevCheck[lastCharIndex] !== "correct") {
@@ -388,7 +416,27 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
                     }
                 } else {
                     if (prevCheck[lastCharIndex] !== "incorrect") {
-                        markIncorrect(prevCheck, lastCharIndex, currentSentenceSeparated, currentInputSeparated);
+                        prevCheck[lastCharIndex] = "incorrect";
+                        setIncorrectCount((prev) => prev + 1);
+
+                        if (isExtraJamoMismatch && extraJamoMismatchInfo) {
+                            // 추가 자모 불일치: 다음 글자 기준으로 typo 기록
+                            const {nextCharIndex, nextSentenceSeparated, extraJamo} = extraJamoMismatchInfo;
+                            typosRef.current.push(createTypoEntry(
+                                sentence[nextCharIndex],
+                                nextSentenceSeparated,
+                                extraJamo,
+                                nextCharIndex,
+                            ));
+                        } else {
+                            // 일반 오답: 현재 글자 기준으로 typo 기록
+                            typosRef.current.push(createTypoEntry(
+                                sentence[lastCharIndex],
+                                currentSentenceSeparated,
+                                currentInputSeparated,
+                                lastCharIndex,
+                            ));
+                        }
                     }
                 }
             } else {

--- a/tp-react/src/pages/Home/components/Quote/Input/InputUtils.js
+++ b/tp-react/src/pages/Home/components/Quote/Input/InputUtils.js
@@ -1,0 +1,27 @@
+export const areJamoEqual = (separated1, separated2) => {
+    if (separated1.length !== separated2.length) return false;
+    for (let i = 0; i < separated1.length; i++) {
+        if (separated1[i] !== separated2[i]) return false;
+    }
+    return true;
+};
+
+export const calculateAccuracy = (isCorrect, correctCount, incorrectCount) => {
+    const totalChecked = correctCount + incorrectCount + 1;
+    const newCorrectCount = correctCount + (isCorrect ? 1 : 0);
+    return (newCorrectCount / totalChecked) * 100;
+};
+
+export const sum = (array) => {
+    return array.reduce((prev, curr) => prev + curr, 0);
+};
+
+export const average = (array) => {
+    if (array.length === 0) return 0;
+    return sum(array) / array.length;
+};
+
+export const max = (array) => {
+    if (array.length === 0) return 0;
+    return Math.max(...array);
+};

--- a/tp-react/src/utils/typingRecordApi.ts
+++ b/tp-react/src/utils/typingRecordApi.ts
@@ -1,0 +1,27 @@
+import apiClient from './apiClient';
+
+export type TypoType = 'INITIAL' | 'MEDIAL' | 'FINAL' | 'LETTER';
+
+export interface TypoEntry {
+    expected: string;
+    actual: string;
+    position: number;
+    type: TypoType;
+}
+
+interface TypingRecordRequest {
+    quoteId: number;
+    cpm: number;
+    accuracy: number;
+    charLength: number;
+    resetCount: number;
+    typos: TypoEntry[];
+}
+
+/**
+ * 타이핑 기록 저장
+ * 비로그인 사용자도 호출 가능 (로그인 시 개인 통계 반영)
+ */
+export const saveTypingRecord = async (request: TypingRecordRequest) => {
+    return apiClient.post('/typing-records', request);
+};

--- a/tp-react/src/utils/typoUtils.ts
+++ b/tp-react/src/utils/typoUtils.ts
@@ -1,0 +1,98 @@
+import {TypoEntry, TypoType} from './typingRecordApi';
+
+const KOREAN_START = 44032;
+const KOREAN_END = 55203;
+
+const isKoreanChar = (character: string): boolean => {
+    const code = character.charCodeAt(0);
+    return code >= KOREAN_START && code <= KOREAN_END;
+};
+
+/**
+ * 한글 자모 분리 결과에서 자모 인덱스로 TypoType을 결정한다.
+ * - 초성: index 0
+ * - 중성: index 1 ~ (종성 시작 전)
+ * - 종성: 나머지
+ *
+ * 초성은 항상 1개, 중성은 1~2개 (복합 모음), 종성은 0~2개 (복합 종성)
+ * separatedSentence 배열에서 초성 1개 + 중성 개수를 알면 종성 시작 위치를 알 수 있다.
+ */
+const getTypoTypeByJamoIndex = (index: number, medialLength: number): TypoType => {
+    if (index === 0) return 'INITIAL';
+    if (index < 1 + medialLength) return 'MEDIAL';
+    return 'FINAL';
+};
+
+/**
+ * 중성 자모 개수를 구한다.
+ * koreanSeparator의 separateMidChar와 동일한 로직으로,
+ * 복합 모음이면 2, 아니면 1을 반환한다.
+ */
+const getMedialLength = (midIndex: number): number => {
+    const compoundMidIndices = [9, 10, 11, 14, 15, 16, 19];
+    return compoundMidIndices.includes(midIndex) ? 2 : 1;
+};
+
+const getMidIndex = (charCode: number): number => {
+    const relativeCode = charCode - KOREAN_START;
+    const firstIndex = Math.floor(relativeCode / 588);
+    return Math.floor((relativeCode - firstIndex * 588) / 28);
+};
+
+/**
+ * 두 자모 분리 배열을 비교하여 첫 번째 불일치 자모의 TypoType을 반환한다.
+ */
+export const determineTypoType = (
+    originalChar: string,
+    separatedSentence: string[],
+    separatedInput: string[],
+): TypoType => {
+    if (!isKoreanChar(originalChar)) {
+        return 'LETTER';
+    }
+
+    const midIndex = getMidIndex(originalChar.charCodeAt(0));
+    const medialLength = getMedialLength(midIndex);
+
+    // 자모 비교하여 첫 번째 불일치 위치 찾기
+    const maxLen = Math.max(separatedSentence.length, separatedInput.length);
+    for (let i = 0; i < maxLen; i++) {
+        const expected = separatedSentence[i] ?? '';
+        const actual = separatedInput[i] ?? '';
+        if (expected !== actual) {
+            return getTypoTypeByJamoIndex(i, medialLength);
+        }
+    }
+
+    // 모든 자모가 일치하는데 호출된 경우 (길이 차이 등) — FINAL로 폴백
+    return 'FINAL';
+};
+
+/**
+ * 오타 엔트리를 생성한다.
+ */
+export const createTypoEntry = (
+    originalChar: string,
+    separatedSentence: string[],
+    separatedInput: string[],
+    position: number,
+): TypoEntry => {
+    const type = determineTypoType(originalChar, separatedSentence, separatedInput);
+
+    // 불일치 자모 찾기
+    let expected = originalChar;
+    let actual = '';
+
+    const maxLen = Math.max(separatedSentence.length, separatedInput.length);
+    for (let i = 0; i < maxLen; i++) {
+        const exp = separatedSentence[i] ?? '';
+        const act = separatedInput[i] ?? '';
+        if (exp !== act) {
+            expected = exp || originalChar;
+            actual = act || '';
+            break;
+        }
+    }
+
+    return {expected, actual, position, type};
+};


### PR DESCRIPTION
## 개요
타이핑 완료 시 기록을 백엔드에 저장하는 API 연동

## 변경 사항

### 신규 파일
- `utils/typingRecordApi.ts` — API 호출 함수 + 타입 정의
- `utils/typoUtils.ts` — 한글 자모 분석 기반 오타 type(INITIAL/MEDIAL/FINAL/LETTER) 결정
- `Input/InputUtils.js` — Input 컴포넌트에서 사용하는 유틸 함수 분리

### API 연동
- 타이핑 완료 시 fire-and-forget 방식으로 `POST /typing-records` 호출
- 비로그인/로그인 모두 호출, 오프라인 fallback 문장은 스킵
- API 실패 시 silent fail (사용자 UX 블로킹 없음)

### resetCount 추적
- ESC: 입력 내용이 있을 때만 증가
- 백스페이스 전체 삭제: 문장의 30% 이상 입력한 경우에만 증가
- IME 조합 취소와 ESC 동시 발생 시 중복 증가 방지 (50ms debounce)

### typo 수집
- 오답 확정 시마다 typosRef에 누적 (reset/백스페이스 시에도 유지)
- submitInput 시 전체 typos 전송 후 초기화

### 채점 로직 수정
- 입력 자모가 예문보다 많은 경우(받침→다음 글자 초성) 다음 글자의 시작과 일치하는지 검증
- 추가 자모 불일치 시 다음 글자 기준으로 typo 기록