### PR TITLE
feat: 문장 중복/유사도 에러 핸들링 및 업로드 API 스펙 대응

### DIFF
--- a/tp-react/src/index.css
+++ b/tp-react/src/index.css
@@ -200,6 +200,7 @@ code {
     margin: 0 0 1.5rem 0;
     line-height: 1.6;
     word-break: keep-all;
+    white-space: pre-line;
 }
 
 .error-popup-btn {

--- a/tp-react/src/pages/MyQuotes/MyQuotes.jsx
+++ b/tp-react/src/pages/MyQuotes/MyQuotes.jsx
@@ -3,7 +3,7 @@ import {useNavigate} from 'react-router-dom';
 import {FaFileCircleQuestion} from 'react-icons/fa6';
 import {useAuth} from '../../Context/AuthContext';
 import {useError} from '../../Context/ErrorContext';
-import {cancelPublishQuote, deleteQuote, getMyQuotes, publishQuote, updateQuote} from '@/utils/quoteApi.ts';
+import {cancelPublishQuote, deleteQuote, getMyQuotes, publishQuote, updateQuote, extractQuoteErrorMessage} from '@/utils/quoteApi.ts';
 import QuoteCard from './components/QuoteCard';
 import QuoteFilters from './components/QuoteFilters';
 import QuoteEditPopup from './components/QuoteEditPopup';
@@ -131,8 +131,7 @@ function MyQuotes() {
             setEditingQuote(null);
         } catch (error) {
             console.error('문장 수정 실패:', error);
-            const message = error.response?.data?.detail || '문장 수정에 실패했습니다.';
-            showError(message);
+            showError(extractQuoteErrorMessage(error, '내 문장 내에 유사한 문장이 존재합니다.', '문장 수정에 실패했습니다.'));
         }
     };
 
@@ -169,8 +168,7 @@ function MyQuotes() {
             ));
         } catch (error) {
             console.error('공개 전환 실패:', error);
-            const message = error.response?.data?.detail || '공개 전환에 실패했습니다.';
-            showError(message);
+            showError(extractQuoteErrorMessage(error, '공개 문장 내에 유사한 문장이 존재합니다.', '공개 전환에 실패했습니다.'));
         }
     };
 

--- a/tp-react/src/pages/QuoteUpload/QuoteUpload.jsx
+++ b/tp-react/src/pages/QuoteUpload/QuoteUpload.jsx
@@ -1,7 +1,7 @@
 import {useEffect, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 import {FaCircleInfo, FaPlus, FaUpload} from 'react-icons/fa6';
-import {uploadQuote} from '@/utils/quoteApi.ts';
+import {uploadQuote, extractQuoteErrorMessage} from '@/utils/quoteApi.ts';
 import {useAuth} from '../../Context/AuthContext';
 import {useError} from '../../Context/ErrorContext';
 import {MAX_AUTHOR_LENGTH, MAX_SENTENCE_LENGTH, MIN_SENTENCE_LENGTH} from '@/const/config.const.js';
@@ -138,7 +138,10 @@ function QuoteUpload() {
                 successCount++;
                 successIds.push(entry.id);
             } catch (error) {
-                const errorMessage = error.response?.data?.message || '업로드에 실패했습니다.';
+                const similarMessage = entry.type === 'public'
+                    ? '공개 문장 내에 유사한 문장이 존재합니다.'
+                    : '내 문장 내에 유사한 문장이 존재합니다.';
+                const errorMessage = extractQuoteErrorMessage(error, similarMessage, '업로드에 실패했습니다.');
                 setEntries(prev => prev.map(e =>
                     e.id === entry.id ? {...e, error: errorMessage} : e
                 ));

--- a/tp-react/src/pages/QuoteUpload/components/UploadEntry.css
+++ b/tp-react/src/pages/QuoteUpload/components/UploadEntry.css
@@ -140,4 +140,5 @@
 .quote-upload-entry-error {
     font-size: 0.85rem;
     color: var(--color-error);
+    white-space: pre-line;
 }

--- a/tp-react/src/utils/quoteApi.ts
+++ b/tp-react/src/utils/quoteApi.ts
@@ -52,7 +52,7 @@ export const getQuotes = async (params: GetQuotesParams = {}) => {
  * 공개 문장 업로드
  */
 const uploadPublicQuote = async (sentence: string, author?: string) => {
-    const body: { sentence: string; author?: string } = {sentence};
+    const body: { sentence: string; author?: string; language: string } = {sentence, language: 'KOREAN'};
     if (author) {
         body.author = author;
     }
@@ -63,7 +63,7 @@ const uploadPublicQuote = async (sentence: string, author?: string) => {
  * 비공개 문장 업로드
  */
 const uploadPrivateQuote = async (sentence: string, author?: string) => {
-    const body: { sentence: string; author?: string } = {sentence};
+    const body: { sentence: string; author?: string; language: string } = {sentence, language: 'KOREAN'};
     if (author) {
         body.author = author;
     }
@@ -120,4 +120,21 @@ export const publishQuote = async (quoteId: number) => {
  */
 export const cancelPublishQuote = async (quoteId: number) => {
     return apiClient.post<ApiResponse<Quote>>(`/quotes/${quoteId}/cancel-publish`);
+};
+
+/**
+ * 문장 관련 API 에러에서 사용자에게 보여줄 메시지를 추출한다.
+ * 유사 문장 에러(409)인 경우 similarMessage를 반환한다.
+ */
+export const extractQuoteErrorMessage = (error: any, similarMessage: string, fallbackMessage: string): string => {
+    const data = error.response?.data;
+    if (!data?.detail) return fallbackMessage;
+
+    // 유사 문장 에러: 호출측에서 제공한 context 메시지 사용
+    if (data.similarSentence !== undefined) {
+        return similarMessage;
+    }
+
+    // 동일 문장 등 기타 에러: 서버 메시지 사용
+    return data.detail;
 };


### PR DESCRIPTION
- extractQuoteErrorMessage 유틸 함수 추가 (유사/동일 문장 에러 메시지 분기)
- 공개/비공개에 따른 유사 문장 에러 메시지 구분
- 문장 업로드 요청에 language 필드 추가 (현재 KOREAN 고정)
- 업로드 에러 필드 수정 (data.message → data.detail)
- 에러 메시지 줄바꿈 지원 (white-space: pre-line)