### PR TITLE
feat: typo 수집 리팩토링, 통계 개선, 동의 배너, Privacy Policy 페이지

### DIFF
--- a/tp-react/src/App.jsx
+++ b/tp-react/src/App.jsx
@@ -13,6 +13,7 @@ import QuoteUpload from "./pages/QuoteUpload/QuoteUpload";
 import MyQuotes from "./pages/MyQuotes/MyQuotes";
 import MyReports from "./pages/MyReports/MyReports";
 import Stats from "./pages/Stats/Stats";
+import PrivacyPolicy from "./pages/PrivacyPolicy/PrivacyPolicy";
 import {Analytics} from "@vercel/analytics/react";
 
 function App() {
@@ -30,6 +31,7 @@ function App() {
                   <Route path="/quote/my" element={<MyQuotes />} />
                   <Route path="/quote/report" element={<MyReports />} />
                   <Route path="/stats" element={<Stats />} />
+                  <Route path="/privacy" element={<PrivacyPolicy />} />
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
                 <Contact />

--- a/tp-react/src/components/AppDiv/AppDiv.jsx
+++ b/tp-react/src/components/AppDiv/AppDiv.jsx
@@ -7,7 +7,7 @@ const AppDiv = ({ children }) => {
   const location = useLocation();
   
   // 상단 여백이 필요 없는 페이지
-  const isCompactPage = location.pathname.startsWith('/quote/') || location.pathname === '/stats';
+  const isCompactPage = location.pathname.startsWith('/quote/') || location.pathname === '/stats' || location.pathname === '/privacy';
   
   return (
     <div className={`background ${isDark ? "dark" : ""} ${isCompactPage ? "compact" : ""}`}>

--- a/tp-react/src/components/ConsentBanner/ConsentBanner.css
+++ b/tp-react/src/components/ConsentBanner/ConsentBanner.css
@@ -1,0 +1,67 @@
+.consent-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: rgba(0, 0, 0, 0.3);
+    backdrop-filter: blur(4px);
+    z-index: 9998;
+}
+
+.consent-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 1.25rem;
+    padding: 1.5rem 2rem;
+    background: var(--color-popup-bg);
+    border-top: 1px solid var(--color-border);
+    z-index: 9999;
+}
+
+.consent-text {
+    margin: 0;
+    font-size: 0.9375rem;
+    color: var(--color-text-muted);
+}
+
+.consent-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}
+
+.consent-btn {
+    padding: 0.5rem 1.25rem;
+    border-radius: 0.375rem;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.consent-btn-accept {
+    border: none;
+    background: var(--color-primary);
+    color: var(--color-white);
+}
+
+.consent-btn-accept:hover {
+    background: var(--color-primary-dark);
+}
+
+.consent-btn-reject {
+    border: 1px solid var(--color-border);
+    background: transparent;
+    color: var(--color-text-muted);
+}
+
+.consent-btn-reject:hover {
+    background: var(--color-bg-secondary);
+    color: var(--color-text);
+}

--- a/tp-react/src/components/ConsentBanner/ConsentBanner.jsx
+++ b/tp-react/src/components/ConsentBanner/ConsentBanner.jsx
@@ -1,0 +1,50 @@
+import {useState} from 'react';
+import {useTheme} from '../../Context/ThemeContext';
+import {Storage_Consent} from '@/const/config.const.ts';
+import './ConsentBanner.css';
+
+export const hasConsent = () => localStorage.getItem(Storage_Consent);
+
+function ConsentBanner({onAccept, onReject}) {
+    const {isDark} = useTheme();
+    const [visible, setVisible] = useState(() => !hasConsent());
+
+    if (!visible) return null;
+
+    const isKorean = navigator.language.startsWith('ko');
+
+    const handleAccept = () => {
+        localStorage.setItem(Storage_Consent, 'accepted');
+        setVisible(false);
+        if (onAccept) onAccept();
+    };
+
+    const handleReject = () => {
+        localStorage.setItem(Storage_Consent, 'rejected');
+        setVisible(false);
+        if (onReject) onReject();
+    };
+
+    return (
+        <>
+            <div className="consent-overlay"/>
+            <div className={`consent-banner ${isDark ? 'dark' : ''}`}>
+                <p className="consent-text">
+                    {isKorean
+                        ? '이 사이트는 설정 저장 및 익명 분석을 위해 로컬 저장소를 사용합니다.'
+                        : 'This site uses local storage for your preferences and anonymous analytics to improve the service.'}
+                </p>
+                <div className="consent-actions">
+                    <button className="consent-btn consent-btn-reject" onClick={handleReject}>
+                        {isKorean ? '거절' : 'Reject'}
+                    </button>
+                    <button className="consent-btn consent-btn-accept" onClick={handleAccept}>
+                        {isKorean ? '확인' : 'Accept'}
+                    </button>
+                </div>
+            </div>
+        </>
+    );
+}
+
+export default ConsentBanner;

--- a/tp-react/src/components/Contact/Contact.css
+++ b/tp-react/src/components/Contact/Contact.css
@@ -1,6 +1,12 @@
-.contact {
+.contact-wrapper {
     margin-top: auto;
     margin-bottom: 10rem;
+    display: flex;
+    gap: 1.25rem;
+    align-items: center;
+}
+
+.contact {
     text-decoration: none;
     color: var(--color-text-muted);
     font-size: 0.9rem;

--- a/tp-react/src/components/Contact/Contact.jsx
+++ b/tp-react/src/components/Contact/Contact.jsx
@@ -1,18 +1,24 @@
 import { useTheme } from "../../Context/ThemeContext";
+import { Link } from "react-router-dom";
 import "./Contact.css";
 
 const Contact = () => {
   const { isDark } = useTheme();
 
   return (
-    <a
-      href={"https://open.kakao.com/o/sMHDrAog"}
-      target="_blank"
-      rel="noopener noreferrer"
-      className={`contact ${isDark && "dark"}`}
-    >
-      Contact
-    </a>
+    <div className={`contact-wrapper ${isDark && "dark"}`}>
+      <a
+        href={"https://open.kakao.com/o/sMHDrAog"}
+        target="_blank"
+        rel="noopener noreferrer"
+        className={`contact ${isDark && "dark"}`}
+      >
+        Contact
+      </a>
+      <Link to="/privacy" className={`contact ${isDark && "dark"}`}>
+        Privacy Policy
+      </Link>
+    </div>
   );
 };
 

--- a/tp-react/src/const/config.const.ts
+++ b/tp-react/src/const/config.const.ts
@@ -7,6 +7,7 @@ export const Storage_Averages_Visible = "Typing-Practice-averagesVisible" as con
 export const Storage_Compact_Mode = "Typing-Practice-compactMode" as const;
 export const Storage_Last_Seen_Version = "Typing-Practice-lastSeenVersion" as const;
 export const Storage_Refresh_Token = "Typing-Practice-refreshToken" as const;
+export const Storage_Consent = "Typing-Practice-storageConsent" as const;
 
 // Quote 관련 상수
 export const MIN_SENTENCE_LENGTH = 5 as const;

--- a/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
+++ b/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
@@ -15,7 +15,7 @@ import {
 } from "@/const/key.const.js";
 import {RESET_COUNT_THRESHOLD_RATIO} from "@/const/config.const.ts";
 import {koreanSeparator} from "@/utils/koreanSeparator.ts";
-import {createTypoEntry} from "@/utils/typoUtils.ts";
+import {createFlatTypoEntry, isLanguageSwitchMistake} from "@/utils/typoUtils.ts";
 import {saveTypingRecord} from "@/utils/typingRecordApi.ts";
 import {areJamoEqual, calculateAccuracy, sum, average, max} from "./InputUtils";
 
@@ -56,6 +56,9 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
     const typedCharCount = useRef([]); // 타이핑한 character 수
     const maxInputLengthRef = useRef(0); // 현재 시도에서 도달한 최대 입력 길이
     const typosRef = useRef([]); // 오타 누적 배열
+    const flatSentenceRef = useRef([]); // 예문 flat 자모 배열
+    const flatInputRef = useRef([]); // 입력 flat 자모 배열
+    const maxCheckedFlatIndexRef = useRef(0); // 체크 완료한 최대 flat 인덱스
     const lastResetTimeRef = useRef(0); // resetCount 중복 증가 방지용 타임스탬프
 
     // resetCount를 안전하게 증가시키는 함수 (50ms 이내 중복 호출 무시)
@@ -66,13 +69,10 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
         setResetCount((prev) => prev + 1);
     };
 
-    // 오답 처리 + typo 기록
-    const markIncorrect = (prevCheck, charIndex, sentenceSeparated, inputSeparated) => {
+    // 오답 처리
+    const markIncorrect = (prevCheck, charIndex) => {
         prevCheck[charIndex] = "incorrect";
         setIncorrectCount((prev) => prev + 1);
-        typosRef.current.push(createTypoEntry(
-            sentence[charIndex], sentenceSeparated, inputSeparated, charIndex,
-        ));
     };
 
     // 문장 이동 (화살표 키)
@@ -101,6 +101,7 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
         separatedSentence.current = sentence.split("").map((character) => {
             return koreanSeparator(character);
         });
+        flatSentenceRef.current = separatedSentence.current.flat();
     }, [sentence]);
 
     // 타자 속도 계산
@@ -144,6 +145,8 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
 
         // 최대 입력 길이 리셋
         maxInputLengthRef.current = 0;
+        flatInputRef.current = [];
+        maxCheckedFlatIndexRef.current = 0;
 
         if (isSubmit) {
             return;
@@ -327,10 +330,30 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
         for (let i = 0; i < newValue.length; i++) {
             separatedInput.current[i] = koreanSeparator(newValue[i]);
         }
+        separatedInput.current.length = newValue.length;
 
         typedCharCount.current = separatedInput.current.map((char) => {
             return char.length;
         });
+
+        // flat 기반 typo 수집
+        const newFlatInput = separatedInput.current.flat();
+        const newLen = newFlatInput.length;
+
+        if (newLen > maxCheckedFlatIndexRef.current) {
+            // 이전에 체크하지 않은 인덱스만 비교
+            for (let i = maxCheckedFlatIndexRef.current; i < newLen; i++) {
+                const exp = flatSentenceRef.current[i];
+                const act = newFlatInput[i];
+                if (exp !== undefined && act !== undefined && exp !== act && !isLanguageSwitchMistake(act)) {
+                    typosRef.current.push(createFlatTypoEntry(
+                        i, exp, act, separatedSentence.current, sentence,
+                    ));
+                }
+            }
+            maxCheckedFlatIndexRef.current = newLen;
+        }
+        flatInputRef.current = newFlatInput;
 
         // 채점 로직 실행
         performGrading(newValue);
@@ -350,7 +373,7 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
 
                 if (!isChecked) {
                     // 채점되지 않은 경우 오답 처리
-                    markIncorrect(prevCheck, prevCharIndex, prevSentenceSeparated, prevInputSeparated);
+                    markIncorrect(prevCheck, prevCharIndex);
                 } else {
                     // 이미 채점된 경우 재채점 (받침 변화 등으로 인한 최종 확정)
                     const isFinalCorrect = areJamoEqual(prevInputSeparated, prevSentenceSeparated);
@@ -358,7 +381,7 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
                     // 이전에 정답이었는데 최종적으로 오답인 경우
                     if (prevCheck[prevCharIndex] === "correct" && !isFinalCorrect) {
                         setCorrectCount((prev) => prev - 1);
-                        markIncorrect(prevCheck, prevCharIndex, prevSentenceSeparated, prevInputSeparated);
+                        markIncorrect(prevCheck, prevCharIndex);
                     }
                     // 이전에 오답이었는데 최종적으로 정답인 경우 (거의 없지만 안전장치)
                     else if (prevCheck[prevCharIndex] === "incorrect" && isFinalCorrect) {
@@ -382,9 +405,6 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
                 );
 
                 // 입력 자모가 예문보다 많을 경우, 추가 자모가 다음 글자의 시작과 일치하는지 확인
-                let isExtraJamoMismatch = false;
-                let extraJamoMismatchInfo = null;
-
                 if (isCorrect && currentInputSeparated.length > currentSentenceSeparated.length) {
                     const extraJamo = currentInputSeparated.slice(currentSentenceSeparated.length);
                     const nextCharIndex = lastCharIndex + 1;
@@ -395,14 +415,6 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
                             extraJamo,
                             nextSentenceSeparated.slice(0, extraJamo.length),
                         );
-                        if (!isCorrect) {
-                            isExtraJamoMismatch = true;
-                            extraJamoMismatchInfo = {
-                                nextCharIndex,
-                                nextSentenceSeparated,
-                                extraJamo,
-                            };
-                        }
                     } else {
                         // 마지막 글자인데 추가 자모가 있으면 오답
                         isCorrect = false;
@@ -418,25 +430,6 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
                     if (prevCheck[lastCharIndex] !== "incorrect") {
                         prevCheck[lastCharIndex] = "incorrect";
                         setIncorrectCount((prev) => prev + 1);
-
-                        if (isExtraJamoMismatch && extraJamoMismatchInfo) {
-                            // 추가 자모 불일치: 다음 글자 기준으로 typo 기록
-                            const {nextCharIndex, nextSentenceSeparated, extraJamo} = extraJamoMismatchInfo;
-                            typosRef.current.push(createTypoEntry(
-                                sentence[nextCharIndex],
-                                nextSentenceSeparated,
-                                extraJamo,
-                                nextCharIndex,
-                            ));
-                        } else {
-                            // 일반 오답: 현재 글자 기준으로 typo 기록
-                            typosRef.current.push(createTypoEntry(
-                                sentence[lastCharIndex],
-                                currentSentenceSeparated,
-                                currentInputSeparated,
-                                lastCharIndex,
-                            ));
-                        }
                     }
                 }
             } else {
@@ -448,7 +441,7 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
 
                 if (!isPartialCorrect) {
                     if (prevCheck[lastCharIndex] !== "incorrect") {
-                        markIncorrect(prevCheck, lastCharIndex, currentSentenceSeparated, currentInputSeparated);
+                        markIncorrect(prevCheck, lastCharIndex);
                     }
                 } else {
                     prevCheck[lastCharIndex] = "none";

--- a/tp-react/src/pages/MyReports/components/ReportFilters.css
+++ b/tp-react/src/pages/MyReports/components/ReportFilters.css
@@ -10,19 +10,19 @@
 }
 
 .report-filter-btn {
-    padding: 0.5rem 1rem;
+    padding: 0.375rem 0.75rem;
     border: 1px solid var(--color-border);
     border-radius: 0.375rem;
     background-color: transparent;
-    color: var(--color-text-muted);
-    font-size: 0.875rem;
+    color: var(--color-text-placeholder);
+    font-size: 0.85rem;
     cursor: pointer;
     transition: all 0.2s;
 }
 
 .report-filter-btn:hover {
-    border-color: var(--color-text-muted);
-    color: var(--color-text);
+    border-color: var(--color-primary);
+    color: var(--color-primary);
 }
 
 .report-filter-btn.active {

--- a/tp-react/src/pages/PrivacyPolicy/PrivacyPolicy.css
+++ b/tp-react/src/pages/PrivacyPolicy/PrivacyPolicy.css
@@ -1,0 +1,87 @@
+.privacy-container {
+    width: 80%;
+    max-width: 800px;
+    min-width: 600px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+.privacy-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--color-primary);
+    margin: 0 0 0.25rem 0;
+}
+
+.privacy-updated {
+    font-size: 0.8125rem;
+    color: var(--color-text-placeholder);
+    margin: 0 0 2rem 0;
+}
+
+.privacy-section {
+    margin-bottom: 1.75rem;
+}
+
+.privacy-section h2 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0 0 0.5rem 0;
+}
+
+.privacy-section h3 {
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--color-text);
+    margin: 1rem 0 0.25rem 0;
+}
+
+.privacy-section p {
+    font-size: 0.875rem;
+    line-height: 1.7;
+    color: var(--color-text-muted);
+    margin: 0 0 0.5rem 0;
+}
+
+.privacy-section ul {
+    margin: 0.25rem 0 0.5rem 1.25rem;
+    padding: 0;
+}
+
+.privacy-section li {
+    font-size: 0.875rem;
+    line-height: 1.7;
+    color: var(--color-text-muted);
+}
+
+.privacy-section a {
+    color: var(--color-primary);
+    text-decoration: none;
+}
+
+.privacy-section a:hover {
+    text-decoration: underline;
+}
+
+.privacy-footer {
+    margin-top: 1.75rem;
+    display: flex;
+    justify-content: center;
+}
+
+.privacy-back-btn {
+    padding: 0.75rem 2rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    background-color: transparent;
+    color: var(--color-text-muted);
+    font-size: 1rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.privacy-back-btn:hover {
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text);
+}

--- a/tp-react/src/pages/PrivacyPolicy/PrivacyPolicy.jsx
+++ b/tp-react/src/pages/PrivacyPolicy/PrivacyPolicy.jsx
@@ -1,0 +1,117 @@
+import {useNavigate} from 'react-router-dom';
+import {useTheme} from '../../Context/ThemeContext';
+import './PrivacyPolicy.css';
+
+const isKorean = navigator.language.startsWith('ko');
+
+function PrivacyPolicy() {
+    const navigate = useNavigate();
+    const {isDark} = useTheme();
+
+    return (
+        <div className={`privacy-container ${isDark ? 'dark' : ''}`}>
+            <h1 className="privacy-title">{isKorean ? '개인정보 처리방침' : 'Privacy Policy'}</h1>
+            <p className="privacy-updated">{isKorean ? '최종 수정일: 2026년 3월 29일' : 'Last updated: March 29, 2026'}</p>
+
+            <section className="privacy-section">
+                <h2>{isKorean ? '1. 개요' : '1. Overview'}</h2>
+                <p>
+                    {isKorean
+                        ? 'Typing Practice는 무료 타이핑 연습 서비스입니다. 이 서비스는 사용자의 개인정보를 소중히 여기며, 수집하는 데이터의 종류, 목적, 처리 방식을 아래에 안내합니다.'
+                        : 'Typing Practice is a free typing practice service. We respect your privacy and are committed to protecting your personal data. This policy explains what data we collect, why, and how we handle it.'}
+                </p>
+            </section>
+
+            <section className="privacy-section">
+                <h2>{isKorean ? '2. 수집하는 데이터' : '2. Data We Collect'}</h2>
+                <h3>{isKorean ? '계정 정보' : 'Account Information'}</h3>
+                <p>
+                    {isKorean
+                        ? 'Google 로그인 시 Google OAuth를 통해 이름과 이메일 주소를 수신합니다. 이 정보는 인증 및 프로필 표시 목적으로만 사용됩니다.'
+                        : 'When you sign in with Google, we receive your name and email address from Google OAuth. We use this solely for authentication and displaying your profile.'}
+                </p>
+                <h3>{isKorean ? '타이핑 기록' : 'Typing Records'}</h3>
+                <p>
+                    {isKorean
+                        ? '로그인 상태에서 타이핑 결과(속도, 정확도, 초기화 횟수, 오타 패턴)를 서버에 저장합니다. 이 데이터는 개인 통계 및 진행 상황 추적에 사용됩니다.'
+                        : 'When you are logged in, we store your typing results including speed (CPM), accuracy, reset count, and typo patterns. This data is used to provide your personal statistics and track your progress.'}
+                </p>
+                <h3>{isKorean ? '사용자 등록 문장' : 'User-Submitted Sentences'}</h3>
+                <p>
+                    {isKorean
+                        ? '업로드한 문장은 서버에 저장되며, 다른 사용자의 타이핑 연습을 위해 공개될 수 있습니다.'
+                        : 'Sentences you upload are stored on our server and may be shared publicly for other users to practice with.'}
+                </p>
+                <h3>{isKorean ? '로컬 저장소' : 'Local Storage'}</h3>
+                <p>
+                    {isKorean
+                        ? '다크 모드, 글꼴 크기, 표시 설정 등의 환경설정을 브라우저의 로컬 저장소에 저장합니다. 이 데이터는 기기에만 남아 있으며 서버로 전송되지 않습니다.'
+                        : "We use your browser's local storage to save preferences such as dark mode, font size, and display settings. This data stays on your device and is never sent to our server."}
+                </p>
+            </section>
+
+            <section className="privacy-section">
+                <h2>{isKorean ? '3. 분석' : '3. Analytics'}</h2>
+                <p>
+                    {isKorean
+                        ? 'Vercel Web Analytics를 사용하여 익명의 집계 데이터를 수집합니다. 쿠키를 사용하지 않으며, 개인 식별 정보를 수집하지 않습니다. 방문자는 수신 요청에서 생성된 해시로 식별됩니다.'
+                        : 'We use Vercel Web Analytics, which collects anonymous, aggregated usage data. It does not use cookies and does not collect personally identifiable information. Visitors are identified by a hash generated from the incoming request.'}
+                </p>
+            </section>
+
+            <section className="privacy-section">
+                <h2>{isKorean ? '4. 데이터 사용 목적' : '4. How We Use Your Data'}</h2>
+                <p>{isKorean ? '수집한 데이터는 다음 목적으로만 사용됩니다:' : 'We use your data only for the following purposes:'}</p>
+                <ul>
+                    <li>{isKorean ? '계정 인증' : 'Authenticating your account'}</li>
+                    <li>{isKorean ? '개인 타이핑 통계 및 진행 상황 추적 제공' : 'Providing personalized typing statistics and progress tracking'}</li>
+                    <li>{isKorean ? '익명 사용 패턴을 기반으로 한 서비스 개선' : 'Improving the service based on anonymous usage patterns'}</li>
+                </ul>
+                <p>{isKorean
+                    ? '개인 데이터를 마케팅 목적으로 제3자에게 판매, 공유 또는 제공하지 않습니다.'
+                    : 'We do not sell, share, or provide your personal data to third parties for marketing purposes.'}</p>
+            </section>
+
+            <section className="privacy-section">
+                <h2>{isKorean ? '5. 데이터 보관' : '5. Data Retention'}</h2>
+                <p>
+                    {isKorean
+                        ? '타이핑 기록 및 계정 데이터는 계정이 활성 상태인 동안 보관됩니다. 문의를 통해 데이터 삭제를 요청할 수 있습니다.'
+                        : 'Your typing records and account data are retained as long as your account is active. You may request deletion of your data by contacting us.'}
+                </p>
+            </section>
+
+            <section className="privacy-section">
+                <h2>{isKorean ? '6. 사용자 권리' : '6. Your Rights'}</h2>
+                <p>{isKorean ? '사용자는 다음과 같은 권리를 갖습니다:' : 'You have the right to:'}</p>
+                <ul>
+                    <li>{isKorean ? '개인 데이터에 대한 접근' : 'Access your personal data'}</li>
+                    <li>{isKorean ? '데이터 수정 또는 삭제 요청' : 'Request correction or deletion of your data'}</li>
+                    <li>{isKorean ? '언제든지 동의 철회' : 'Withdraw consent at any time'}</li>
+                </ul>
+                <p>
+                    {isKorean
+                        ? <>권리 행사를 원하시면 <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">카카오톡</a>으로 문의해 주세요.</>
+                        : <>To exercise these rights, please contact us at <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">KakaoTalk</a>.</>}
+                </p>
+            </section>
+
+            <section className="privacy-section">
+                <h2>{isKorean ? '7. 방침 변경' : '7. Changes to This Policy'}</h2>
+                <p>
+                    {isKorean
+                        ? '이 방침은 수시로 업데이트될 수 있습니다. 변경 사항은 이 페이지에 수정 날짜와 함께 반영됩니다.'
+                        : 'We may update this policy from time to time. Changes will be reflected on this page with an updated date.'}
+                </p>
+            </section>
+
+            <div className="privacy-footer">
+                <button className="privacy-back-btn" onClick={() => navigate('/')}>
+                    {isKorean ? '돌아가기' : 'Back'}
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export default PrivacyPolicy;

--- a/tp-react/src/pages/Stats/components/StatsSummary.jsx
+++ b/tp-react/src/pages/Stats/components/StatsSummary.jsx
@@ -9,7 +9,10 @@ const formatTime = (min) => {
 
 const calcTrend = (recentAvg, totalAvg) => {
     if (!totalAvg || !recentAvg) return {text: '', className: ''};
-    const percent = ((recentAvg - totalAvg) / totalAvg * 100).toFixed(1);
+    const roundedRecent = Math.round(recentAvg);
+    const roundedTotal = Math.round(totalAvg);
+    if (roundedRecent === roundedTotal) return {text: '\u2014 0%', className: 'stats-trend neutral'};
+    const percent = ((roundedRecent - roundedTotal) / roundedTotal * 100).toFixed(1);
     if (percent > 0) return {text: '\u25B2 ' + percent + '%', className: 'stats-trend up'};
     if (percent < 0) return {text: '\u25BC ' + Math.abs(percent) + '%', className: 'stats-trend down'};
     return {text: '\u2014 0%', className: 'stats-trend neutral'};

--- a/tp-react/src/pages/Stats/components/TypoList.jsx
+++ b/tp-react/src/pages/Stats/components/TypoList.jsx
@@ -2,7 +2,11 @@ import {useState} from 'react';
 import {getTypoDetailStats} from '@/utils/statsApi.ts';
 import './TypoList.css';
 
-const displayChar = (ch) => ch === ' ' ? '\u2423' : ch;
+const displayChar = (ch) => {
+    if (ch === '') return '\u2205';
+    if (ch === ' ') return '\u2423';
+    return ch;
+};
 
 function TypoList({typoStats}) {
     const [selectedTypo, setSelectedTypo] = useState(null);

--- a/tp-react/src/utils/typoUtils.ts
+++ b/tp-react/src/utils/typoUtils.ts
@@ -9,6 +9,15 @@ const isKoreanChar = (character: string): boolean => {
 };
 
 /**
+ * 한/영 전환 실수 여부를 판별한다.
+ * actual이 영문자이면 오타가 아니라 한/영 전환 실수로 간주한다.
+ */
+export const isLanguageSwitchMistake = (actual: string): boolean => {
+    if (!actual) return false;
+    return /^[a-zA-Z]$/.test(actual);
+};
+
+/**
  * 한글 자모 분리 결과에서 자모 인덱스로 TypoType을 결정한다.
  * - 초성: index 0
  * - 중성: index 1 ~ (종성 시작 전)
@@ -69,30 +78,38 @@ export const determineTypoType = (
 };
 
 /**
- * 오타 엔트리를 생성한다.
+ * flat 자모 인덱스에서 오타 엔트리를 생성한다.
+ * 예문과 입력을 각각 flat 자모 배열로 비교하여 불일치 시 호출.
  */
-export const createTypoEntry = (
-    originalChar: string,
-    separatedSentence: string[],
-    separatedInput: string[],
-    position: number,
+export const createFlatTypoEntry = (
+    flatIndex: number,
+    expected: string,
+    actual: string,
+    separatedSentence: string[][],
+    sentence: string,
 ): TypoEntry => {
-    const type = determineTypoType(originalChar, separatedSentence, separatedInput);
-
-    // 불일치 자모 찾기
-    let expected = originalChar;
-    let actual = '';
-
-    const maxLen = Math.max(separatedSentence.length, separatedInput.length);
-    for (let i = 0; i < maxLen; i++) {
-        const exp = separatedSentence[i] ?? '';
-        const act = separatedInput[i] ?? '';
-        if (exp !== act) {
-            expected = exp || originalChar;
-            actual = act || '';
+    // flat index → charIndex, jamoIndex 계산
+    let accumulated = 0;
+    let charIndex = 0;
+    let jamoIndex = 0;
+    for (let i = 0; i < separatedSentence.length; i++) {
+        if (flatIndex < accumulated + separatedSentence[i].length) {
+            charIndex = i;
+            jamoIndex = flatIndex - accumulated;
             break;
         }
+        accumulated += separatedSentence[i].length;
     }
 
-    return {expected, actual, position, type};
+    const originalChar = sentence[charIndex];
+    let type: TypoType;
+    if (!isKoreanChar(originalChar)) {
+        type = 'LETTER';
+    } else {
+        const midIndex = getMidIndex(originalChar.charCodeAt(0));
+        const medialLength = getMedialLength(midIndex);
+        type = getTypoTypeByJamoIndex(jamoIndex, medialLength);
+    }
+
+    return {expected, actual, position: charIndex, type};
 };


### PR DESCRIPTION
- typo 수집을 flat 자모 비교 방식으로 변경 (채점 로직과 분리)
- IME 재조합 중복 방지 (maxCheckedFlatIndexRef)
- 한/영 전환 실수 및 actual 빈 문자열 typo 수집 제외
- 종합 통계 증감률 정수 반올림 후 비교
- 신고 내역 필터 버튼 크기 통일
- 동의 배너 컴포넌트 추가 (미사용 상태)
- Privacy Policy 페이지 및 /privacy 라우트 추가
- Contact 영역에 Privacy Policy 링크 추가
- 브라우저 언어에 따른 한국어/영어 전환 (Privacy Policy, 동의 배너)