### PR TITLE
타이핑 기록 페이지 프로토타입 + React 구현

### DIFF
--- a/tp-react/prototype.css
+++ b/tp-react/prototype.css
@@ -3041,3 +3041,685 @@ body.dark .my-reports-spinner {
 body.dark .my-reports-empty {
     color: #71717a;
 }
+
+/* ===========================================
+   Stats Page
+   =========================================== */
+.stats-page {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: #fafafa;
+    z-index: 200;
+    overflow-y: auto;
+    padding: 2rem 0;
+}
+
+body.dark .stats-page {
+    background-color: #0f0f0f;
+}
+
+.stats-container {
+    width: 80%;
+    max-width: 1000px;
+    min-width: 600px;
+    margin: 0 auto;
+}
+
+.stats-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.75rem;
+}
+
+.stats-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: #6d28d9;
+}
+
+.stats-refresh-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    padding: 0.5rem 1rem;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    background: #fff;
+    color: #666;
+    font-size: 0.8125rem;
+    cursor: pointer;
+    transition: background-color 0.15s;
+}
+
+.stats-refresh-btn:hover {
+    background-color: #f4f4f5;
+}
+
+body.dark .stats-refresh-btn {
+    border-color: #3f3f46;
+    background: #18181b;
+    color: #a1a1aa;
+}
+
+body.dark .stats-refresh-btn:hover {
+    background-color: #27272a;
+}
+
+/* Summary Layout */
+.stats-summary {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+    margin-bottom: 1.75rem;
+}
+
+.stats-main-card {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+body.dark .stats-main-card {
+    background: #18181b;
+    border-color: #3f3f46;
+}
+
+.stats-main-label {
+    font-size: 0.75rem;
+    color: #666;
+    font-weight: 500;
+    margin-bottom: 0.25rem;
+}
+
+body.dark .stats-main-label {
+    color: #a1a1aa;
+}
+
+.stats-main-value {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+}
+
+.stats-main-value > span:first-child {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: #333;
+    letter-spacing: -1px;
+}
+
+body.dark .stats-main-value > span:first-child {
+    color: #e5e7eb;
+}
+
+.stats-main-unit {
+    font-size: 0.875rem;
+    color: #666;
+}
+
+body.dark .stats-main-unit {
+    color: #a1a1aa;
+}
+
+.stats-trend {
+    font-size: 0.875rem;
+    font-weight: 600;
+}
+
+.stats-trend.up {
+    color: #16a34a;
+}
+
+.stats-trend.down {
+    color: #dc2626;
+}
+
+.stats-trend.neutral {
+    color: #666;
+}
+
+body.dark .stats-trend.up {
+    color: #22c55e;
+}
+
+body.dark .stats-trend.down {
+    color: #f87171;
+}
+
+body.dark .stats-trend.neutral {
+    color: #a1a1aa;
+}
+
+.stats-main-sub {
+    margin-top: 0.375rem;
+    font-size: 0.8125rem;
+    color: #666;
+}
+
+body.dark .stats-main-sub {
+    color: #a1a1aa;
+}
+
+.stats-sub-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+}
+
+.stats-sub-card {
+    background: #f4f4f5;
+    border-radius: 0.5rem;
+    padding: 0.75rem;
+}
+
+body.dark .stats-sub-card {
+    background: #27272a;
+}
+
+.stats-sub-label {
+    font-size: 0.6875rem;
+    color: #999;
+}
+
+body.dark .stats-sub-label {
+    color: #71717a;
+}
+
+.stats-sub-value {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: #333;
+    margin-top: 0.125rem;
+}
+
+body.dark .stats-sub-value {
+    color: #e5e7eb;
+}
+
+.stats-sub-unit {
+    font-size: 0.6875rem;
+    color: #999;
+    margin-left: 0.125rem;
+}
+
+body.dark .stats-sub-unit {
+    color: #71717a;
+}
+
+/* Section */
+.stats-section {
+    position: relative;
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    margin-bottom: 1.25rem;
+}
+
+body.dark .stats-section {
+    background: #18181b;
+    border-color: #3f3f46;
+}
+
+.stats-section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.25rem;
+}
+
+.stats-section-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #333;
+}
+
+body.dark .stats-section-title {
+    color: #e5e7eb;
+}
+
+/* Tabs */
+.stats-tabs {
+    display: flex;
+    gap: 0.375rem;
+    align-items: center;
+}
+
+.stats-tab {
+    padding: 0.375rem 0.875rem;
+    border-radius: 0.375rem;
+    border: 1px solid #e5e7eb;
+    background: transparent;
+    color: #666;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.stats-tab.active {
+    border-color: #6d28d9;
+    background: #f5f3ff;
+    color: #6d28d9;
+}
+
+body.dark .stats-tab {
+    border-color: #3f3f46;
+    color: #a1a1aa;
+}
+
+body.dark .stats-tab.active {
+    border-color: #8b5cf6;
+    background: rgba(139, 92, 246, 0.15);
+    color: #8b5cf6;
+}
+
+.stats-tab-divider {
+    width: 1px;
+    height: 1rem;
+    background: #e5e7eb;
+    margin: 0 0.25rem;
+}
+
+body.dark .stats-tab-divider {
+    background: #3f3f46;
+}
+
+/* Chart */
+.stats-chart {
+    height: 11.25rem;
+    padding: 0;
+}
+
+.stats-chart svg {
+    display: block;
+}
+
+.stats-chart-grid {
+    stroke: #e5e7eb;
+    stroke-width: 0.5;
+}
+
+body.dark .stats-chart-grid {
+    stroke: #3f3f46;
+}
+
+.stats-chart-grid-label {
+    font-size: 0.6875rem;
+    fill: #999;
+    text-anchor: end;
+}
+
+body.dark .stats-chart-grid-label {
+    fill: #71717a;
+}
+
+.stats-chart-area {
+    fill: #6d28d9;
+    opacity: 0.08;
+}
+
+body.dark .stats-chart-area {
+    fill: #8b5cf6;
+    opacity: 0.12;
+}
+
+.stats-chart-line {
+    fill: none;
+    stroke: #6d28d9;
+    stroke-width: 2;
+    stroke-linejoin: round;
+    stroke-linecap: round;
+}
+
+body.dark .stats-chart-line {
+    stroke: #8b5cf6;
+}
+
+.stats-chart-dot {
+    fill: #6d28d9;
+    stroke: #fff;
+    stroke-width: 2;
+    transition: r 0.15s;
+}
+
+body.dark .stats-chart-dot {
+    fill: #8b5cf6;
+    stroke: #18181b;
+}
+
+.stats-chart-point-label {
+    font-size: 0.875rem;
+    fill: #333;
+    font-weight: 600;
+    text-anchor: middle;
+}
+
+body.dark .stats-chart-point-label {
+    fill: #e5e7eb;
+}
+
+.stats-chart-tooltip-group {
+    transition: opacity 0.15s;
+    pointer-events: none;
+}
+
+.stats-chart-tooltip-bg {
+    fill: #fff;
+    stroke: #e5e7eb;
+    stroke-width: 0.5;
+}
+
+body.dark .stats-chart-tooltip-bg {
+    fill: #27272a;
+    stroke: #3f3f46;
+}
+
+.stats-chart-date-label {
+    font-size: 0.6875rem;
+    fill: #999;
+}
+
+body.dark .stats-chart-date-label {
+    fill: #71717a;
+}
+
+.stats-chart-empty {
+    text-align: center;
+    padding: 2rem;
+    color: #999;
+    font-size: 0.875rem;
+}
+
+/* Typo Area */
+.stats-typo-area {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+}
+
+.stats-typo-area:has(#statsTypoDetailSection:not(.display-none)) {
+    grid-template-columns: 1fr 1fr;
+}
+
+/* Typo list item */
+.stats-typo-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.625rem 0.875rem;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: all 0.15s;
+}
+
+.stats-typo-item:hover {
+    background: #f5f3ff;
+}
+
+.stats-typo-item.selected {
+    background: #f5f3ff;
+    border-color: #6d28d9;
+}
+
+body.dark .stats-typo-item:hover {
+    background: rgba(139, 92, 246, 0.1);
+}
+
+body.dark .stats-typo-item.selected {
+    background: rgba(139, 92, 246, 0.15);
+    border-color: #8b5cf6;
+}
+
+.stats-typo-char {
+    width: 2rem;
+    height: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #f5f3ff;
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    font-weight: 700;
+    color: #6d28d9;
+    flex-shrink: 0;
+}
+
+body.dark .stats-typo-char {
+    background: rgba(139, 92, 246, 0.15);
+    color: #8b5cf6;
+}
+
+.stats-typo-bar-container {
+    flex: 1;
+    height: 0.375rem;
+    background: #e5e7eb;
+    border-radius: 0.1875rem;
+    overflow: hidden;
+}
+
+body.dark .stats-typo-bar-container {
+    background: #3f3f46;
+}
+
+.stats-typo-bar-fill {
+    height: 100%;
+    background: #6d28d9;
+    border-radius: 0.1875rem;
+    opacity: 0.7;
+}
+
+body.dark .stats-typo-bar-fill {
+    background: #8b5cf6;
+}
+
+.stats-typo-count {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #333;
+    min-width: 2rem;
+    text-align: right;
+}
+
+body.dark .stats-typo-count {
+    color: #e5e7eb;
+}
+
+.stats-typo-empty {
+    text-align: center;
+    padding: 2rem;
+    color: #999;
+    font-size: 0.875rem;
+}
+
+/* Typo detail */
+.stats-typo-detail-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.625rem 0.875rem;
+    background: #f4f4f5;
+    border-radius: 0.5rem;
+    margin-bottom: 0.5rem;
+}
+
+body.dark .stats-typo-detail-item {
+    background: #1a1a1d;
+}
+
+.stats-typo-detail-expected {
+    padding: 0.25rem 0.625rem;
+    background: #f5f3ff;
+    border-radius: 0.375rem;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: #6d28d9;
+}
+
+body.dark .stats-typo-detail-expected {
+    background: rgba(139, 92, 246, 0.15);
+    color: #8b5cf6;
+}
+
+.stats-typo-detail-arrow {
+    font-size: 0.875rem;
+    color: #999;
+}
+
+.stats-typo-detail-actual {
+    padding: 0.25rem 0.625rem;
+    background: #fee2e2;
+    border-radius: 0.375rem;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: #dc2626;
+}
+
+body.dark .stats-typo-detail-actual {
+    background: rgba(248, 113, 113, 0.12);
+    color: #f87171;
+}
+
+.stats-typo-detail-count {
+    margin-left: auto;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #333;
+}
+
+body.dark .stats-typo-detail-count {
+    color: #e5e7eb;
+}
+
+/* Footer */
+.stats-footer {
+    margin-top: 1.75rem;
+    display: flex;
+    justify-content: center;
+}
+
+/* Daily Detail Popup */
+.stats-daily-popup-overlay {
+    position: absolute;
+    z-index: 10;
+    pointer-events: none;
+    display: none;
+}
+
+.stats-daily-popup-overlay.visible {
+    display: block;
+}
+
+.stats-daily-popup {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.5rem;
+    padding: 0.875rem;
+    width: 280px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+    pointer-events: none;
+}
+
+body.dark .stats-daily-popup {
+    background: #18181b;
+    border-color: #3f3f46;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
+}
+
+.stats-daily-popup-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.625rem;
+}
+
+.stats-daily-popup-title {
+    margin: 0;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: #6d28d9;
+}
+
+body.dark .stats-daily-popup-title {
+    color: #8b5cf6;
+}
+
+.stats-daily-popup-close {
+    display: none;
+}
+
+.stats-daily-popup-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+}
+
+.stats-daily-popup-item {
+    background: #f4f4f5;
+    border-radius: 0.375rem;
+    padding: 0.5rem 0.625rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+}
+
+body.dark .stats-daily-popup-item {
+    background: #27272a;
+}
+
+.stats-daily-popup-label {
+    font-size: 0.625rem;
+    color: #999;
+}
+
+body.dark .stats-daily-popup-label {
+    color: #71717a;
+}
+
+.stats-daily-popup-value {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: #333;
+}
+
+body.dark .stats-daily-popup-value {
+    color: #e5e7eb;
+}
+
+.stats-back-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1.5rem;
+    border-radius: 0.5rem;
+    border: 1px solid #e5e7eb;
+    background: #fff;
+    color: #666;
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: background-color 0.15s;
+}
+
+.stats-back-btn:hover {
+    background-color: #f4f4f5;
+}
+
+body.dark .stats-back-btn {
+    border-color: #3f3f46;
+    background: #18181b;
+    color: #a1a1aa;
+}
+
+body.dark .stats-back-btn:hover {
+    background-color: #27272a;
+}

--- a/tp-react/prototype1.js
+++ b/tp-react/prototype1.js
@@ -349,7 +349,7 @@ document.getElementById('loginBtn').addEventListener('click', () => {
             // 기존 회원은 바로 로그인 처리
             handleLoginSuccess({nickname: "홍남김"});
         }
-    }, 1500);
+    }, 300);
 });
 
 // 닉네임 제출

--- a/tp-react/prototype2.js
+++ b/tp-react/prototype2.js
@@ -301,7 +301,7 @@ document.getElementById('mysentencesBtn').addEventListener('click', () => {
 });
 
 document.getElementById('statsBtn').addEventListener('click', () => {
-    alert('통계 기능 (준비 중)');
+    // 통계 기능은 prototype4-stats.js에서 처리
     document.getElementById('dropdownMenu').classList.add('display-none');
 });
 

--- a/tp-react/prototype4-stats.js
+++ b/tp-react/prototype4-stats.js
@@ -1,0 +1,336 @@
+/* eslint-disable no-undef */
+// ===========================================
+// 통계 페이지
+// ===========================================
+
+// Mock Data
+var mockTypingStats = {
+    totalAttempts: 247,
+    avgCpm: 342.5,
+    avgAcc: 0.94,
+    bestCpm: 512,
+    totalPracticeTimeMin: 186.3,
+    totalResetCount: 41
+};
+var mockDailyStats = [
+    {date: '2026-02-23', attempts: 10, avgCpm: 290, avgAcc: 0.88, bestCpm: 380, resetCount: 6, practiceTimeMin: 14.5},
+    {date: '2026-02-24', attempts: 14, avgCpm: 305, avgAcc: 0.90, bestCpm: 400, resetCount: 5, practiceTimeMin: 19.2},
+    {date: '2026-02-25', attempts: 6, avgCpm: 280, avgAcc: 0.87, bestCpm: 370, resetCount: 3, practiceTimeMin: 8.8},
+    {date: '2026-02-27', attempts: 16, avgCpm: 310, avgAcc: 0.91, bestCpm: 420, resetCount: 7, practiceTimeMin: 22.1},
+    {date: '2026-02-28', attempts: 9, avgCpm: 295, avgAcc: 0.89, bestCpm: 385, resetCount: 4, practiceTimeMin: 13.0},
+    {date: '2026-03-01', attempts: 20, avgCpm: 315, avgAcc: 0.92, bestCpm: 430, resetCount: 8, practiceTimeMin: 27.5},
+    {date: '2026-03-02', attempts: 11, avgCpm: 300, avgAcc: 0.90, bestCpm: 410, resetCount: 5, practiceTimeMin: 15.8},
+    {date: '2026-03-03', attempts: 7, avgCpm: 288, avgAcc: 0.88, bestCpm: 375, resetCount: 3, practiceTimeMin: 10.2},
+    {date: '2026-03-05', attempts: 18, avgCpm: 320, avgAcc: 0.93, bestCpm: 440, resetCount: 6, practiceTimeMin: 24.3},
+    {date: '2026-03-06', attempts: 13, avgCpm: 325, avgAcc: 0.92, bestCpm: 435, resetCount: 5, practiceTimeMin: 18.0},
+    {date: '2026-03-07', attempts: 8, avgCpm: 308, avgAcc: 0.91, bestCpm: 415, resetCount: 4, practiceTimeMin: 11.5},
+    {date: '2026-03-09', attempts: 22, avgCpm: 330, avgAcc: 0.93, bestCpm: 450, resetCount: 9, practiceTimeMin: 30.2},
+    {date: '2026-03-10', attempts: 15, avgCpm: 335, avgAcc: 0.94, bestCpm: 455, resetCount: 6, practiceTimeMin: 21.0},
+    {date: '2026-03-11', attempts: 5, avgCpm: 310, avgAcc: 0.90, bestCpm: 410, resetCount: 2, practiceTimeMin: 7.3},
+    {date: '2026-03-12', attempts: 19, avgCpm: 340, avgAcc: 0.94, bestCpm: 465, resetCount: 7, practiceTimeMin: 26.5},
+    {date: '2026-03-13', attempts: 12, avgCpm: 328, avgAcc: 0.93, bestCpm: 445, resetCount: 5, practiceTimeMin: 17.2},
+    {date: '2026-03-15', attempts: 17, avgCpm: 345, avgAcc: 0.95, bestCpm: 470, resetCount: 6, practiceTimeMin: 23.8},
+    {date: '2026-03-16', attempts: 10, avgCpm: 332, avgAcc: 0.93, bestCpm: 448, resetCount: 4, practiceTimeMin: 14.0},
+    {date: '2026-03-18', attempts: 12, avgCpm: 310, avgAcc: 0.91, bestCpm: 420, resetCount: 5, practiceTimeMin: 18.2},
+    {date: '2026-03-19', attempts: 18, avgCpm: 325, avgAcc: 0.93, bestCpm: 445, resetCount: 7, practiceTimeMin: 25.5},
+    {date: '2026-03-20', attempts: 8, avgCpm: 298, avgAcc: 0.89, bestCpm: 390, resetCount: 4, practiceTimeMin: 12.3},
+    {date: '2026-03-21', attempts: 22, avgCpm: 340, avgAcc: 0.95, bestCpm: 478, resetCount: 8, practiceTimeMin: 30.1},
+    {date: '2026-03-22', attempts: 15, avgCpm: 355, avgAcc: 0.94, bestCpm: 490, resetCount: 6, practiceTimeMin: 22.7},
+    {date: '2026-03-23', attempts: 20, avgCpm: 360, avgAcc: 0.96, bestCpm: 512, resetCount: 3, practiceTimeMin: 28.4},
+    {date: '2026-03-24', attempts: 5, avgCpm: 348, avgAcc: 0.93, bestCpm: 465, resetCount: 2, practiceTimeMin: 8.6}
+];
+var mockTypoStats = [
+    {expected: 'ㅔ', count: 34}, {expected: 'ㅐ', count: 28}, {expected: 'ㄱ', count: 19},
+    {expected: 'ㅂ', count: 15}, {expected: 'ㅈ', count: 12}, {expected: 'ㅌ', count: 10},
+    {expected: 'ㅎ', count: 8}, {expected: 'ㄷ', count: 7}, {expected: 'ㅍ', count: 5}, {expected: 'ㅊ', count: 3}
+];
+var mockTypoDetail = {
+    'ㅔ': [{expected: 'ㅔ', actual: 'ㅐ', typoCount: 22}, {expected: 'ㅔ', actual: 'ㅓ', typoCount: 8}, {
+        expected: 'ㅔ',
+        actual: 'ㅣ',
+        typoCount: 4
+    }],
+    'ㅐ': [{expected: 'ㅐ', actual: 'ㅔ', typoCount: 18}, {expected: 'ㅐ', actual: 'ㅏ', typoCount: 10}],
+    'ㄱ': [{expected: 'ㄱ', actual: 'ㅋ', typoCount: 12}, {expected: 'ㄱ', actual: 'ㄲ', typoCount: 7}]
+};
+
+var statsChartMetric = 'cpm';
+var statsDailyRange = 7;
+var statsSelectedTypo = null;
+
+function openStatsPage() {
+    document.getElementById('statsPage').classList.remove('display-none');
+    document.body.style.overflow = 'hidden';
+    renderStats();
+}
+
+function closeStatsPage() {
+    document.getElementById('statsPage').classList.add('display-none');
+    document.body.style.overflow = '';
+}
+
+function renderStats() {
+    renderSummary();
+    renderChart();
+    renderTypoList();
+}
+
+function renderSummary() {
+    var s = mockTypingStats;
+    document.getElementById('statsTotalAttempts').textContent = s.totalAttempts;
+    document.getElementById('statsAvgCpm').textContent = Math.round(s.avgCpm);
+    document.getElementById('statsAvgAcc').textContent = Math.round(s.avgAcc * 100);
+    document.getElementById('statsBestCpm').textContent = s.bestCpm;
+    var avgResetPerAttempt = s.totalAttempts > 0 ? (s.totalResetCount / s.totalAttempts) : 0;
+    document.getElementById('statsResetCount').textContent = avgResetPerAttempt.toFixed(2);
+    var h = Math.floor(s.totalPracticeTimeMin / 60);
+    var m = Math.round(s.totalPracticeTimeMin % 60);
+    document.getElementById('statsTotalTime').textContent = h > 0 ? h + '시간 ' + m + '분' : m + '분';
+
+    // 최근 7일 평균 CPM 계산
+    var recentData = mockDailyStats.slice(-7);
+    var recentTotal = 0;
+    var recentCount = 0;
+    for (var i = 0; i < recentData.length; i++) {
+        recentTotal += recentData[i].avgCpm * recentData[i].attempts;
+        recentCount += recentData[i].attempts;
+    }
+    var recentAvg = recentCount > 0 ? Math.round(recentTotal / recentCount) : 0;
+    document.getElementById('statsRecentCpm').textContent = recentAvg;
+
+    // 추세 계산 (전체 평균 대비)
+    var trendEl = document.getElementById('statsTrend');
+    if (s.avgCpm > 0 && recentAvg > 0) {
+        var changePercent = ((recentAvg - s.avgCpm) / s.avgCpm * 100).toFixed(1);
+        if (changePercent > 0) {
+            trendEl.textContent = '\u25B2 ' + changePercent + '%';
+            trendEl.className = 'stats-trend up';
+        } else if (changePercent < 0) {
+            trendEl.textContent = '\u25BC ' + Math.abs(changePercent) + '%';
+            trendEl.className = 'stats-trend down';
+        } else {
+            trendEl.textContent = '\u2014 0%';
+            trendEl.className = 'stats-trend neutral';
+        }
+    } else {
+        trendEl.textContent = '';
+        trendEl.className = 'stats-trend';
+    }
+}
+
+function renderChart() {
+    var chartEl = document.getElementById('statsChart');
+    var emptyEl = document.getElementById('statsChartEmpty');
+    var data = mockDailyStats.slice(-statsDailyRange);
+    if (data.length === 0) {
+        chartEl.classList.add('display-none');
+        emptyEl.classList.remove('display-none');
+        return;
+    }
+    chartEl.classList.remove('display-none');
+    emptyEl.classList.add('display-none');
+    var values = data.map(function (d) {
+        return statsChartMetric === 'cpm' ? d.avgCpm : Math.round(d.avgAcc * 100);
+    });
+    var maxVal = Math.max.apply(null, values);
+    var minVal = Math.min.apply(null, values);
+    var padding = (maxVal - minVal) * 0.1 || 5;
+    var yMax = maxVal + padding;
+    var yMin = minVal - padding;
+    var yRange = yMax - yMin || 1;
+
+    var svgW = chartEl.clientWidth || 600;
+    var svgH = 180;
+    var padLeft = 48;
+    var padRight = 16;
+    var padTop = 24;
+    var padBottom = 28;
+    var chartW = svgW - padLeft - padRight;
+    var chartH = svgH - padTop - padBottom;
+
+    var points = data.map(function (d, i) {
+        var x = data.length > 1 ? padLeft + (i / (data.length - 1)) * chartW : padLeft + chartW / 2;
+        var y = padTop + chartH - ((values[i] - yMin) / yRange) * chartH;
+        return {x: x, y: y};
+    });
+
+    var linePoints = points.map(function (p) { return p.x + ',' + p.y; }).join(' ');
+    var areaPoints = padLeft + ',' + (padTop + chartH) + ' ' + linePoints + ' ' + points[points.length - 1].x + ',' + (padTop + chartH);
+
+    var gridLines = '';
+    var gridCount = 4;
+    for (var g = 0; g <= gridCount; g++) {
+        var gy = padTop + (g / gridCount) * chartH;
+        var gVal = Math.round(yMax - (g / gridCount) * yRange);
+        var displayGVal = statsChartMetric === 'cpm' ? gVal : gVal + '%';
+        gridLines += '<line x1="' + padLeft + '" y1="' + gy + '" x2="' + (svgW - padRight) + '" y2="' + gy + '" class="stats-chart-grid"/>';
+        gridLines += '<text x="' + (padLeft - 8) + '" y="' + (gy + 4) + '" class="stats-chart-grid-label">' + displayGVal + '</text>';
+    }
+
+    var dotsAndLabels = '';
+    for (var i = 0; i < points.length; i++) {
+        var monthNames = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+        var dateParts = data[i].date.split('-');
+        var dateLabel = monthNames[parseInt(dateParts[1]) - 1] + ' ' + parseInt(dateParts[2]);
+
+        // 데이터가 많을 때 날짜 라벨을 간격을 두고 표시
+        var labelInterval = data.length > 14 ? Math.ceil(data.length / 6) : 1;
+        var showDateLabel = (i % labelInterval === 0) || (i === data.length - 1);
+
+        // 첫/마지막 라벨 정렬 조정 (잘림 방지)
+        var textAnchor = 'middle';
+        if (showDateLabel && i === 0) textAnchor = 'start';
+        else if (showDateLabel && i === data.length - 1) textAnchor = 'end';
+
+        var displayVal = statsChartMetric === 'cpm' ? values[i] : values[i] + '%';
+        dotsAndLabels += '<circle cx="' + points[i].x + '" cy="' + points[i].y + '" r="4" class="stats-chart-dot"/>';
+        dotsAndLabels += '<g class="stats-chart-tooltip-group" style="opacity:0">'
+            + '<rect x="' + (points[i].x - 28) + '" y="' + (points[i].y - 32) + '" width="56" height="24" rx="4" class="stats-chart-tooltip-bg"/>'
+            + '<text x="' + points[i].x + '" y="' + (points[i].y - 16) + '" class="stats-chart-point-label">' + displayVal + '</text>'
+            + '</g>';
+        dotsAndLabels += '<circle cx="' + points[i].x + '" cy="' + points[i].y + '" r="16" class="stats-chart-hover-area" data-index="' + i + '" style="fill:transparent;cursor:pointer"/>';
+        if (showDateLabel) {
+            dotsAndLabels += '<text x="' + points[i].x + '" y="' + (padTop + chartH + 16) + '" class="stats-chart-date-label" text-anchor="' + textAnchor + '">' + dateLabel + '</text>';
+        }
+    }
+
+    chartEl.innerHTML = '<svg width="100%" height="' + svgH + '" viewBox="0 0 ' + svgW + ' ' + svgH + '">'
+        + gridLines
+        + '<polygon points="' + areaPoints + '" class="stats-chart-area"/>'
+        + '<polyline points="' + linePoints + '" class="stats-chart-line"/>'
+        + dotsAndLabels
+        + '</svg>';
+
+    // hover + 팝업 이벤트
+    chartEl.querySelectorAll('.stats-chart-hover-area').forEach(function(area) {
+        var idx = area.getAttribute('data-index');
+        var tooltipGroup = chartEl.querySelectorAll('.stats-chart-tooltip-group')[idx];
+        var dot = chartEl.querySelectorAll('.stats-chart-dot')[idx];
+        area.addEventListener('mouseenter', function() {
+            tooltipGroup.style.opacity = '1';
+            dot.setAttribute('r', '6');
+            showDailyPopup(data[idx], points[idx]);
+        });
+        area.addEventListener('mouseleave', function() {
+            tooltipGroup.style.opacity = '0';
+            dot.setAttribute('r', '4');
+            hideDailyPopup();
+        });
+    });
+}
+
+function renderTypoList() {
+    var listEl = document.getElementById('statsTypoList');
+    var emptyEl = document.getElementById('statsTypoEmpty');
+    if (mockTypoStats.length === 0) {
+        listEl.classList.add('display-none');
+        emptyEl.classList.remove('display-none');
+        return;
+    }
+    listEl.classList.remove('display-none');
+    emptyEl.classList.add('display-none');
+    var maxCount = mockTypoStats[0].count;
+    listEl.innerHTML = mockTypoStats.map(function (item) {
+        var widthPercent = (item.count / maxCount) * 100;
+        var selectedClass = statsSelectedTypo === item.expected ? 'selected' : '';
+        return '<div class="stats-typo-item ' + selectedClass + '" data-expected="' + item.expected + '"><span class="stats-typo-char">' + item.expected + '</span><div class="stats-typo-bar-container"><div class="stats-typo-bar-fill" style="width:' + widthPercent + '%;"></div></div><span class="stats-typo-count">' + item.count + '</span></div>';
+    }).join('');
+}
+
+function renderTypoDetail(expected) {
+    var sectionEl = document.getElementById('statsTypoDetailSection');
+    document.getElementById('statsTypoDetailChar').textContent = expected;
+    var details = mockTypoDetail[expected];
+    if (!details || details.length === 0) {
+        sectionEl.classList.add('display-none');
+        return;
+    }
+    sectionEl.classList.remove('display-none');
+    document.getElementById('statsTypoDetailList').innerHTML = details.map(function (d) {
+        return '<div class="stats-typo-detail-item"><span class="stats-typo-detail-expected">' + d.expected + '</span><span class="stats-typo-detail-arrow">\u2192</span><span class="stats-typo-detail-actual">' + d.actual + '</span><span class="stats-typo-detail-count">' + d.typoCount + '\uD68C</span></div>';
+    }).join('');
+}
+
+// Events
+document.getElementById('statsBtn').addEventListener('click', function () {
+    document.getElementById('dropdownMenu').classList.add('display-none');
+    openStatsPage();
+});
+document.getElementById('statsBackBtn').addEventListener('click', closeStatsPage);
+document.getElementById('statsRefreshBtn').addEventListener('click', function () {
+    renderStats();
+});
+
+// 일별 상세 팝업
+function showDailyPopup(dayData, point) {
+    var overlay = document.getElementById('statsDailyPopupOverlay');
+    var parts = dayData.date.split('-');
+    var title = parts[0] + '년 ' + parseInt(parts[1]) + '월 ' + parseInt(parts[2]) + '일';
+    document.getElementById('statsDailyPopupTitle').textContent = title;
+    document.getElementById('dailyPopupAttempts').textContent = dayData.attempts + '회';
+    document.getElementById('dailyPopupAvgCpm').textContent = Math.round(dayData.avgCpm) + ' CPM';
+    document.getElementById('dailyPopupBestCpm').textContent = dayData.bestCpm + ' CPM';
+    document.getElementById('dailyPopupAcc').textContent = Math.round(dayData.avgAcc * 100) + '%';
+
+    var pMin = dayData.practiceTimeMin || 0;
+    var ph = Math.floor(pMin / 60);
+    var pm = Math.round(pMin % 60);
+    document.getElementById('dailyPopupTime').textContent = ph > 0 ? ph + '시간 ' + pm + '분' : pm + '분';
+
+    var avgReset = dayData.attempts > 0 ? (dayData.resetCount || 0) / dayData.attempts : 0;
+    document.getElementById('dailyPopupReset').textContent = avgReset.toFixed(2) + '회';
+
+    // SVG 좌표를 section 기준 픽셀로 변환
+    var chartEl = document.getElementById('statsChart');
+    var svg = chartEl.querySelector('svg');
+    var svgRect = svg.getBoundingClientRect();
+    var sectionRect = overlay.parentElement.getBoundingClientRect();
+    var viewBox = svg.viewBox.baseVal;
+    var scaleX = svgRect.width / viewBox.width;
+    var scaleY = svgRect.height / viewBox.height;
+
+    var pixelX = svgRect.left - sectionRect.left + point.x * scaleX;
+    var pixelY = svgRect.top - sectionRect.top + point.y * scaleY;
+
+    overlay.style.left = pixelX + 'px';
+    overlay.style.top = (pixelY + 16) + 'px';
+    overlay.classList.add('visible');
+}
+
+function hideDailyPopup() {
+    document.getElementById('statsDailyPopupOverlay').classList.remove('visible');
+}
+
+document.querySelectorAll('.stats-tab[data-metric]').forEach(function (tab) {
+    tab.addEventListener('click', function () {
+        document.querySelectorAll('.stats-tab[data-metric]').forEach(function (t) {
+            t.classList.remove('active');
+        });
+        tab.classList.add('active');
+        statsChartMetric = tab.dataset.metric;
+        renderChart();
+    });
+});
+document.querySelectorAll('.stats-tab[data-range]').forEach(function (tab) {
+    tab.addEventListener('click', function () {
+        document.querySelectorAll('.stats-tab[data-range]').forEach(function (t) {
+            t.classList.remove('active');
+        });
+        tab.classList.add('active');
+        statsDailyRange = parseInt(tab.dataset.range);
+        renderChart();
+    });
+});
+document.getElementById('statsTypoList').addEventListener('click', function (e) {
+    var item = e.target.closest('.stats-typo-item');
+    if (!item) return;
+    var expected = item.dataset.expected;
+    if (statsSelectedTypo === expected) {
+        statsSelectedTypo = null;
+        document.getElementById('statsTypoDetailSection').classList.add('display-none');
+    } else {
+        statsSelectedTypo = expected;
+        renderTypoDetail(expected);
+    }
+    renderTypoList();
+});

--- a/tp-react/src/App.jsx
+++ b/tp-react/src/App.jsx
@@ -12,6 +12,7 @@ import Home from "./pages/Home/Home";
 import QuoteUpload from "./pages/QuoteUpload/QuoteUpload";
 import MyQuotes from "./pages/MyQuotes/MyQuotes";
 import MyReports from "./pages/MyReports/MyReports";
+import Stats from "./pages/Stats/Stats";
 import {Analytics} from "@vercel/analytics/react";
 
 function App() {
@@ -28,6 +29,7 @@ function App() {
                   <Route path="/quote/upload" element={<QuoteUpload />} />
                   <Route path="/quote/my" element={<MyQuotes />} />
                   <Route path="/quote/report" element={<MyReports />} />
+                  <Route path="/stats" element={<Stats />} />
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
                 <Contact />

--- a/tp-react/src/components/AppDiv/AppDiv.jsx
+++ b/tp-react/src/components/AppDiv/AppDiv.jsx
@@ -7,7 +7,7 @@ const AppDiv = ({ children }) => {
   const location = useLocation();
   
   // 상단 여백이 필요 없는 페이지
-  const isCompactPage = location.pathname.startsWith('/quote/');
+  const isCompactPage = location.pathname.startsWith('/quote/') || location.pathname === '/stats';
   
   return (
     <div className={`background ${isDark ? "dark" : ""} ${isCompactPage ? "compact" : ""}`}>

--- a/tp-react/src/components/ProfileDropdown/ProfileDropdown.jsx
+++ b/tp-react/src/components/ProfileDropdown/ProfileDropdown.jsx
@@ -52,7 +52,7 @@ const ProfileDropdown = () => {
                 navigate('/quote/report');
                 break;
             case 'stats':
-                showError('통계 기능 (준비 중)');
+                navigate('/stats');
                 break;
             case 'settings':
                 setShowProfilePopup(true);
@@ -98,7 +98,7 @@ const ProfileDropdown = () => {
                             onClick={() => handleMenuClick('stats')}
                         >
                             <FaChartBar/>
-                            <span>통계</span>
+                            <span>기록</span>
                         </button>
                         <button
                             className={`dropdown-item ${isDark ? 'dark' : ''}`}

--- a/tp-react/src/pages/Stats/Stats.css
+++ b/tp-react/src/pages/Stats/Stats.css
@@ -1,0 +1,85 @@
+.stats-container {
+    width: 80%;
+    max-width: 1000px;
+    min-width: 600px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+.stats-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.75rem;
+}
+
+.stats-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--color-primary);
+    margin: 0;
+}
+
+.stats-refresh-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    border: none;
+    border-radius: 0.375rem;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: color 0.15s;
+}
+
+.stats-refresh-btn:hover {
+    color: var(--color-text);
+}
+
+/* Loading */
+.stats-loading {
+    display: flex;
+    justify-content: center;
+    padding: 4rem;
+}
+
+.stats-spinner {
+    width: 2rem;
+    height: 2rem;
+    border: 2px solid var(--color-border);
+    border-top-color: var(--color-primary);
+    border-radius: 50%;
+    animation: stats-spin 0.6s linear infinite;
+}
+
+@keyframes stats-spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+/* Footer */
+.stats-footer {
+    margin-top: 1.75rem;
+    display: flex;
+    justify-content: center;
+}
+
+.stats-back-btn {
+    padding: 0.75rem 2rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    background-color: transparent;
+    color: var(--color-text-muted);
+    font-size: 1rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.stats-back-btn:hover {
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text);
+}

--- a/tp-react/src/pages/Stats/Stats.jsx
+++ b/tp-react/src/pages/Stats/Stats.jsx
@@ -1,0 +1,122 @@
+import {useEffect, useState} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {FaRotateRight} from 'react-icons/fa6';
+import {useAuth} from '../../Context/AuthContext';
+import {useError} from '../../Context/ErrorContext';
+import {getDailyStats, getTypingStats, getTypoStats, refreshStats} from '@/utils/statsApi.ts';
+import StatsSummary from './components/StatsSummary';
+import DailyChart from './components/DailyChart';
+import TypoList from './components/TypoList';
+import './Stats.css';
+
+function Stats() {
+    const navigate = useNavigate();
+    const {user, isInitialized} = useAuth();
+    const {showError} = useError();
+
+    const [typingStats, setTypingStats] = useState(null);
+    const [dailyStats, setDailyStats] = useState([]);
+    const [typoStats, setTypoStats] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [dailyRange, setDailyRange] = useState(7);
+
+    // 비로그인 시 홈으로
+    useEffect(() => {
+        if (isInitialized && !user) {
+            navigate('/');
+        }
+    }, [user, isInitialized, navigate]);
+
+    // 데이터 로드
+    useEffect(() => {
+        if (!user) return;
+        loadAllStats();
+    }, [user]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    // dailyRange 변경 시 일별 통계 재조회
+    useEffect(() => {
+        if (!user) return;
+        loadDailyStats();
+    }, [dailyRange]); // eslint-disable-line react-hooks/exhaustive-deps
+
+    const loadAllStats = async () => {
+        setIsLoading(true);
+        try {
+            const [typingRes, dailyRes, typoRes] = await Promise.all([
+                getTypingStats('KOREAN'),
+                getDailyStats('KOREAN', dailyRange),
+                getTypoStats('KOREAN'),
+            ]);
+            setTypingStats(typingRes.data.data);
+            setDailyStats(dailyRes.data.data.content || []);
+            setTypoStats(typoRes.data.data.content || []);
+        } catch (error) {
+            console.error('통계 로드 실패:', error);
+            showError('기록을 불러오는데 실패했습니다.');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    const loadDailyStats = async () => {
+        try {
+            const res = await getDailyStats('KOREAN', dailyRange);
+            setDailyStats(res.data.data.content || []);
+        } catch (error) {
+            console.error('일별 통계 로드 실패:', error);
+        }
+    };
+
+    const handleRefresh = async () => {
+        try {
+            const res = await refreshStats('KOREAN');
+            setTypingStats(res.data.data);
+            await loadAllStats();
+        } catch (error) {
+            if (error.response?.status === 429) {
+                showError('새로고침은 1분에 한 번만 가능합니다.');
+            } else {
+                showError('새로고침에 실패했습니다.');
+            }
+        }
+    };
+
+    if (!isInitialized) return null;
+    if (!user) return null;
+
+    return (
+        <div className="stats-container">
+            <div className="stats-header">
+                <h1 className="stats-title">내 타이핑 기록</h1>
+                <button className="stats-refresh-btn" onClick={handleRefresh} title="새로고침">
+                    <FaRotateRight/>
+                </button>
+            </div>
+
+            {isLoading ? (
+                <div className="stats-loading">
+                    <div className="stats-spinner"></div>
+                </div>
+            ) : (
+                <>
+                    {/* 종합 통계 */}
+                    <StatsSummary typingStats={typingStats} dailyStats={dailyStats}/>
+
+                    {/* 일별 추이 */}
+                    <DailyChart dailyStats={dailyStats} dailyRange={dailyRange} onRangeChange={setDailyRange}/>
+
+                    {/* 오타 통계 */}
+                    <TypoList typoStats={typoStats}/>
+                </>
+            )}
+
+            <div className="stats-footer">
+                <button className="stats-back-btn" onClick={() => navigate('/')}>
+                    돌아가기
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export default Stats;

--- a/tp-react/src/pages/Stats/components/DailyChart.css
+++ b/tp-react/src/pages/Stats/components/DailyChart.css
@@ -1,0 +1,168 @@
+.daily-chart-section {
+    position: relative;
+    background: var(--color-popup-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    margin-bottom: 1.25rem;
+}
+
+.daily-chart-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1.25rem;
+}
+
+.daily-chart-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.daily-chart-tabs {
+    display: flex;
+    gap: 0.375rem;
+    align-items: center;
+}
+
+.daily-chart-tab {
+    padding: 0.375rem 0.875rem;
+    border-radius: 0.375rem;
+    border: 1px solid var(--color-border);
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.daily-chart-tab.active {
+    border-color: var(--color-primary);
+    background: var(--color-primary-bg);
+    color: var(--color-primary);
+}
+
+.daily-chart-tab-divider {
+    width: 1px;
+    height: 1rem;
+    background: var(--color-border);
+    margin: 0 0.25rem;
+}
+
+.daily-chart-area {
+    height: 11.25rem;
+}
+
+.daily-chart-area svg {
+    display: block;
+}
+
+.daily-chart-grid {
+    stroke: var(--color-border);
+    stroke-width: 0.5;
+}
+
+.daily-chart-grid-label {
+    font-size: 0.6875rem;
+    fill: var(--color-text-muted);
+    text-anchor: end;
+}
+
+.daily-chart-fill {
+    fill: var(--color-primary);
+    opacity: 0.08;
+}
+
+.daily-chart-line {
+    fill: none;
+    stroke: var(--color-primary);
+    stroke-width: 2;
+    stroke-linejoin: round;
+    stroke-linecap: round;
+}
+
+.daily-chart-dot {
+    fill: var(--color-primary);
+    stroke: var(--color-popup-bg);
+    stroke-width: 2;
+    transition: r 0.15s;
+}
+
+.daily-chart-tooltip {
+    transition: opacity 0.15s;
+    pointer-events: none;
+}
+
+.daily-chart-tooltip-bg {
+    fill: var(--color-popup-bg);
+    stroke: var(--color-border);
+    stroke-width: 0.5;
+}
+
+.daily-chart-tooltip-text {
+    font-size: 0.875rem;
+    fill: var(--color-text);
+    font-weight: 600;
+    text-anchor: middle;
+}
+
+.daily-chart-date-label {
+    font-size: 0.6875rem;
+    fill: var(--color-text-muted);
+}
+
+.daily-chart-empty {
+    text-align: center;
+    padding: 2rem;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+}
+
+/* Hover popup */
+.daily-chart-popup {
+    position: absolute;
+    z-index: 10;
+    pointer-events: none;
+    background: var(--color-popup-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    padding: 0.875rem;
+    width: 280px;
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+}
+
+.daily-chart-popup-title {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--color-primary);
+    margin-bottom: 0.625rem;
+}
+
+.daily-chart-popup-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+}
+
+.daily-chart-popup-item {
+    background: var(--color-bg-secondary);
+    border-radius: 0.375rem;
+    padding: 0.5rem 0.625rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+}
+
+.daily-chart-popup-label {
+    font-size: 0.625rem;
+    color: var(--color-text-muted);
+}
+
+.daily-chart-popup-value {
+    font-size: 0.8125rem;
+    font-weight: 500;
+    color: var(--color-text);
+}

--- a/tp-react/src/pages/Stats/components/DailyChart.jsx
+++ b/tp-react/src/pages/Stats/components/DailyChart.jsx
@@ -1,0 +1,177 @@
+import {useState, useRef, useCallback} from 'react';
+import './DailyChart.css';
+
+const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+const formatDateLabel = (dateStr) => {
+    const parts = dateStr.split('-');
+    return MONTH_NAMES[parseInt(parts[1]) - 1] + ' ' + parseInt(parts[2]);
+};
+
+const formatPopupTitle = (dateStr) => {
+    const parts = dateStr.split('-');
+    return parts[0] + '\uB144 ' + parseInt(parts[1]) + '\uC6D4 ' + parseInt(parts[2]) + '\uC77C';
+};
+
+const formatTime = (min) => {
+    if (!min || min <= 0) return '0\uBD84';
+    const h = Math.floor(min / 60);
+    const m = Math.round(min % 60);
+    return h > 0 ? h + '\uC2DC\uAC04 ' + m + '\uBD84' : m + '\uBD84';
+};
+
+const SVG_W = 600;
+const SVG_H = 180;
+const PAD = {left: 48, right: 16, top: 24, bottom: 28};
+const CHART_W = SVG_W - PAD.left - PAD.right;
+const CHART_H = SVG_H - PAD.top - PAD.bottom;
+const GRID_COUNT = 4;
+
+function DailyChart({dailyStats, dailyRange, onRangeChange}) {
+    const [metric, setMetric] = useState('cpm');
+    const [hoverIndex, setHoverIndex] = useState(null);
+    const [popupData, setPopupData] = useState(null);
+    const [popupPos, setPopupPos] = useState({x: 0, y: 0});
+    const chartRef = useRef(null);
+    const svgRef = useRef(null);
+
+    const data = dailyStats || [];
+    const values = data.map(d => metric === 'cpm' ? d.avgCpm : Math.round(d.avgAcc * 100));
+    const maxVal = values.length > 0 ? Math.max(...values) : 0;
+    const minVal = values.length > 0 ? Math.min(...values) : 0;
+    const padding = (maxVal - minVal) * 0.1 || 5;
+    const yMax = metric === 'acc' ? Math.min(maxVal + padding, 100) : maxVal + padding;
+    const yMin = minVal - padding;
+    const yRange = yMax - yMin || 1;
+
+    const points = data.map((d, i) => {
+        const x = data.length > 1 ? PAD.left + (i / (data.length - 1)) * CHART_W : PAD.left + CHART_W / 2;
+        const y = PAD.top + CHART_H - ((values[i] - yMin) / yRange) * CHART_H;
+        return {x, y};
+    });
+
+    const linePoints = points.map(p => p.x + ',' + p.y).join(' ');
+    const areaPoints = points.length > 0
+        ? PAD.left + ',' + (PAD.top + CHART_H) + ' ' + linePoints + ' ' + points[points.length - 1].x + ',' + (PAD.top + CHART_H)
+        : '';
+
+    const gridLines = [];
+    for (let g = 0; g <= GRID_COUNT; g++) {
+        const gy = PAD.top + (g / GRID_COUNT) * CHART_H;
+        const gVal = Math.round(yMax - (g / GRID_COUNT) * yRange);
+        gridLines.push({y: gy, label: metric === 'cpm' ? gVal : gVal + '%'});
+    }
+
+    const labelInterval = data.length > 14 ? Math.ceil(data.length / 6) : 1;
+
+    const handleMouseEnter = useCallback((i) => {
+        setHoverIndex(i);
+        setPopupData(data[i]);
+        if (svgRef.current && chartRef.current) {
+            const svg = svgRef.current;
+            const section = chartRef.current.closest('.daily-chart-section');
+            if (!svg || !section) return;
+            const svgRect = svg.getBoundingClientRect();
+            const sectionRect = section.getBoundingClientRect();
+            const vb = svg.viewBox.baseVal;
+            const sx = svgRect.width / vb.width;
+            const sy = svgRect.height / vb.height;
+            setPopupPos({
+                x: svgRect.left - sectionRect.left + points[i].x * sx,
+                y: svgRect.top - sectionRect.top + points[i].y * sy + 16,
+            });
+        }
+    }, [data, points]);
+
+    const handleMouseLeave = useCallback(() => {
+        setHoverIndex(null);
+        setPopupData(null);
+    }, []);
+
+    return (
+        <div className="daily-chart-section">
+            <div className="daily-chart-header">
+                <h3 className="daily-chart-title">{'\uC77C\uBCC4 \uCD94\uC774'}</h3>
+                <div className="daily-chart-tabs">
+                    <button className={'daily-chart-tab' + (metric === 'cpm' ? ' active' : '')} onClick={() => setMetric('cpm')}>CPM</button>
+                    <button className={'daily-chart-tab' + (metric === 'acc' ? ' active' : '')} onClick={() => setMetric('acc')}>{'\uC815\uD655\uB3C4'}</button>
+                    <span className="daily-chart-tab-divider"/>
+                    <button className={'daily-chart-tab' + (dailyRange === 7 ? ' active' : '')} onClick={() => onRangeChange(7)}>7{'\uC77C'}</button>
+                    <button className={'daily-chart-tab' + (dailyRange === 30 ? ' active' : '')} onClick={() => onRangeChange(30)}>30{'\uC77C'}</button>
+                </div>
+            </div>
+            {data.length === 0 ? (
+                <div className="daily-chart-empty">{'\uB370\uC774\uD130\uAC00 \uC5C6\uC2B5\uB2C8\uB2E4.'}</div>
+            ) : (
+                <div className="daily-chart-area" ref={chartRef}>
+                    <svg ref={svgRef} width="100%" height={SVG_H} viewBox={'0 0 ' + SVG_W + ' ' + SVG_H}>
+                        {gridLines.map((gl, i) => (
+                            <g key={i}>
+                                <line x1={PAD.left} y1={gl.y} x2={SVG_W - PAD.right} y2={gl.y} className="daily-chart-grid"/>
+                                <text x={PAD.left - 8} y={gl.y + 4} className="daily-chart-grid-label">{gl.label}</text>
+                            </g>
+                        ))}
+                        {areaPoints && data.length > 1 && <polygon points={areaPoints} className="daily-chart-fill"/>}
+                        {linePoints && data.length > 1 && <polyline points={linePoints} className="daily-chart-line"/>}
+                        {points.map((p, i) => {
+                            const showLabel = (i % labelInterval === 0) || (i === data.length - 1);
+                            let textAnchor = 'middle';
+                            if (showLabel && i === 0) textAnchor = 'start';
+                            else if (showLabel && i === data.length - 1) textAnchor = 'end';
+                            const displayVal = metric === 'cpm' ? Math.round(values[i]) : values[i] + '%';
+                            return (
+                                <g key={i}>
+                                    <circle cx={p.x} cy={p.y} r={hoverIndex === i ? 6 : 4} className="daily-chart-dot"/>
+                                    <g className="daily-chart-tooltip" style={{opacity: hoverIndex === i ? 1 : 0}}>
+                                        <rect x={p.x - 28} y={p.y - 32} width={56} height={24} rx={4} className="daily-chart-tooltip-bg"/>
+                                        <text x={p.x} y={p.y - 16} className="daily-chart-tooltip-text">{displayVal}</text>
+                                    </g>
+                                    <circle cx={p.x} cy={p.y} r={16} style={{fill: 'transparent', cursor: 'pointer'}}
+                                        onMouseEnter={() => handleMouseEnter(i)} onMouseLeave={handleMouseLeave}/>
+                                    {showLabel && (
+                                        <text x={p.x} y={PAD.top + CHART_H + 16} className="daily-chart-date-label" textAnchor={textAnchor}>
+                                            {formatDateLabel(data[i].date)}
+                                        </text>
+                                    )}
+                                </g>
+                            );
+                        })}
+                    </svg>
+                    {popupData && (
+                        <div className="daily-chart-popup" style={{left: popupPos.x, top: popupPos.y}}>
+                            <div className="daily-chart-popup-title">{formatPopupTitle(popupData.date)}</div>
+                            <div className="daily-chart-popup-grid">
+                                <div className="daily-chart-popup-item">
+                                    <span className="daily-chart-popup-label">{'\uC5F0\uC2B5 \uD69F\uC218'}</span>
+                                    <span className="daily-chart-popup-value">{popupData.attempts + '\uD68C'}</span>
+                                </div>
+                                <div className="daily-chart-popup-item">
+                                    <span className="daily-chart-popup-label">{'\uC5F0\uC2B5 \uC2DC\uAC04'}</span>
+                                    <span className="daily-chart-popup-value">{formatTime(popupData.practiceTimeMin)}</span>
+                                </div>
+                                <div className="daily-chart-popup-item">
+                                    <span className="daily-chart-popup-label">{'\uD3C9\uADE0 \uD0C0\uC790 \uC18D\uB3C4'}</span>
+                                    <span className="daily-chart-popup-value">{Math.round(popupData.avgCpm) + ' CPM'}</span>
+                                </div>
+                                <div className="daily-chart-popup-item">
+                                    <span className="daily-chart-popup-label">{'\uCD5C\uACE0 \uD0C0\uC790 \uC18D\uB3C4'}</span>
+                                    <span className="daily-chart-popup-value">{popupData.bestCpm + ' CPM'}</span>
+                                </div>
+                                <div className="daily-chart-popup-item">
+                                    <span className="daily-chart-popup-label">{'\uD3C9\uADE0 \uC815\uD655\uB3C4'}</span>
+                                    <span className="daily-chart-popup-value">{Math.round(popupData.avgAcc * 100) + '%'}</span>
+                                </div>
+                                <div className="daily-chart-popup-item">
+                                    <span className="daily-chart-popup-label">{'\uD3C9\uADE0 \uCD08\uAE30\uD654 \uD69F\uC218'}</span>
+                                    <span className="daily-chart-popup-value">{(popupData.attempts > 0 ? (popupData.resetCount / popupData.attempts).toFixed(2) : '0') + '\uD68C'}</span>
+                                </div>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default DailyChart;

--- a/tp-react/src/pages/Stats/components/StatsSummary.css
+++ b/tp-react/src/pages/Stats/components/StatsSummary.css
@@ -1,0 +1,94 @@
+.stats-summary {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+    margin-bottom: 1.75rem;
+}
+
+.stats-main-card {
+    background: var(--color-popup-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+.stats-main-label {
+    font-size: 0.75rem;
+    color: var(--color-text-muted);
+    font-weight: 500;
+    margin-bottom: 0.25rem;
+}
+
+.stats-main-value {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+}
+
+.stats-main-number {
+    font-size: 2.5rem;
+    font-weight: 700;
+    color: var(--color-text);
+    letter-spacing: -1px;
+}
+
+.stats-main-unit {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+}
+
+.stats-trend {
+    font-size: 0.875rem;
+    font-weight: 600;
+}
+
+.stats-trend.up {
+    color: var(--color-success);
+}
+
+.stats-trend.down {
+    color: var(--color-error);
+}
+
+.stats-trend.neutral {
+    color: var(--color-text-muted);
+}
+
+.stats-main-sub {
+    margin-top: 0.375rem;
+    font-size: 0.8125rem;
+    color: var(--color-text-muted);
+}
+
+.stats-sub-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5rem;
+}
+
+.stats-sub-card {
+    background: var(--color-bg-secondary);
+    border-radius: 0.5rem;
+    padding: 0.75rem;
+}
+
+.stats-sub-label {
+    font-size: 0.6875rem;
+    color: var(--color-text-muted);
+}
+
+.stats-sub-value {
+    font-size: 1.25rem;
+    font-weight: 700;
+    color: var(--color-text);
+    margin-top: 0.125rem;
+}
+
+.stats-sub-unit {
+    font-size: 0.6875rem;
+    color: var(--color-text-muted);
+    margin-left: 0.125rem;
+}

--- a/tp-react/src/pages/Stats/components/StatsSummary.jsx
+++ b/tp-react/src/pages/Stats/components/StatsSummary.jsx
@@ -1,0 +1,79 @@
+import './StatsSummary.css';
+
+const formatTime = (min) => {
+    if (!min || min <= 0) return '0분';
+    const h = Math.floor(min / 60);
+    const m = Math.round(min % 60);
+    return h > 0 ? h + '시간 ' + m + '분' : m + '분';
+};
+
+const calcTrend = (recentAvg, totalAvg) => {
+    if (!totalAvg || !recentAvg) return {text: '', className: ''};
+    const percent = ((recentAvg - totalAvg) / totalAvg * 100).toFixed(1);
+    if (percent > 0) return {text: '\u25B2 ' + percent + '%', className: 'stats-trend up'};
+    if (percent < 0) return {text: '\u25BC ' + Math.abs(percent) + '%', className: 'stats-trend down'};
+    return {text: '\u2014 0%', className: 'stats-trend neutral'};
+};
+
+const calcRecentAvgCpm = (dailyStats) => {
+    if (!dailyStats || dailyStats.length === 0) return 0;
+    let totalWeighted = 0;
+    let totalAttempts = 0;
+    for (let i = 0; i < dailyStats.length; i++) {
+        totalWeighted += dailyStats[i].avgCpm * dailyStats[i].attempts;
+        totalAttempts += dailyStats[i].attempts;
+    }
+    return totalAttempts > 0 ? Math.round(totalWeighted / totalAttempts) : 0;
+};
+
+function StatsSummary({typingStats, dailyStats}) {
+    if (!typingStats) return null;
+
+    const recentAvg = calcRecentAvgCpm(dailyStats);
+    const trend = calcTrend(recentAvg, typingStats.avgCpm);
+    const avgReset = typingStats.totalAttempts > 0
+        ? (typingStats.totalResetCount / typingStats.totalAttempts).toFixed(2)
+        : '0';
+
+    return (
+        <div className="stats-summary">
+            <div className="stats-main-card">
+                <span className="stats-main-label">최근 7일 평균</span>
+                <div className="stats-main-value">
+                    <span className="stats-main-number">{recentAvg}</span>
+                    <span className="stats-main-unit">CPM</span>
+                    {trend.text && <span className={trend.className}>{trend.text}</span>}
+                </div>
+                <div className="stats-main-sub">
+                    최고 {typingStats.bestCpm} CPM · 정확도 {Math.round(typingStats.avgAcc * 100)}%
+                </div>
+            </div>
+            <div className="stats-sub-grid">
+                <div className="stats-sub-card">
+                    <span className="stats-sub-label">연습 시간</span>
+                    <div className="stats-sub-value">{formatTime(typingStats.totalPracticeTimeMin)}</div>
+                </div>
+                <div className="stats-sub-card">
+                    <span className="stats-sub-label">연습 횟수</span>
+                    <div className="stats-sub-value">
+                        {typingStats.totalAttempts}<span className="stats-sub-unit">회</span>
+                    </div>
+                </div>
+                <div className="stats-sub-card">
+                    <span className="stats-sub-label">전체 평균</span>
+                    <div className="stats-sub-value">
+                        {Math.round(typingStats.avgCpm)}<span className="stats-sub-unit">CPM</span>
+                    </div>
+                </div>
+                <div className="stats-sub-card">
+                    <span className="stats-sub-label">평균 초기화</span>
+                    <div className="stats-sub-value">
+                        {avgReset}<span className="stats-sub-unit">회</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+    );
+}
+
+export default StatsSummary;

--- a/tp-react/src/pages/Stats/components/TypoList.css
+++ b/tp-react/src/pages/Stats/components/TypoList.css
@@ -1,0 +1,148 @@
+.typo-area {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1rem;
+}
+
+.typo-area:has(.typo-section:nth-child(2)) {
+    grid-template-columns: 1fr 1fr;
+}
+
+.typo-section {
+    background: var(--color-popup-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+}
+
+.typo-section-header {
+    margin-bottom: 1.25rem;
+}
+
+.typo-section-title {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.typo-detail-char {
+    color: var(--color-primary);
+    font-weight: 700;
+}
+
+.typo-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.typo-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.625rem 0.875rem;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    border: 1px solid transparent;
+    transition: all 0.15s;
+}
+
+.typo-item:hover {
+    background: var(--color-primary-bg);
+}
+
+.typo-item.selected {
+    background: var(--color-primary-bg);
+    border-color: var(--color-primary);
+}
+
+.typo-char {
+    width: 2rem;
+    height: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--color-primary-bg);
+    border-radius: 0.5rem;
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--color-primary);
+    flex-shrink: 0;
+}
+
+.typo-bar-container {
+    flex: 1;
+    height: 0.375rem;
+    background: var(--color-border);
+    border-radius: 0.1875rem;
+    overflow: hidden;
+}
+
+.typo-bar-fill {
+    height: 100%;
+    background: var(--color-primary);
+    border-radius: 0.1875rem;
+    opacity: 0.7;
+}
+
+.typo-count {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text);
+    min-width: 2rem;
+    text-align: right;
+}
+
+.typo-empty {
+    text-align: center;
+    padding: 2rem;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+}
+
+/* Detail */
+.typo-detail-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.typo-detail-item {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    padding: 0.625rem 0.875rem;
+    background: var(--color-bg-secondary);
+    border-radius: 0.5rem;
+}
+
+.typo-detail-expected {
+    padding: 0.25rem 0.625rem;
+    background: var(--color-primary-bg);
+    border-radius: 0.375rem;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: var(--color-primary);
+}
+
+.typo-detail-arrow {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+}
+
+.typo-detail-actual {
+    padding: 0.25rem 0.625rem;
+    background: var(--color-error-light);
+    border-radius: 0.375rem;
+    font-size: 0.9375rem;
+    font-weight: 700;
+    color: var(--color-error);
+}
+
+.typo-detail-count {
+    margin-left: auto;
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text);
+}

--- a/tp-react/src/pages/Stats/components/TypoList.jsx
+++ b/tp-react/src/pages/Stats/components/TypoList.jsx
@@ -1,0 +1,96 @@
+import {useState} from 'react';
+import {getTypoDetailStats} from '@/utils/statsApi.ts';
+import './TypoList.css';
+
+const displayChar = (ch) => ch === ' ' ? '\u2423' : ch;
+
+function TypoList({typoStats}) {
+    const [selectedTypo, setSelectedTypo] = useState(null);
+    const [typoDetail, setTypoDetail] = useState([]);
+    const [detailLoading, setDetailLoading] = useState(false);
+
+    if (!typoStats || typoStats.length === 0) {
+        return (
+            <div className="typo-section">
+                <div className="typo-section-header">
+                    <h3 className="typo-section-title">{'\uC790\uC8FC \uD2C0\uB9AC\uB294 \uAE00\uC790 TOP 10'}</h3>
+                </div>
+                <div className="typo-empty">{'\uC624\uD0C0 \uB370\uC774\uD130\uAC00 \uC5C6\uC2B5\uB2C8\uB2E4.'}</div>
+            </div>
+        );
+    }
+
+    const maxCount = typoStats[0].count;
+
+    const handleTypoClick = async (expected) => {
+        if (selectedTypo === expected) {
+            setSelectedTypo(null);
+            setTypoDetail([]);
+            return;
+        }
+        setSelectedTypo(expected);
+        setDetailLoading(true);
+        try {
+            const res = await getTypoDetailStats('KOREAN', expected);
+            setTypoDetail(res.data.data.content || []);
+        } catch (error) {
+            console.error('\uC624\uD0C0 \uC0C1\uC138 \uB85C\uB4DC \uC2E4\uD328:', error);
+            setTypoDetail([]);
+        } finally {
+            setDetailLoading(false);
+        }
+    };
+
+    return (
+        <div className="typo-area">
+            <div className="typo-section">
+                <div className="typo-section-header">
+                    <h3 className="typo-section-title">{'\uC790\uC8FC \uD2C0\uB9AC\uB294 \uAE00\uC790 TOP 10'}</h3>
+                </div>
+                <div className="typo-list">
+                    {typoStats.map((item, i) => (
+                        <div
+                            key={i}
+                            className={'typo-item' + (selectedTypo === item.expected ? ' selected' : '')}
+                            onClick={() => handleTypoClick(item.expected)}
+                        >
+                            <span className="typo-char">{displayChar(item.expected)}</span>
+                            <div className="typo-bar-container">
+                                <div className="typo-bar-fill" style={{width: (item.count / maxCount * 100) + '%'}}/>
+                            </div>
+                            <span className="typo-count">{item.count}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            {selectedTypo && (
+                <div className="typo-section">
+                    <div className="typo-section-header">
+                        <h3 className="typo-section-title">
+                            &lsquo;<span className="typo-detail-char">{displayChar(selectedTypo)}</span>&rsquo; {'\uC624\uD0C0 \uC0C1\uC138'}
+                        </h3>
+                    </div>
+                    {detailLoading ? (
+                        <div className="typo-empty">{'\uB85C\uB529 \uC911...'}</div>
+                    ) : typoDetail.length === 0 ? (
+                        <div className="typo-empty">{'\uC0C1\uC138 \uB370\uC774\uD130\uAC00 \uC5C6\uC2B5\uB2C8\uB2E4.'}</div>
+                    ) : (
+                        <div className="typo-detail-list">
+                            {typoDetail.map((d, i) => (
+                                <div key={i} className="typo-detail-item">
+                                    <span className="typo-detail-expected">{displayChar(d.expected)}</span>
+                                    <span className="typo-detail-arrow">{'\u2192'}</span>
+                                    <span className="typo-detail-actual">{displayChar(d.actual)}</span>
+                                    <span className="typo-detail-count">{d.typoCount + '\uD68C'}</span>
+                                </div>
+                            ))}
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default TypoList;

--- a/tp-react/src/utils/statsApi.ts
+++ b/tp-react/src/utils/statsApi.ts
@@ -1,0 +1,105 @@
+import apiClient from './apiClient';
+import {ApiResponse} from '../types/api.types';
+
+// 종합 통계 응답
+export interface TypingStatsResponse {
+    totalAttempts: number;
+    avgCpm: number;
+    avgAcc: number;
+    bestCpm: number;
+    totalPracticeTimeMin: number;
+    totalResetCount: number;
+}
+
+// 일별 통계 항목
+export interface DayEntry {
+    date: string;
+    attempts: number;
+    avgCpm: number;
+    avgAcc: number;
+    bestCpm: number;
+    resetCount: number;
+    practiceTimeMin: number;
+}
+
+// 일별 통계 응답
+export interface DailyStatsResponse {
+    days: number;
+    content: DayEntry[];
+}
+
+// 오타 항목
+export interface TypoStatsEntry {
+    language: string;
+    expected: string;
+    count: number;
+}
+
+// 오타 통계 응답
+export interface TypoStatsResponse {
+    content: TypoStatsEntry[];
+}
+
+// 오타 상세 항목
+export interface TypoDetailEntry {
+    language: string;
+    expected: string;
+    actual: string;
+    typoCount: number;
+    initialCount: number;
+    medialCount: number;
+    finalCount: number;
+    letterCount: number;
+}
+
+// 오타 상세 응답
+export interface TypoDetailStatsResponse {
+    content: TypoDetailEntry[];
+}
+
+type Language = 'KOREAN' | 'ENGLISH';
+
+/**
+ * 종합 타이핑 통계 조회
+ */
+export const getTypingStats = async (language: Language) => {
+    return apiClient.get<ApiResponse<TypingStatsResponse>>(
+        `/members/me/stats/typing?language=${language}`
+    );
+};
+
+/**
+ * 일별 타이핑 추이 조회
+ */
+export const getDailyStats = async (language: Language, days: number = 7) => {
+    return apiClient.get<ApiResponse<DailyStatsResponse>>(
+        `/members/me/stats/daily?language=${language}&days=${days}`
+    );
+};
+
+/**
+ * 오타 상위 10개 조회
+ */
+export const getTypoStats = async (language: Language) => {
+    return apiClient.get<ApiResponse<TypoStatsResponse>>(
+        `/members/me/stats/typos?language=${language}`
+    );
+};
+
+/**
+ * 오타 상세 조회 (drill-down)
+ */
+export const getTypoDetailStats = async (language: Language, expected: string) => {
+    return apiClient.get<ApiResponse<TypoDetailStatsResponse>>(
+        `/members/me/stats/typos/detail?language=${language}&expected=${encodeURIComponent(expected)}`
+    );
+};
+
+/**
+ * 통계 리프레시 (1분 쿨다운)
+ */
+export const refreshStats = async (language: Language) => {
+    return apiClient.post<ApiResponse<TypingStatsResponse>>(
+        `/members/me/stats/refresh?language=${language}`
+    );
+};

--- a/tp-react/typing-practice-prototype.html
+++ b/tp-react/typing-practice-prototype.html
@@ -438,8 +438,149 @@
     </div>
 </div>
 
+<!-- 통계 페이지 -->
+<div class="stats-page display-none" id="statsPage">
+    <div class="stats-container">
+        <div class="stats-header">
+            <h1 class="stats-title">내 타이핑 통계</h1>
+            <button class="stats-refresh-btn" id="statsRefreshBtn">
+                <i class="fa-solid fa-rotate-right"></i>
+                <span>새로고침</span>
+            </button>
+        </div>
+
+        <!-- 종합 통계 카드 -->
+        <div class="stats-summary">
+            <div class="stats-main-card">
+                <span class="stats-main-label">최근 7일 평균</span>
+                <div class="stats-main-value">
+                    <span id="statsRecentCpm">0</span>
+                    <span class="stats-main-unit">CPM</span>
+                    <span class="stats-trend" id="statsTrend"></span>
+                </div>
+                <div class="stats-main-sub">
+                    최고 <span id="statsBestCpm">0</span> CPM · 정확도 <span id="statsAvgAcc">0</span>%
+                </div>
+            </div>
+            <div class="stats-sub-grid">
+                <div class="stats-sub-card">
+                    <span class="stats-sub-label">연습 시간</span>
+                    <div class="stats-sub-value"><span id="statsTotalTime">0분</span></div>
+                </div>
+                <div class="stats-sub-card">
+                    <span class="stats-sub-label">연습 횟수</span>
+                    <div class="stats-sub-value"><span id="statsTotalAttempts">0</span><span class="stats-sub-unit">회</span></div>
+                </div>
+                <div class="stats-sub-card">
+                    <span class="stats-sub-label">전체 평균</span>
+                    <div class="stats-sub-value"><span id="statsAvgCpm">0</span><span class="stats-sub-unit">CPM</span></div>
+                </div>
+                <div class="stats-sub-card">
+                    <span class="stats-sub-label">평균 초기화</span>
+                    <div class="stats-sub-value"><span id="statsResetCount">0</span><span class="stats-sub-unit">회</span></div>
+                </div>
+            </div>
+        </div>
+
+        <!-- 일별 추이 -->
+        <div class="stats-section">
+            <div class="stats-section-header">
+                <h3 class="stats-section-title">일별 추이</h3>
+                <div class="stats-tabs">
+                    <button class="stats-tab active" data-metric="cpm">CPM</button>
+                    <button class="stats-tab" data-metric="acc">정확도</button>
+                    <span class="stats-tab-divider"></span>
+                    <button class="stats-tab active" data-range="7">7일</button>
+                    <button class="stats-tab" data-range="30">30일</button>
+                </div>
+            </div>
+            <div class="stats-chart" id="statsChart">
+                <!-- JS로 바 차트 렌더링 -->
+            </div>
+            <div class="stats-chart-empty display-none" id="statsChartEmpty">
+                데이터가 없습니다.
+            </div>
+            <!-- 일별 상세 팝업 (차트 위에 오버레이) -->
+            <div class="stats-daily-popup-overlay" id="statsDailyPopupOverlay">
+                <div class="stats-daily-popup">
+                    <div class="stats-daily-popup-header">
+                        <h3 class="stats-daily-popup-title" id="statsDailyPopupTitle">2026년 3월 23일</h3>
+                        <button class="stats-daily-popup-close" id="statsDailyPopupClose">
+                            <i class="fa-solid fa-xmark"></i>
+                        </button>
+                    </div>
+                    <div class="stats-daily-popup-grid">
+                        <div class="stats-daily-popup-item">
+                            <span class="stats-daily-popup-label">연습 횟수</span>
+                            <span class="stats-daily-popup-value" id="dailyPopupAttempts">0회</span>
+                        </div>
+                        <div class="stats-daily-popup-item">
+                            <span class="stats-daily-popup-label">연습 시간</span>
+                            <span class="stats-daily-popup-value" id="dailyPopupTime">0분</span>
+                        </div>
+                        <div class="stats-daily-popup-item">
+                            <span class="stats-daily-popup-label">평균 타자 속도</span>
+                            <span class="stats-daily-popup-value" id="dailyPopupAvgCpm">0 CPM</span>
+                        </div>
+                        <div class="stats-daily-popup-item">
+                            <span class="stats-daily-popup-label">최고 타자 속도</span>
+                            <span class="stats-daily-popup-value" id="dailyPopupBestCpm">0 CPM</span>
+                        </div>
+                        <div class="stats-daily-popup-item">
+                            <span class="stats-daily-popup-label">평균 정확도</span>
+                            <span class="stats-daily-popup-value" id="dailyPopupAcc">0%</span>
+                        </div>
+                        <div class="stats-daily-popup-item">
+                            <span class="stats-daily-popup-label">평균 초기화 횟수</span>
+                            <span class="stats-daily-popup-value" id="dailyPopupReset">0회</span>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- 오타 통계 -->
+        <div class="stats-typo-area">
+            <div class="stats-section">
+                <div class="stats-section-header">
+                    <h3 class="stats-section-title">자주 틀리는 글자 TOP 10</h3>
+                </div>
+                <div class="stats-typo-list" id="statsTypoList">
+                    <!-- JS로 렌더링 -->
+                </div>
+                <div class="stats-typo-empty display-none" id="statsTypoEmpty">
+                    오타 데이터가 없습니다.
+                </div>
+            </div>
+
+            <div class="stats-section display-none" id="statsTypoDetailSection">
+                <div class="stats-section-header">
+                    <h3 class="stats-section-title">
+                        '<span id="statsTypoDetailChar">ㅔ</span>' 오타 상세
+                    </h3>
+                </div>
+                <div class="stats-typo-detail-list" id="statsTypoDetailList">
+                    <!-- JS로 렌더링 -->
+                </div>
+            </div>
+        </div>
+
+        <!-- 돌아가기 -->
+        <div class="stats-footer">
+            <button class="stats-back-btn" id="statsBackBtn">
+                <i class="fa-solid fa-arrow-left"></i>
+                <span>돌아가기</span>
+            </button>
+        </div>
+    </div>
+
+    <!-- 일별 상세 팝업 -->
+    <!-- 일별 추이 섹션 내부로 이동됨 -->
+</div>
+
 <script src="prototype1.js"></script>
 <script src="prototype2.js"></script>
 <script src="prototype3.js"></script>
+<script src="prototype4-stats.js"></script>
 </body>
 </html>


### PR DESCRIPTION
### 프로토타입
- `prototype4-stats.js` 신규 생성 (mock 데이터 + 렌더링 로직)
- `prototype.css`, `typing-practice-prototype.html`에 기록 페이지 UI 추가
- 종합 통계 (메인 카드 + 서브 카드 4개), 일별 추이 (꺾은선 그래프), 오타 TOP 10
- 로그인 시뮬레이션 로딩 시간 단축, statsBtn 핸들러 변경

### React 구현
- `/stats` 라우트 추가, 프로필 드롭다운 "기록" 메뉴 연결
- `statsApi.ts`: 종합 통계 / 일별 추이 / 오타 통계 / 오타 상세 / 리프레시 API
- `StatsSummary`: 최근 7일 평균 CPM + 전체 평균 대비 추세 화살표(▲/▼), 서브 카드 4개 (연습 시간 / 연습 횟수 / 전체 평균 / 평균 초기화)
- `DailyChart`: SVG 꺾은선 그래프, CPM/정확도 탭, 7일/30일 전환, hover 툴팁 + 일별 상세 팝업, 30일 시 라벨 간격 조절
- `TypoList`: 오타 TOP 10 수평 바 + 클릭 시 detail API 호출하여 상세 패널 표시, 공백 문자 ␣ 시각화
- 새로고침 버튼 (429 쿨다운 에러 처리), 비로그인 시 홈으로 리다이렉트
- AppDiv에 `/stats` compact 레이아웃 적용