### PR TITLE
feat: Redis 모니터링 추가 및 k6 부하 테스트 스크립트 추가

### DIFF
--- a/typing-practice-be/docker-compose.prod.yaml
+++ b/typing-practice-be/docker-compose.prod.yaml
@@ -17,6 +17,14 @@ services:
     ports:
       - '6379:6379'
 
+  redis-exporter:
+    image: oliver006/redis_exporter:latest
+    restart: always
+    ports:
+      - '9121:9121'
+    environment:
+      - REDIS_ADDR=redis://redis:6379
+
   prometheus:
     image: prom/prometheus:latest
     restart: always

--- a/typing-practice-be/docker-compose.yaml
+++ b/typing-practice-be/docker-compose.yaml
@@ -18,6 +18,14 @@ services:
       - '6379:6379'
   #    command: redis-server --requirepass redis123
 
+  redis-exporter:
+    image: oliver006/redis_exporter:latest
+    restart: always
+    ports:
+      - '9121:9121'
+    environment:
+      - REDIS_ADDR=redis://redis:6379
+
   mongodb:
     image: mongo:8
     container_name: typing-mongodb

--- a/typing-practice-be/k6/load-test.js
+++ b/typing-practice-be/k6/load-test.js
@@ -1,0 +1,28 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+
+const BASE_URL = 'http://3.34.181.102:8080';
+
+export const options = {
+    stages: [
+        {duration: '30s', target: 10}, // 30초 동안 10명까지 증가
+        {duration: '2m', target: 10}, // 2분 동안 10명 유지
+        {duration: '30s', target: 0} // 30초 동안 0명으로 감소
+    ],
+    thresholds: {
+        http_req_duration: ['p(95)<500'] // p95 요청이 500ms 이내
+    }
+};
+
+export default function () {
+    // 랜덤 문장 조회
+    const seed = Math.random();
+    const res = http.get(`${BASE_URL}/quotes?page=1&count=10&seed=${seed}&language=KOREAN`);
+
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+        'response time < 500ms': (r) => r.timings.duration < 500,
+    });
+
+    sleep(1); // 사용자 간 1초 대기 (실제 사용 패턴 시뮬레이션)
+}

--- a/typing-practice-be/k6/mixed-test.js
+++ b/typing-practice-be/k6/mixed-test.js
@@ -1,0 +1,70 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+
+const BASE_URL = 'http://3.34.181.102:8080';
+
+export const options = {
+    stages: [
+        {duration: '30s', target: 10},
+        {duration: '1m', target: 10},
+        {duration: '10s', target: 200},
+        {duration: '3m', target: 200},  // 1분 → 3분으로 늘림
+        {duration: '10s', target: 10},
+        {duration: '1m', target: 10},
+        {duration: '30s', target: 0},
+    ],
+    thresholds: {
+        http_req_duration: ['p(95)<2000'],
+    },
+};
+
+const TYPO_TYPES = ['INITIAL', 'MEDIAL', 'FINAL', 'LETTER'];
+
+function randomTypos() {
+    const count = Math.floor(Math.random() * 3);
+    const typos = [];
+    for (let i = 0; i < count; i++) {
+        typos.push({
+            expected: 'ㄱ',
+            actual: 'ㄴ',
+            position: Math.floor(Math.random() * 50),
+            type: TYPO_TYPES[Math.floor(Math.random() * TYPO_TYPES.length)],
+        });
+    }
+    return typos;
+}
+
+export default function () {
+    const isWrite = Math.random() < 0.9; // 90% 쓰기
+
+    if (isWrite) {
+        const payload = JSON.stringify({
+            quoteId: Math.floor(Math.random() * 100) + 1,
+            cpm: Math.floor(Math.random() * 300) + 100,
+            accuracy: Math.random() * 30 + 70,
+            charLength: Math.floor(Math.random() * 100) + 20,
+            resetCount: Math.floor(Math.random() * 3),
+            typos: randomTypos(),
+        });
+
+        const res = http.post(`${BASE_URL}/typing-records`, payload, {
+            headers: {'Content-Type': 'application/json'},
+        });
+
+        check(res, {
+            'write status is 200': (r) => r.status === 200,
+        });
+    } else {
+        const seed = Math.random();
+        const res = http.get(
+            `${BASE_URL}/quotes?page=1&count=10&seed=${seed}&language=KOREAN`
+        );
+
+        check(res, {
+            'read status is 200': (r) => r.status === 200,
+            'read response time < 500ms': (r) => r.timings.duration < 500,
+        });
+    }
+
+    sleep(1);
+}

--- a/typing-practice-be/k6/realistic-test.js
+++ b/typing-practice-be/k6/realistic-test.js
@@ -1,0 +1,71 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+
+const BASE_URL = 'http://3.34.181.102:8080';
+
+export const options = {
+    stages: [
+        {duration: '30s', target: 10},
+        {duration: '1m', target: 10},
+        {duration: '10s', target: 200},
+        {duration: '3m', target: 200},
+        {duration: '10s', target: 10},
+        {duration: '1m', target: 10},
+        {duration: '30s', target: 0},
+    ],
+    thresholds: {
+        http_req_duration: ['p(95)<2000'],
+    },
+};
+
+const TYPO_TYPES = ['INITIAL', 'MEDIAL', 'FINAL', 'LETTER'];
+
+function randomTypos() {
+    const count = Math.floor(Math.random() * 3);
+    const typos = [];
+    for (let i = 0; i < count; i++) {
+        typos.push({
+            expected: 'ㄱ',
+            actual: 'ㄴ',
+            position: Math.floor(Math.random() * 50),
+            type: TYPO_TYPES[Math.floor(Math.random() * TYPO_TYPES.length)],
+        });
+    }
+    return typos;
+}
+
+function submitTypingRecord() {
+    const payload = JSON.stringify({
+        quoteId: Math.floor(Math.random() * 100) + 1,
+        cpm: Math.floor(Math.random() * 300) + 100,
+        accuracy: Math.random() * 30 + 70,
+        charLength: Math.floor(Math.random() * 100) + 20,
+        resetCount: Math.floor(Math.random() * 3),
+        typos: randomTypos(),
+    });
+
+    const res = http.post(`${BASE_URL}/typing-records`, payload, {
+        headers: {'Content-Type': 'application/json'},
+    });
+
+    check(res, {
+        'write status is 200': (r) => r.status === 200,
+    });
+}
+
+export default function () {
+    // 1. 문장 조회 (한 페이지에 10개)
+    const seed = Math.random();
+    const res = http.get(`${BASE_URL}/quotes?page=1&count=10&seed=${seed}&language=KOREAN`);
+
+    check(res, {
+        'read status is 200': (r) => r.status === 200,
+    });
+
+    // 2. 10개 문장을 순서대로 타이핑
+    const typingCount = Math.floor(Math.random() * 6) + 5; // 5~10개 문장 타이핑
+    for (let i = 0; i < typingCount; i++) {
+        sleep(Math.random() * 20 + 10); // 10~30초 타이핑 시간
+        submitTypingRecord();
+    }
+}

--- a/typing-practice-be/k6/spike-test.js
+++ b/typing-practice-be/k6/spike-test.js
@@ -1,0 +1,31 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+
+const BASE_URL = 'http://3.34.181.102:8080';
+
+export const options = {
+    stages: [
+        {duration: '30s', target: 10},   // 평소 트래픽
+        {duration: '1m', target: 10},    // 유지
+        {duration: '10s', target: 200},  // 급격히 200명으로 스파이크
+        {duration: '1m', target: 200},   // 스파이크 유지
+        {duration: '10s', target: 10},   // 급격히 감소
+        {duration: '1m', target: 10},    // 회복 확인
+        {duration: '30s', target: 0},    // 정리
+    ],
+    thresholds: {
+        http_req_duration: ['p(95)<2000'],
+    },
+};
+
+export default function () {
+    const seed = Math.random();
+    const res = http.get(`${BASE_URL}/quotes?page=1&count=10&seed=${seed}&language=KOREAN`);
+
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+        'response time < 500ms': (r) => r.timings.duration < 500,
+    });
+
+    sleep(1);
+}

--- a/typing-practice-be/k6/stress-test.js
+++ b/typing-practice-be/k6/stress-test.js
@@ -1,0 +1,30 @@
+import http from 'k6/http';
+import {check, sleep} from 'k6';
+
+const BASE_URL = 'http://3.34.181.102:8080';
+
+export const options = {
+    stages: [
+        {duration: '30s', target: 10},   // 워밍업
+        {duration: '1m', target: 30},    // 30명
+        {duration: '1m', target: 50},    // 50명
+        {duration: '1m', target: 100},   // 100명
+        {duration: '1m', target: 150},   // 150명
+        {duration: '30s', target: 0},    // 정리
+    ],
+    thresholds: {
+        http_req_duration: ['p(95)<1000'],
+    },
+};
+
+export default function () {
+    const seed = Math.random();
+    const res = http.get(`${BASE_URL}/quotes?page=1&count=10&seed=${seed}&language=KOREAN`);
+
+    check(res, {
+        'status is 200': (r) => r.status === 200,
+        'response time < 500ms': (r) => r.timings.duration < 500,
+    });
+
+    sleep(1);
+}

--- a/typing-practice-be/prometheus-local.yml
+++ b/typing-practice-be/prometheus-local.yml
@@ -6,3 +6,7 @@ scrape_configs:
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: [ 'host.docker.internal:8080' ]
+
+  - job_name: 'redis'
+    static_configs:
+      - targets: [ 'redis-exporter:9121' ]

--- a/typing-practice-be/prometheus-prod.yml
+++ b/typing-practice-be/prometheus-prod.yml
@@ -6,3 +6,7 @@ scrape_configs:
     metrics_path: '/actuator/prometheus'
     static_configs:
       - targets: [ 'app:8080' ]
+
+  - job_name: 'redis'
+    static_configs:
+      - targets: [ 'redis-exporter:9121' ]

--- a/typing-practice-be/src/main/resources/application-example.yaml
+++ b/typing-practice-be/src/main/resources/application-example.yaml
@@ -4,6 +4,8 @@ spring:
     driver-class-name: org.postgresql.Driver
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
+    hikari:
+      maximum-pool-size: 10
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
### 개요
Redis Exporter를 추가하여 Redis 서버 모니터링을 구성하고, k6 부하 테스트 스크립트를 작성하여 EC2 배포 환경에서 성능을 검증합니다.

### 변경 사항

**Redis 모니터링**
- docker-compose에 redis-exporter 컨테이너 추가 (로컬/운영)
- Prometheus scrape config에 redis target 추가 (로컬/운영)

**k6 부하 테스트 스크립트**
- Load Test: 동시 10명 기본 부하
- Stress Test: 10 → 150명 점진적 증가
- Spike Test: 10 → 200명 급격한 트래픽
- Mixed Test: 읽기/쓰기 혼합 스파이크
- Realistic Test: 실제 사용 패턴 시뮬레이션 (10~30초 타이핑 간격)

**설정**
- HikariCP pool-size 10 명시 (application-example.yaml)

### 부하 테스트 결과 요약

| 테스트 | 동시 사용자 | 평균 응답 | p95 | 에러율 |
|--------|-----------|----------|-----|-------|
| Load | 10명 | 33.7ms | 45.3ms | 0% |
| Stress | 150명 | 38.3ms | 63.1ms | 0% |
| Spike | 200명 | 53.7ms | 103.2ms | 0% |
| Realistic | 200명 | 28.3ms | 44.1ms | 0% |

- 커넥션 풀 10 → 20 변경 시 오히려 성능 저하 확인 (RDS db.t3.micro CPU 병목)
- 현실적 사용 패턴(10~30초 타이핑 간격)에서는 동시 200명도 문제없음
- HikariCP pending은 비현실적 부하에서만 발생, 실제 사용 패턴에서는 0