### PR TITLE
fix: 결과 주기 선택 시 음수 인덱스 저장 및 이벤트 타겟 버그 수정

### DIFF
--- a/tp-react/src/pages/Home/components/Info/ResultPeriod/ResultPeriod.jsx
+++ b/tp-react/src/pages/Home/components/Info/ResultPeriod/ResultPeriod.jsx
@@ -10,26 +10,17 @@ const ResultPeriod = () => {
     const {resultPeriod, setResultPeriod} = useSetting();
 
     const handleResultPeriod = (event) => {
-        if (event.target.id === "result-period-up") {
-            setResultPeriod((prev) => {
-                return (prev + 1) % 4;
-            });
+        const length = resultPeriodDisplaySet.length;
+        let newPeriod;
 
-            localStorage.setItem(
-                Storage_Result_Period,
-                ((resultPeriod + 1) % 4).toString(),
-            );
+        if (event.currentTarget.id === "result-period-up") {
+            newPeriod = (resultPeriod + 1) % length;
         } else {
-            setResultPeriod((prev) => {
-                if (prev === 0) return prev + 3;
-                return prev - 1;
-            });
-
-            localStorage.setItem(
-                Storage_Result_Period,
-                ((resultPeriod - 1) % 4).toString(),
-            );
+            newPeriod = (resultPeriod - 1 + length) % length;
         }
+
+        setResultPeriod(newPeriod);
+        localStorage.setItem(Storage_Result_Period, newPeriod.toString());
     };
 
     return (
@@ -41,7 +32,6 @@ const ResultPeriod = () => {
                 className={isDark ? "result-period-button dark" : "result-period-button"}
             >
                 <FaChevronDown
-                    id={"result-period-down"}
                     className={isDark ? "result-period-dark" : ""}
                 />
             </button>
@@ -62,7 +52,6 @@ const ResultPeriod = () => {
                 className={isDark ? "result-period-button dark" : "result-period-button"}
             >
                 <FaChevronUp
-                    id={"result-period-up"}
                     className={isDark ? "result-period-dark" : ""}
                 />
             </button>


### PR DESCRIPTION
- down 버튼 클릭 시 localStorage에 음수 인덱스(-1) 저장되던 문제 수정
- state와 localStorage 값 계산 통일
- event.target → event.currentTarget으로 변경 (아이콘 클릭 시 버튼 id 미참조 문제)
- 아이콘의 중복 id 속성 제거
- 매직넘버 4를 resultPeriodDisplaySet.length로 변경