### PR TITLE
fix: 결과 주기 선택 시 음수 인덱스 저장되는 버그 수정

### DIFF
--- a/tp-react/src/components/Info/ResultPeriod/ResultPeriod.jsx
+++ b/tp-react/src/components/Info/ResultPeriod/ResultPeriod.jsx
@@ -13,26 +13,17 @@ const ResultPeriod = () => {
   const { resultPeriod, setResultPeriod } = useContext(SettingContext);
 
   const handleResultPeriod = (event) => {
+    const length = resultPeriodDisplaySet.length;
+    let newPeriod;
+
     if (event.target.id === "result-period-up") {
-      setResultPeriod((prev) => {
-        return (prev + 1) % 4;
-      });
-
-      localStorage.setItem(
-        Storage_Result_Period,
-        ((resultPeriod + 1) % 4).toString(),
-      );
+      newPeriod = (resultPeriod + 1) % length;
     } else {
-      setResultPeriod((prev) => {
-        if (prev === 0) return prev + 3;
-        return prev - 1;
-      });
-
-      localStorage.setItem(
-        Storage_Result_Period,
-        ((resultPeriod - 1) % 4).toString(),
-      );
+      newPeriod = (resultPeriod - 1 + length) % length;
     }
+
+    setResultPeriod(newPeriod);
+    localStorage.setItem(Storage_Result_Period, newPeriod.toString());
   };
 
   return (


### PR DESCRIPTION
- down 버튼 클릭 시 localStorage에 음수 인덱스(-1) 저장되던 문제 수정
- state와 localStorage 값 계산을 통일하여 불일치 방지
- 매직넘버 4를 resultPeriodDisplaySet.length로 변경