### PR TITLE
chore: MongoDB Atlas 연동 및 프로파일별 .env 분리 설정

### DIFF
--- a/typing-practice-be/.env.example
+++ b/typing-practice-be/.env.example
@@ -1,0 +1,12 @@
+DB_URL=postgresql_database_url
+DB_USERNAME=postgresql_username
+DB_PASSWORD=postgresql_password
+
+MONGODB_URI=mongodb_uri
+
+JWT_SECRET=jwt_secret
+
+GOOGLE_CLIENT_ID=google_client_id
+GOOGLE_CLIENT_SECRET=google_client_secret
+GOOGLE_REDIRECT_URI=google_redirect_uri
+ADMIN_EMAIL=admin_google_email

--- a/typing-practice-be/.gitignore
+++ b/typing-practice-be/.gitignore
@@ -5,8 +5,16 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+data.mv.db
+
+# .env
+.env
+.env.local
+.env.prod
+
 # application-local.yaml (민감정보 포함)
 src/main/resources/application-local.yaml
+src/main/resources/application-prod.yaml
 
 # config.js
 src/main/resources/config.js

--- a/typing-practice-be/build.gradle
+++ b/typing-practice-be/build.gradle
@@ -49,6 +49,8 @@ dependencies {
 
     testCompileOnly 'org.projectlombok:lombok'
     testAnnotationProcessor 'org.projectlombok:lombok'
+
+    implementation 'one.stayfocused.spring:dotenv-spring-boot:1.0.0'
 }
 
 tasks.named('test') {

--- a/typing-practice-be/docker-compose.prod.yaml
+++ b/typing-practice-be/docker-compose.prod.yaml
@@ -1,0 +1,21 @@
+services:
+  postgres:
+    image: postgres:16
+    restart: always
+    volumes:
+      - ./postgres-data:/var/lib/postgresql/data
+    ports:
+      - '5432:5432'
+    environment:
+      POSTGRES_USER: user
+      POSTGRES_PASSWORD: user
+      POSTGRES_DB: typing
+
+  redis:
+    image: redis:8
+    restart: always
+    ports:
+      - '6379:6379'
+
+volumes:
+  postgres-data:

--- a/typing-practice-be/src/main/resources/application-example.yaml
+++ b/typing-practice-be/src/main/resources/application-example.yaml
@@ -1,0 +1,42 @@
+spring:
+  datasource:
+    url: ${DB_URL}
+    driver-class-name: org.postgresql.Driver
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+        #show_sql: true
+    defer-datasource-initialization: true
+  sql:
+    init:
+      mode: always
+
+  data:
+    redis:
+      host: localhost #redis
+      port: 6379
+    mongodb:
+      uri: ${MONGODB_URI}
+
+jwt:
+  access-token-expiration-ms: 300000
+  refresh-token-expiration-days: 15
+  secret: ${JWT_SECRET}
+
+google:
+  client-id: ${GOOGLE_CLIENT_ID}
+  client-secret: ${GOOGLE_CLIENT_SECRET}
+  redirect-uri: ${GOOGLE_REDIRECT_URI}
+
+logging:
+  level:
+    org.springframework.security: DEBUG
+
+admin:
+  emails:
+    - ${ADMIN_EMAIL}

--- a/typing-practice-be/src/main/resources/application.yaml
+++ b/typing-practice-be/src/main/resources/application.yaml
@@ -1,6 +1,6 @@
 spring:
   profiles:
-    active: local
+    active: local #prod
   application:
     name: typing-practice-be
 
@@ -9,10 +9,9 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
 
-jwt:
-  access-token-expiration-ms: 300000
-  refresh-token-expiration-days: 15
 
+dotenv:
+  path: .env.${spring.profiles.active}
 
 springdoc:
   api-docs:


### PR DESCRIPTION
- dotenv 라이브러리(one.stayfocused.spring:dotenv-spring-boot) 추가
- application.yaml에 dotenv.path 추가로 프로파일별 .env 파일 분기
- .gitignore에 .env.local, .env.prod, application-prod.yaml 추가
- .env.example, application-example.yaml 추가
- docker-compose.prod.yaml 추가 (app + redis, MongoDB는 Atlas 사용)