### PR TITLE
feat: i18n 유틸리티 추가 및 전체 UI 국제화 적용

### DIFF
--- a/tp-react/src/Context/ErrorContext.tsx
+++ b/tp-react/src/Context/ErrorContext.tsx
@@ -1,6 +1,7 @@
 import {createContext, ReactNode, useContext, useState} from 'react';
 import {FaExclamationCircle} from 'react-icons/fa';
 import {useTheme} from './ThemeContext';
+import {t} from '../utils/i18n';
 
 interface ErrorContextType {
     showError: (message: string) => void;
@@ -45,7 +46,7 @@ export const ErrorProvider = ({children}: ErrorProviderProps) => {
                             <FaExclamationCircle/>
                         </div>
                         <p className="error-popup-message">{errorMessage}</p>
-                        <button className="error-popup-btn" onClick={clearError}>확인</button>
+                        <button className="error-popup-btn" onClick={clearError}>{t('errorConfirm')}</button>
                     </div>
                 </div>
             )}

--- a/tp-react/src/Context/QuoteContext.tsx
+++ b/tp-react/src/Context/QuoteContext.tsx
@@ -4,6 +4,7 @@ import {useAuth} from "./AuthContext";
 import {useError} from "./ErrorContext";
 import {getQuotes} from "../utils/quoteApi";
 import {defaultQuotes} from "../const/default-quotes.const";
+import {t} from "../utils/i18n";
 
 interface Quote {
     quoteId?: number;
@@ -150,7 +151,7 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
                 console.log('서버 연결 실패 - 로컬 문장 사용');
                 loadFallbackQuotes();
             } else {
-                showError('문장을 불러오는데 실패했습니다.');
+                showError(t('sentenceLoadFailed'));
                 if (reset) {
                     setIsEmpty(true);
                 }

--- a/tp-react/src/components/ConfirmPopup/ConfirmPopup.jsx
+++ b/tp-react/src/components/ConfirmPopup/ConfirmPopup.jsx
@@ -1,7 +1,8 @@
 import {useTheme} from '../../Context/ThemeContext';
+import {t} from '@/utils/i18n.ts';
 import './ConfirmPopup.css';
 
-const ConfirmPopup = ({message, onConfirm, onCancel, confirmText = '확인', cancelText = '취소', isDanger = false, showCancel = true}) => {
+const ConfirmPopup = ({message, onConfirm, onCancel, confirmText = t('confirm'), cancelText = t('cancel'), isDanger = false, showCancel = true}) => {
     const {isDark} = useTheme();
     
     return (

--- a/tp-react/src/components/Head/Head.jsx
+++ b/tp-react/src/components/Head/Head.jsx
@@ -13,6 +13,7 @@ import {useError} from "../../Context/ErrorContext";
 import {useGoogleLogin} from "@react-oauth/google";
 import {loginWithGoogle} from "@/utils/authApi.ts";
 import {FaPlus} from "react-icons/fa";
+import {t} from "@/utils/i18n.ts";
 import "./Head.css";
 
 // UUID 형식 체크 함수
@@ -66,13 +67,13 @@ const Head = () => {
                 setIsLoading(false);
             } catch (error) {
                 console.error('로그인 실패:', error);
-                showError('로그인에 실패했습니다. 다시 시도해주세요.');
+                showError(t('loginFailed'));
                 setIsLoading(false);
             }
         },
         onError: (error) => {
             console.error('구글 로그인 실패:', error);
-            showError('구글 로그인에 실패했습니다.');
+            showError(t('googleLoginFailed'));
         },
     });
 
@@ -114,7 +115,7 @@ const Head = () => {
                         }}
                     >
                         <FaPlus/>
-                        <span>문장 업로드</span>
+                        <span>{t('uploadSentence')}</span>
                     </button>
                     {user ? <ProfileDropdown/> : <LoginButton onClick={handleLogin}/>}
                     <DarkModeButton/>
@@ -130,7 +131,7 @@ const Head = () => {
             )}
             {showLoginPopup && (
                 <LoginRequiredPopup
-                    message="문장을 업로드하려면 로그인이 필요합니다."
+                    message={t('uploadLoginRequired')}
                     onClose={() => setShowLoginPopup(false)}
                 />
             )}

--- a/tp-react/src/components/LoginButton/LoginButton.jsx
+++ b/tp-react/src/components/LoginButton/LoginButton.jsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import {FaGoogle} from 'react-icons/fa';
+import {t} from '@/utils/i18n.ts';
 import './LoginButton.css';
 
 const LoginButton = ({onClick}) => {
     return (
         <button className="header-btn" onClick={onClick}>
             <FaGoogle />
-            <span>구글 로그인</span>
+            <span>{t('googleLogin')}</span>
         </button>
     );
 };

--- a/tp-react/src/components/LoginRequiredPopup/LoginRequiredPopup.jsx
+++ b/tp-react/src/components/LoginRequiredPopup/LoginRequiredPopup.jsx
@@ -1,6 +1,7 @@
 import {FaExclamationCircle, FaGoogle} from 'react-icons/fa';
 import {useTheme} from '../../Context/ThemeContext';
 import {useAuth} from '../../Context/AuthContext';
+import {t} from '@/utils/i18n.ts';
 import './LoginRequiredPopup.css';
 
 const LoginRequiredPopup = ({message, onClose}) => {
@@ -29,13 +30,13 @@ const LoginRequiredPopup = ({message, onClose}) => {
                         onClick={handleLogin}
                     >
                         <FaGoogle/>
-                        <span>구글 로그인</span>
+                        <span>{t('googleLogin')}</span>
                     </button>
                     <button
                         className={`login-required-cancel-btn ${isDark ? 'dark' : ''}`}
                         onClick={onClose}
                     >
-                        취소
+                        {t('cancel')}
                     </button>
                 </div>
             </div>

--- a/tp-react/src/components/NicknamePopup/NicknamePopup.jsx
+++ b/tp-react/src/components/NicknamePopup/NicknamePopup.jsx
@@ -1,6 +1,7 @@
 import React, {useState} from 'react';
 import {useTheme} from '../../Context/ThemeContext';
-import {checkNickname, updateNickname} from '../../utils/authApi';
+import {checkNickname, updateNickname} from '@/utils/authApi.ts';
+import {t} from '@/utils/i18n.ts';
 import './NicknamePopup.css';
 
 // UUID 형식 체크 함수
@@ -25,7 +26,7 @@ const NicknamePopup = ({initialNickname, onSubmit}) => {
 
         // 유효성 검증
         if (trimmedNickname.length < 2 || trimmedNickname.length > 10) {
-            setError('닉네임은 2-10자여야 합니다.');
+            setError(t('nicknameLength'));
             return;
         }
 
@@ -36,7 +37,7 @@ const NicknamePopup = ({initialNickname, onSubmit}) => {
             const isDuplicate = await checkNickname(trimmedNickname);
 
             if (isDuplicate) {
-                setError('이미 사용 중인 닉네임입니다.');
+                setError(t('nicknameDuplicate'));
                 setIsNicknameAvailable(false);
                 setLastCheckedNickname(''); // 실패 시 초기화
             } else {
@@ -45,7 +46,7 @@ const NicknamePopup = ({initialNickname, onSubmit}) => {
                 setLastCheckedNickname(trimmedNickname); // 통과한 닉네임 저장
             }
         } catch (err) {
-            const errorMessage = err.response?.data?.detail || err.response?.data?.message || '중복 확인에 실패했습니다.';
+            const errorMessage = err.response?.data?.detail || err.response?.data?.message || t('nicknameCheckFailed');
             setError(errorMessage);
             setIsNicknameAvailable(false);
             setLastCheckedNickname(''); // 에러 시 초기화
@@ -56,14 +57,14 @@ const NicknamePopup = ({initialNickname, onSubmit}) => {
 
     const handleSubmit = async () => {
         if (!isNicknameAvailable) {
-            setError('닉네임 중복 확인을 먼저 해주세요.');
+            setError(t('nicknameCheckFirst'));
             return;
         }
 
         const trimmedNickname = nickname.trim();
 
         if (trimmedNickname.length < 2 || trimmedNickname.length > 10) {
-            setError('닉네임은 2-10자여야 합니다.');
+            setError(t('nicknameLength'));
             return;
         }
 
@@ -73,7 +74,7 @@ const NicknamePopup = ({initialNickname, onSubmit}) => {
             onSubmit(trimmedNickname);
         } catch (err) {
             // axios 에러 메시지 파싱
-            const errorMessage = err.response?.data?.detail || err.response?.data?.message || err.message || '닉네임 설정에 실패했습니다.';
+            const errorMessage = err.response?.data?.detail || err.response?.data?.message || err.message || t('nicknameSetFailed');
             setError(errorMessage);
         } finally {
             setIsSubmitting(false);
@@ -105,9 +106,9 @@ const NicknamePopup = ({initialNickname, onSubmit}) => {
     return (
         <div className="nickname-popup-overlay">
             <div className={`nickname-popup ${isDark ? 'dark' : ''}`}>
-                <h2 className="nickname-popup-title">환영합니다! 🎉</h2>
+                <h2 className="nickname-popup-title">{t('welcome')}</h2>
                 <p className={`nickname-popup-description ${isDark ? 'dark' : ''}`}>
-                    닉네임을 설정해주세요. (2-10자)
+                    {t('setNickname')}
                 </p>
                 <div className="nickname-input-group">
                     <div className="nickname-input-wrapper">
@@ -115,7 +116,7 @@ const NicknamePopup = ({initialNickname, onSubmit}) => {
                             type="text"
                             className={`nickname-input ${isDark ? 'dark' : ''}`}
                             id="nicknameInput"
-                            placeholder="닉네임 입력"
+                            placeholder={t('nicknamePlaceholder')}
                             maxLength={10}
                             value={nickname}
                             onChange={handleInputChange}
@@ -125,15 +126,15 @@ const NicknamePopup = ({initialNickname, onSubmit}) => {
                             onClick={handleCheckNickname}
                             disabled={isChecking || !isCheckButtonEnabled}
                         >
-                            {isChecking ? '확인 중...' : '중복확인'}
+                            {isChecking ? t('checking') : t('checkDuplicate')}
                         </button>
                     </div>
                     {error && <div className="nickname-error show">{error}</div>}
                     {isNicknameAvailable && !error && (
-                        <div className="nickname-success">사용 가능한 닉네임입니다.</div>
+                        <div className="nickname-success">{t('nicknameAvailable')}</div>
                     )}
                     <div className={`nickname-helper ${isDark ? 'dark' : ''}`}>
-                        한글, 영문, 숫자 사용 가능
+                        {t('nicknameHelper')}
                     </div>
                 </div>
                 <button
@@ -141,7 +142,7 @@ const NicknamePopup = ({initialNickname, onSubmit}) => {
                     onClick={handleSubmit}
                     disabled={isSubmitting || !isNicknameAvailable}
                 >
-                    {isSubmitting ? '설정 중...' : '시작하기'}
+                    {isSubmitting ? t('setting') : t('start')}
                 </button>
             </div>
         </div>

--- a/tp-react/src/components/ProfileDropdown/ProfileDropdown.jsx
+++ b/tp-react/src/components/ProfileDropdown/ProfileDropdown.jsx
@@ -2,10 +2,10 @@ import React, {useEffect, useRef, useState} from 'react';
 import {useNavigate} from 'react-router-dom';
 import {useTheme} from '../../Context/ThemeContext';
 import {useAuth} from '../../Context/AuthContext';
-import {useError} from '../../Context/ErrorContext';
 import {logout as logoutApi} from '../../utils/authApi';
 import ProfilePopup from '../ProfilePopup/ProfilePopup';
 import {FaChartBar, FaChevronDown, FaCog, FaFileAlt, FaFlag, FaSignOutAlt, FaUser} from 'react-icons/fa';
+import {t} from '@/utils/i18n.ts';
 import './ProfileDropdown.css';
 
 // UUID 형식 체크 함수
@@ -19,7 +19,7 @@ const ProfileDropdown = () => {
     const navigate = useNavigate();
     const {isDark} = useTheme();
     const {user, logout} = useAuth();
-    const {showError} = useError();
+    //const {showError} = useError();
     const [isOpen, setIsOpen] = useState(false);
     const [showProfilePopup, setShowProfilePopup] = useState(false);
     const dropdownRef = useRef(null);
@@ -80,7 +80,7 @@ const ProfileDropdown = () => {
                     onClick={toggleDropdown}
                 >
                     <FaUser/>
-                    <span>{isUuidFormat(user?.nickname) ? '닉네임 설정' : (user?.nickname || '사용자')}</span>
+                    <span>{isUuidFormat(user?.nickname) ? t('setNicknameBtn') : (user?.nickname || t('user'))}</span>
                     <FaChevronDown style={{fontSize: '0.7rem'}}/>
                 </button>
 
@@ -91,28 +91,28 @@ const ProfileDropdown = () => {
                             onClick={() => handleMenuClick('my-sentences')}
                         >
                             <FaFileAlt/>
-                            <span>내 문장</span>
+                            <span>{t('mySentences')}</span>
                         </button>
                         <button
                             className={`dropdown-item ${isDark ? 'dark' : ''}`}
                             onClick={() => handleMenuClick('stats')}
                         >
                             <FaChartBar/>
-                            <span>기록</span>
+                            <span>{t('records')}</span>
                         </button>
                         <button
                             className={`dropdown-item ${isDark ? 'dark' : ''}`}
                             onClick={() => handleMenuClick('settings')}
                         >
                             <FaCog/>
-                            <span>프로필</span>
+                            <span>{t('profile')}</span>
                         </button>
                         <button
                             className={`dropdown-item ${isDark ? 'dark' : ''}`}
                             onClick={() => handleMenuClick('my-reports')}
                         >
                             <FaFlag/>
-                            <span>신고 내역</span>
+                            <span>{t('reportHistory')}</span>
                         </button>
                         <div className={`dropdown-divider ${isDark ? 'dark' : ''}`}></div>
                         <button
@@ -120,7 +120,7 @@ const ProfileDropdown = () => {
                             onClick={() => handleMenuClick('logout')}
                         >
                             <FaSignOutAlt/>
-                            <span>로그아웃</span>
+                            <span>{t('logout')}</span>
                         </button>
                     </div>
                 )}

--- a/tp-react/src/components/ProfilePopup/ProfilePopup.jsx
+++ b/tp-react/src/components/ProfilePopup/ProfilePopup.jsx
@@ -2,6 +2,7 @@ import React, {useEffect, useState} from 'react';
 import {useTheme} from '../../Context/ThemeContext';
 import {useAuth} from '../../Context/AuthContext';
 import {checkNickname, getMyInfo, updateNickname} from '@/utils/authApi.ts';
+import {t} from '@/utils/i18n.ts';
 import './ProfilePopup.css';
 
 // UUID 형식 체크 함수
@@ -36,7 +37,7 @@ const ProfilePopup = ({onClose}) => {
                 setProfile(data);
                 setNickname(isUuidFormat(data.nickname) ? '' : data.nickname);
             } catch (err) {
-                setError('프로필을 불러오는데 실패했습니다.');
+                setError(t('profileLoadFailed'));
             } finally {
                 setIsLoadingProfile(false);
             }
@@ -51,7 +52,7 @@ const ProfilePopup = ({onClose}) => {
         const trimmedNickname = nickname.trim();
 
         if (trimmedNickname.length < 2 || trimmedNickname.length > 10) {
-            setError('닉네임은 2-10자여야 합니다.');
+            setError(t('nicknameLength'));
             return;
         }
 
@@ -62,7 +63,7 @@ const ProfilePopup = ({onClose}) => {
             const isDuplicate = await checkNickname(trimmedNickname);
 
             if (isDuplicate) {
-                setError('이미 사용 중인 닉네임입니다.');
+                setError(t('nicknameDuplicate'));
                 setIsNicknameAvailable(false);
                 setCheckedNickname('');
             } else {
@@ -71,7 +72,7 @@ const ProfilePopup = ({onClose}) => {
                 setCheckedNickname(trimmedNickname);
             }
         } catch (err) {
-            const errorMessage = err.response?.data?.detail || err.response?.data?.message || '중복 확인에 실패했습니다.';
+            const errorMessage = err.response?.data?.detail || err.response?.data?.message || t('nicknameCheckFailed');
             setError(errorMessage);
             setIsNicknameAvailable(false);
             setCheckedNickname('');
@@ -82,14 +83,14 @@ const ProfilePopup = ({onClose}) => {
 
     const handleSave = async () => {
         if (!isNicknameAvailable) {
-            setError('닉네임 중복 확인을 먼저 해주세요.');
+            setError(t('nicknameCheckFirst'));
             return;
         }
 
         const trimmedNickname = nickname.trim();
 
         if (trimmedNickname.length < 2 || trimmedNickname.length > 10) {
-            setError('닉네임은 2-10자여야 합니다.');
+            setError(t('nicknameLength'));
             return;
         }
 
@@ -108,7 +109,7 @@ const ProfilePopup = ({onClose}) => {
 
             onClose();
         } catch (err) {
-            const errorMessage = err.response?.data?.detail || err.response?.data?.message || err.message || '닉네임 수정에 실패했습니다.';
+            const errorMessage = err.response?.data?.detail || err.response?.data?.message || err.message || t('nicknameEditFailed');
             setError(errorMessage);
         } finally {
             setIsSaving(false);
@@ -138,7 +139,7 @@ const ProfilePopup = ({onClose}) => {
         return (
             <div className="profile-popup-overlay" onClick={onClose}>
                 <div className={`profile-popup ${isDark ? 'dark' : ''}`} onClick={(e) => e.stopPropagation()}>
-                    <div className="profile-loading">로딩 중...</div>
+                    <div className="profile-loading">{t('loading')}</div>
                 </div>
             </div>
         );
@@ -147,21 +148,21 @@ const ProfilePopup = ({onClose}) => {
     return (
         <div className="profile-popup-overlay" onClick={onClose}>
             <div className={`profile-popup ${isDark ? 'dark' : ''}`} onClick={(e) => e.stopPropagation()}>
-                <h2 className="profile-popup-title">프로필</h2>
+                <h2 className="profile-popup-title">{t('profile')}</h2>
 
                 <div className="profile-content">
                     <div className="profile-section">
-                        <label className={`profile-label ${isDark ? 'dark' : ''}`}>이메일</label>
+                        <label className={`profile-label ${isDark ? 'dark' : ''}`}>{t('email')}</label>
                         <div className={`profile-value ${isDark ? 'dark' : ''}`}>{profile?.email || '-'}</div>
                     </div>
 
                     <div className="profile-section">
-                        <label className={`profile-label ${isDark ? 'dark' : ''}`}>닉네임</label>
+                        <label className={`profile-label ${isDark ? 'dark' : ''}`}>{t('nickname')}</label>
                         <div className="nickname-input-wrapper">
                             <input
                                 type="text"
                                 className={`profile-input ${isDark ? 'dark' : ''}`}
-                                placeholder="닉네임 입력"
+                                placeholder={t('nicknamePlaceholder')}
                                 maxLength={10}
                                 value={nickname}
                                 onChange={handleInputChange}
@@ -172,18 +173,18 @@ const ProfilePopup = ({onClose}) => {
                                     onClick={handleCheckNickname}
                                     disabled={isChecking || !isCheckButtonEnabled}
                                 >
-                                    {isChecking ? '확인 중...' : '중복확인'}
+                                    {isChecking ? t('checking') : t('checkDuplicate')}
                                 </button>
                             )}
                         </div>
                         {error && <div className="profile-error">{error}</div>}
                         {isNicknameAvailable && !error && (
-                            <div className="profile-success">사용 가능한 닉네임입니다.</div>
+                            <div className="profile-success">{t('nicknameAvailable')}</div>
                         )}
                     </div>
 
                     <div className="profile-section">
-                        <label className={`profile-label ${isDark ? 'dark' : ''}`}>가입일</label>
+                        <label className={`profile-label ${isDark ? 'dark' : ''}`}>{t('joinDate')}</label>
                         <div className={`profile-value ${isDark ? 'dark' : ''}`}>
                             {profile?.createdAt ? new Date(profile.createdAt).toLocaleDateString() : '-'}
                         </div>
@@ -196,13 +197,13 @@ const ProfilePopup = ({onClose}) => {
                         onClick={handleSave}
                         disabled={!isNicknameChanged || !isNicknameAvailable || isSaving}
                     >
-                        {isSaving ? '저장 중...' : '저장하기'}
+                        {isSaving ? t('saving') : t('saveChanges')}
                     </button>
                     <button
                         className={`profile-btn profile-btn-close ${isDark ? 'dark' : ''}`}
                         onClick={onClose}
                     >
-                        닫기
+                        {t('close')}
                     </button>
                 </div>
             </div>

--- a/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
+++ b/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
@@ -17,6 +17,7 @@ import {RESET_COUNT_THRESHOLD_RATIO} from "@/const/config.const.ts";
 import {koreanSeparator} from "@/utils/koreanSeparator.ts";
 import {createFlatTypoEntry, isLanguageSwitchMistake} from "@/utils/typoUtils.ts";
 import {saveTypingRecord} from "@/utils/typingRecordApi.ts";
+import {t} from "@/utils/i18n.ts";
 import {areJamoEqual, calculateAccuracy, sum, average, max} from "./InputUtils";
 
 const Input = ({onInputChange: onInputChangeCallback}) => {
@@ -459,7 +460,7 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
 
     const preventPaste = (e) => {
         e.preventDefault();
-        showError("붙여넣기가 금지되어 있습니다!");
+        showError(t('pasteBlocked'));
     };
 
     return (
@@ -471,7 +472,7 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
             spellCheck={false}
             value={input}
             rows={1}
-            placeholder={isCompactMode ? "" : "위 문장을 입력하세요."}
+            placeholder={isCompactMode ? "" : t('inputPlaceholder')}
             onInput={onInputChange}
             onKeyDown={handleKeyDown}
             onPaste={preventPaste}

--- a/tp-react/src/pages/Home/components/Quote/QuoteEmpty/QuoteEmpty.jsx
+++ b/tp-react/src/pages/Home/components/Quote/QuoteEmpty/QuoteEmpty.jsx
@@ -3,6 +3,7 @@ import {FaFileCircleQuestion, FaPlus} from 'react-icons/fa6';
 import './QuoteEmpty.css';
 import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useQuote} from "@/Context/QuoteContext.tsx";
+import {t} from "@/utils/i18n.ts";
 
 const QuoteEmpty = () => {
     const navigate = useNavigate();
@@ -12,14 +13,14 @@ const QuoteEmpty = () => {
     return (
         <div className={`quote-empty ${isDark ? 'dark' : ''}`}>
             <FaFileCircleQuestion/>
-            <p>등록된 문장이 없습니다.</p>
+            <p>{t('noSentences')}</p>
             {quoteSource === 'my' && (
                 <button
                     className="quote-empty-upload-btn"
                     onClick={() => navigate('/quote/upload')}
                 >
                     <FaPlus/>
-                    <span>문장 업로드</span>
+                    <span>{t('uploadSentence')}</span>
                 </button>
             )}
         </div>

--- a/tp-react/src/pages/Home/components/Quote/QuoteLoading/QuoteLoading.jsx
+++ b/tp-react/src/pages/Home/components/Quote/QuoteLoading/QuoteLoading.jsx
@@ -1,5 +1,6 @@
 import './QuoteLoading.css';
 import {useTheme} from "@/Context/ThemeContext.tsx";
+import {t} from "@/utils/i18n.ts";
 
 const QuoteLoading = () => {
     const {isDark} = useTheme();
@@ -7,7 +8,7 @@ const QuoteLoading = () => {
     return (
         <div className={`quote-loading ${isDark ? 'dark' : ''}`}>
             <div className="quote-loading-spinner"></div>
-            <span>문장을 불러오는 중...</span>
+            <span>{t('loadingSentences')}</span>
         </div>
     );
 };

--- a/tp-react/src/pages/Home/components/Quote/QuoteMoreMenu/QuoteMoreMenu.jsx
+++ b/tp-react/src/pages/Home/components/Quote/QuoteMoreMenu/QuoteMoreMenu.jsx
@@ -5,6 +5,7 @@ import './QuoteMoreMenu.css';
 import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useAuth} from "@/Context/AuthContext.tsx";
 import {useQuote} from "@/Context/QuoteContext.tsx";
+import {t} from "@/utils/i18n.ts";
 import LoginRequiredPopup from "@/components/LoginRequiredPopup/LoginRequiredPopup.jsx";
 
 const QuoteMoreMenu = () => {
@@ -74,7 +75,7 @@ const QuoteMoreMenu = () => {
                             onClick={handleReportClick}
                         >
                             <FaFlag/>
-                            <span>신고</span>
+                            <span>{t('report')}</span>
                         </button>
                     </div>
                 )}
@@ -82,7 +83,7 @@ const QuoteMoreMenu = () => {
 
             {showLoginPopup && (
                 <LoginRequiredPopup
-                    message="문장을 신고하려면 로그인이 필요합니다."
+                    message={t('reportLoginRequired')}
                     onClose={() => setShowLoginPopup(false)}
                 />
             )}

--- a/tp-react/src/pages/Home/components/Quote/QuoteSourceSelector/QuoteSourceSelector.jsx
+++ b/tp-react/src/pages/Home/components/Quote/QuoteSourceSelector/QuoteSourceSelector.jsx
@@ -3,6 +3,7 @@ import {FaGlobe, FaUser} from 'react-icons/fa';
 import './QuoteSourceSelector.css';
 import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useQuote} from "@/Context/QuoteContext.tsx";
+import {t} from "@/utils/i18n.ts";
 import LoginRequiredPopup from "@/components/LoginRequiredPopup/LoginRequiredPopup.jsx";
 
 const QuoteSourceSelector = () => {
@@ -29,20 +30,20 @@ const QuoteSourceSelector = () => {
                     onClick={handleAllClick}
                 >
                     <FaGlobe/>
-                    <span>전체 문장</span>
+                    <span>{t('allSentences')}</span>
                 </button>
                 <button
                     className={`quote-source-btn ${quoteSource === 'my' ? 'active' : ''} ${isDark ? 'dark' : ''}`}
                     onClick={handleMyClick}
                 >
                     <FaUser/>
-                    <span>내 문장만</span>
+                    <span>{t('mySentencesOnly')}</span>
                 </button>
             </div>
 
             {showLoginPopup && (
                 <LoginRequiredPopup
-                    message="내 문장을 사용하려면 로그인이 필요합니다."
+                    message={t('mySentencesLoginRequired')}
                     onClose={() => setShowLoginPopup(false)}
                 />
             )}

--- a/tp-react/src/pages/Home/components/ReportPopup/ReportPopup.jsx
+++ b/tp-react/src/pages/Home/components/ReportPopup/ReportPopup.jsx
@@ -5,11 +5,12 @@ import ReportReasonOption from './ReportReasonOption';
 import './ReportPopup.css';
 import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useError} from "@/Context/ErrorContext.tsx";
+import {t} from "@/utils/i18n.ts";
 import {createReport} from "@/utils/reportApi.ts";
 
 const REASON_OPTIONS = [
-    {value: 'MODIFY', title: '수정 요청', description: '오타, 맞춤법 오류 등'},
-    {value: 'DELETE', title: '삭제 요청', description: '부적절한 내용, 저작권 위반 등'},
+    {value: 'MODIFY', title: t('reportModify'), description: t('reportModifyDesc')},
+    {value: 'DELETE', title: t('reportDelete'), description: t('reportDeleteDesc')},
 ];
 
 const DETAIL_MAX_LENGTH = 120;
@@ -40,7 +41,7 @@ const ReportPopup = ({quote, onClose, onSuccess}) => {
             onClose();
         } catch (error) {
             console.error('신고 실패:', error);
-            const message = error.response?.data?.detail || '신고 접수에 실패했습니다.';
+            const message = error.response?.data?.detail || t('reportFailed');
             showError(message);
         } finally {
             setIsSubmitting(false);
@@ -58,14 +59,14 @@ const ReportPopup = ({quote, onClose, onSuccess}) => {
         <div className="report-popup-overlay" onClick={handleOverlayClick}>
             <div className={`report-popup ${isDark ? 'dark' : ''}`}>
                 <div className="report-popup-header">
-                    <h3 className="report-popup-title">문장 신고</h3>
+                    <h3 className="report-popup-title">{t('reportSentence')}</h3>
                     <button className="report-popup-close-btn" onClick={onClose}>
                         <FaXmark/>
                     </button>
                 </div>
 
                 <div className={`report-quote-preview ${isDark ? 'dark' : ''}`}>
-                    <span className="report-quote-label">신고 대상</span>
+                    <span className="report-quote-label">{t('reportTarget')}</span>
                     <p className="report-quote-sentence">{quote.sentence}</p>
                     {quote.author && (
                         <span className="report-quote-author">- {quote.author}</span>
@@ -73,7 +74,7 @@ const ReportPopup = ({quote, onClose, onSuccess}) => {
                 </div>
 
                 <div className="report-reason-section">
-                    <span className={`report-section-label ${isDark ? 'dark' : ''}`}>신고 사유</span>
+                    <span className={`report-section-label ${isDark ? 'dark' : ''}`}>{t('reportReason')}</span>
                     <div className="report-reason-options">
                         {REASON_OPTIONS.map((option) => (
                             <ReportReasonOption
@@ -90,12 +91,12 @@ const ReportPopup = ({quote, onClose, onSuccess}) => {
 
                 <div className="report-detail-section">
                     <label className={`report-section-label ${isDark ? 'dark' : ''}`} htmlFor="reportDetail">
-                        상세 설명 <span className="report-optional">(선택)</span>
+                        {t('reportDetail')} <span className="report-optional">({t('optional')})</span>
                     </label>
                     <textarea
                         id="reportDetail"
                         className={`report-detail-input ${isDark ? 'dark' : ''}`}
-                        placeholder="신고 사유를 자세히 설명해주세요."
+                        placeholder={t('reportDetailPlaceholder')}
                         maxLength={DETAIL_MAX_LENGTH}
                         rows={3}
                         value={detail}
@@ -112,7 +113,7 @@ const ReportPopup = ({quote, onClose, onSuccess}) => {
                         onClick={onClose}
                         disabled={isSubmitting}
                     >
-                        취소
+                        {t('cancel')}
                     </button>
                     <button
                         className="report-submit-btn"
@@ -120,7 +121,7 @@ const ReportPopup = ({quote, onClose, onSuccess}) => {
                         disabled={isSubmitting}
                     >
                         <FaFlag/>
-                        <span>{isSubmitting ? '신고 중...' : '신고'}</span>
+                        <span>{isSubmitting ? t('reporting') : t('report')}</span>
                     </button>
                 </div>
             </div>

--- a/tp-react/src/pages/MyQuotes/MyQuotes.jsx
+++ b/tp-react/src/pages/MyQuotes/MyQuotes.jsx
@@ -4,6 +4,7 @@ import {FaFileCircleQuestion} from 'react-icons/fa6';
 import {useAuth} from '../../Context/AuthContext';
 import {useError} from '../../Context/ErrorContext';
 import {cancelPublishQuote, deleteQuote, getMyQuotes, publishQuote, updateQuote, extractQuoteErrorMessage} from '@/utils/quoteApi.ts';
+import {t} from '@/utils/i18n.ts';
 import QuoteCard from './components/QuoteCard';
 import QuoteFilters from './components/QuoteFilters';
 import QuoteEditPopup from './components/QuoteEditPopup';
@@ -131,7 +132,7 @@ function MyQuotes() {
             setEditingQuote(null);
         } catch (error) {
             console.error('문장 수정 실패:', error);
-            showError(extractQuoteErrorMessage(error, '내 문장 내에 유사한 문장이 존재합니다.', '문장 수정에 실패했습니다.'));
+            showError(extractQuoteErrorMessage(error, t('similarMy'), t('editSentenceFailed')));
         }
     };
 
@@ -150,7 +151,7 @@ function MyQuotes() {
             }
         } catch (error) {
             console.error('문장 삭제 실패:', error);
-            const message = error.response?.data?.detail || '문장 삭제에 실패했습니다.';
+            const message = error.response?.data?.detail || t('deleteSentenceFailed');
             showError(message);
             setDeletingQuoteId(null);
         }
@@ -168,7 +169,7 @@ function MyQuotes() {
             ));
         } catch (error) {
             console.error('공개 전환 실패:', error);
-            showError(extractQuoteErrorMessage(error, '공개 문장 내에 유사한 문장이 존재합니다.', '공개 전환에 실패했습니다.'));
+            showError(extractQuoteErrorMessage(error, t('similarPublic'), t('makePublicFailed')));
         }
     };
 
@@ -184,7 +185,7 @@ function MyQuotes() {
             ));
         } catch (error) {
             console.error('공개 취소 실패:', error);
-            const message = error.response?.data?.detail || '공개 취소에 실패했습니다.';
+            const message = error.response?.data?.detail || t('cancelPublicFailed');
             showError(message);
         }
     };
@@ -199,11 +200,11 @@ function MyQuotes() {
         return (
             <div className="my-quotes-container">
                 <div className="my-quotes-header">
-                    <h1 className="my-quotes-title">내 문장</h1>
+                    <h1 className="my-quotes-title">{t('mySentencesTitle')}</h1>
                 </div>
                 <div className="my-quotes-login-required">
-                    <p>로그인이 필요합니다.</p>
-                    <button onClick={() => navigate('/')}>홈으로 돌아가기</button>
+                    <p>{t('loginRequired')}</p>
+                    <button onClick={() => navigate('/')}>{t('backToHome')}</button>
                 </div>
             </div>
         );
@@ -212,7 +213,7 @@ function MyQuotes() {
     return (
         <div className="my-quotes-container">
             <div className="my-quotes-header">
-                <h1 className="my-quotes-title">내 문장</h1>
+                <h1 className="my-quotes-title">{t('mySentencesTitle')}</h1>
             </div>
 
             <QuoteFilters
@@ -243,7 +244,7 @@ function MyQuotes() {
                 {isEmpty && (
                     <div className="my-quotes-empty">
                         <FaFileCircleQuestion/>
-                        <p>등록한 문장이 없습니다.</p>
+                        <p>{t('noMySentences')}</p>
                     </div>
                 )}
 
@@ -253,10 +254,10 @@ function MyQuotes() {
 
             <div className="my-quotes-actions">
                 <button className="my-quotes-back-btn" onClick={() => navigate('/')}>
-                    돌아가기
+                    {t('back')}
                 </button>
                 <button className="my-quotes-upload-btn" onClick={() => navigate('/quote/upload')}>
-                    문장 업로드
+                    {t('uploadSentence')}
                 </button>
             </div>
 
@@ -272,8 +273,8 @@ function MyQuotes() {
             {/* 삭제 확인 팝업 */}
             {deletingQuoteId && (
                 <ConfirmPopup
-                    message="이 문장을 삭제하시겠습니까?"
-                    confirmText="삭제"
+                    message={t('deleteSentenceConfirm')}
+                    confirmText={t('delete')}
                     onConfirm={handleDelete}
                     onCancel={() => setDeletingQuoteId(null)}
                     isDanger

--- a/tp-react/src/pages/MyQuotes/components/QuoteCard.jsx
+++ b/tp-react/src/pages/MyQuotes/components/QuoteCard.jsx
@@ -1,16 +1,17 @@
 import Badge from '../../../components/Badge/Badge';
+import {t} from '@/utils/i18n.ts';
 import './QuoteCard.css';
 
 // 타입 매핑
 const TYPE_MAP = {
-    PUBLIC: {variant: 'type-public', text: '공개'},
-    PRIVATE: {variant: 'type-private', text: '비공개'},
+    PUBLIC: {variant: 'type-public', text: t('public')},
+    PRIVATE: {variant: 'type-private', text: t('private')},
 };
 
 // 상태 매핑
 const STATUS_MAP = {
-    PENDING: {variant: 'status-pending', text: '대기중'},
-    ACTIVE: {variant: 'status-active', text: '활성'},
+    PENDING: {variant: 'status-pending', text: t('pending')},
+    ACTIVE: {variant: 'status-active', text: t('active')},
 };
 
 const QuoteCard = ({quote, onEdit, onDelete, onPublish, onCancelPublish}) => {
@@ -29,19 +30,19 @@ const QuoteCard = ({quote, onEdit, onDelete, onPublish, onCancelPublish}) => {
                 {quote.type === 'PRIVATE' && quote.status === 'ACTIVE' && (
                     <>
                         <button className="my-quote-action-btn" onClick={() => onEdit(quote)}>
-                            수정
+                            {t('edit')}
                         </button>
                         <button className="my-quote-action-btn danger" onClick={() => onDelete(quote.quoteId)}>
-                            삭제
+                            {t('delete')}
                         </button>
                         <button className="my-quote-action-btn primary" onClick={() => onPublish(quote.quoteId)}>
-                            공개전환
+                            {t('makePublic')}
                         </button>
                     </>
                 )}
                 {quote.type === 'PUBLIC' && quote.status === 'PENDING' && (
                     <button className="my-quote-action-btn" onClick={() => onCancelPublish(quote.quoteId)}>
-                        공개취소
+                        {t('cancelPublic')}
                     </button>
                 )}
             </div>

--- a/tp-react/src/pages/MyQuotes/components/QuoteEditPopup.jsx
+++ b/tp-react/src/pages/MyQuotes/components/QuoteEditPopup.jsx
@@ -1,6 +1,7 @@
 import {useEffect, useRef, useState} from 'react';
-import {useTheme} from '../../../Context/ThemeContext';
-import {MAX_AUTHOR_LENGTH, MAX_SENTENCE_LENGTH, MIN_SENTENCE_LENGTH} from '../../../const/config.const';
+import {useTheme} from '@/Context/ThemeContext.tsx';
+import {MAX_AUTHOR_LENGTH, MAX_SENTENCE_LENGTH, MIN_SENTENCE_LENGTH} from '@/const/config.const.ts';
+import {t} from '@/utils/i18n.ts';
 import './QuoteEditPopup.css';
 
 const QuoteEditPopup = ({quote, onSave, onClose}) => {
@@ -34,10 +35,10 @@ const QuoteEditPopup = ({quote, onSave, onClose}) => {
     return (
         <div className={`quote-edit-popup-overlay ${isDark ? 'dark' : ''}`} onClick={onClose}>
             <div className="quote-edit-popup" onClick={e => e.stopPropagation()}>
-                <h3 className="quote-edit-title">문장 수정</h3>
+                <h3 className="quote-edit-title">{t('editSentence')}</h3>
                 <div className="quote-edit-content">
                     <div className="quote-edit-field">
-                        <label className="quote-edit-label">문장</label>
+                        <label className="quote-edit-label">{t('sentence')}</label>
                         <textarea
                             ref={textareaRef}
                             className="quote-edit-input quote-edit-sentence"
@@ -56,7 +57,7 @@ const QuoteEditPopup = ({quote, onSave, onClose}) => {
                         </span>
                     </div>
                     <div className="quote-edit-field">
-                        <label className="quote-edit-label">저자 (선택)</label>
+                        <label className="quote-edit-label">{t('authorOptional')}</label>
                         <input
                             type="text"
                             className="quote-edit-input"
@@ -71,13 +72,13 @@ const QuoteEditPopup = ({quote, onSave, onClose}) => {
                     </div>
                 </div>
                 <div className="quote-edit-actions">
-                    <button className="quote-edit-cancel-btn" onClick={onClose}>취소</button>
+                    <button className="quote-edit-cancel-btn" onClick={onClose}>{t('cancel')}</button>
                     <button
                         className="quote-edit-save-btn"
                         onClick={handleSave}
                         disabled={!isValid()}
                     >
-                        저장
+                        {t('save')}
                     </button>
                 </div>
             </div>

--- a/tp-react/src/pages/MyQuotes/components/QuoteFilters.jsx
+++ b/tp-react/src/pages/MyQuotes/components/QuoteFilters.jsx
@@ -1,3 +1,4 @@
+import {t} from '@/utils/i18n.ts';
 import './QuoteFilters.css';
 
 const QuoteFilters = ({typeFilter, statusFilter, onTypeChange, onStatusChange}) => {
@@ -8,19 +9,19 @@ const QuoteFilters = ({typeFilter, statusFilter, onTypeChange, onStatusChange}) 
                     className={`my-quotes-filter-btn ${typeFilter === 'all' ? 'active' : ''}`}
                     onClick={() => onTypeChange('all')}
                 >
-                    전체
+                    {t('all')}
                 </button>
                 <button
                     className={`my-quotes-filter-btn ${typeFilter === 'PUBLIC' ? 'active' : ''}`}
                     onClick={() => onTypeChange('PUBLIC')}
                 >
-                    공개
+                    {t('public')}
                 </button>
                 <button
                     className={`my-quotes-filter-btn ${typeFilter === 'PRIVATE' ? 'active' : ''}`}
                     onClick={() => onTypeChange('PRIVATE')}
                 >
-                    비공개
+                    {t('private')}
                 </button>
             </div>
             <div className="my-quotes-filter-group">
@@ -28,19 +29,19 @@ const QuoteFilters = ({typeFilter, statusFilter, onTypeChange, onStatusChange}) 
                     className={`my-quotes-filter-btn ${statusFilter === 'all' ? 'active' : ''}`}
                     onClick={() => onStatusChange('all')}
                 >
-                    전체
+                    {t('all')}
                 </button>
                 <button
                     className={`my-quotes-filter-btn ${statusFilter === 'PENDING' ? 'active' : ''}`}
                     onClick={() => onStatusChange('PENDING')}
                 >
-                    대기중
+                    {t('pending')}
                 </button>
                 <button
                     className={`my-quotes-filter-btn ${statusFilter === 'ACTIVE' ? 'active' : ''}`}
                     onClick={() => onStatusChange('ACTIVE')}
                 >
-                    활성
+                    {t('active')}
                 </button>
             </div>
         </div>

--- a/tp-react/src/pages/MyReports/MyReports.jsx
+++ b/tp-react/src/pages/MyReports/MyReports.jsx
@@ -4,6 +4,7 @@ import {FaFlag} from 'react-icons/fa6';
 import {useAuth} from '../../Context/AuthContext';
 import {useError} from '../../Context/ErrorContext';
 import {deleteReport, getMyReports} from '@/utils/reportApi.ts';
+import {t} from '@/utils/i18n.ts';
 import ReportCard from './components/ReportCard';
 import ReportFilters from './components/ReportFilters';
 import ConfirmPopup from '../../components/ConfirmPopup/ConfirmPopup';
@@ -127,7 +128,7 @@ function MyReports() {
             }
         } catch (error) {
             console.error('신고 삭제 실패:', error);
-            const message = error.response?.data?.detail || '신고 삭제에 실패했습니다.';
+            const message = error.response?.data?.detail || t('deleteReportFailed');
             showError(message);
             setDeletingReportId(null);
         }
@@ -143,11 +144,11 @@ function MyReports() {
         return (
             <div className="my-reports-container">
                 <div className="my-reports-header">
-                    <h1 className="my-reports-title">신고 내역</h1>
+                    <h1 className="my-reports-title">{t('reportHistoryTitle')}</h1>
                 </div>
                 <div className="my-reports-login-required">
-                    <p>로그인이 필요합니다.</p>
-                    <button onClick={() => navigate('/')}>홈으로 돌아가기</button>
+                    <p>{t('loginRequired')}</p>
+                    <button onClick={() => navigate('/')}>{t('backToHome')}</button>
                 </div>
             </div>
         );
@@ -156,7 +157,7 @@ function MyReports() {
     return (
         <div className="my-reports-container">
             <div className="my-reports-header">
-                <h1 className="my-reports-title">신고 내역</h1>
+                <h1 className="my-reports-title">{t('reportHistoryTitle')}</h1>
             </div>
 
             <ReportFilters
@@ -182,7 +183,7 @@ function MyReports() {
                 {isEmpty && (
                     <div className="my-reports-empty">
                         <FaFlag/>
-                        <p>신고 내역이 없습니다.</p>
+                        <p>{t('noReports')}</p>
                     </div>
                 )}
 
@@ -192,15 +193,15 @@ function MyReports() {
 
             <div className="my-reports-actions">
                 <button className="my-reports-back-btn" onClick={() => navigate('/')}>
-                    돌아가기
+                    {t('back')}
                 </button>
             </div>
 
             {/* 삭제 확인 팝업 */}
             {deletingReportId && (
                 <ConfirmPopup
-                    message="이 신고를 취소하시겠습니까?"
-                    confirmText="삭제"
+                    message={t('deleteReportConfirm')}
+                    confirmText={t('delete')}
                     onConfirm={handleDelete}
                     onCancel={() => setDeletingReportId(null)}
                     isDanger

--- a/tp-react/src/pages/MyReports/components/ReportCard.jsx
+++ b/tp-react/src/pages/MyReports/components/ReportCard.jsx
@@ -1,19 +1,20 @@
 import {FaTrash} from 'react-icons/fa6';
-import {useTheme} from '../../../Context/ThemeContext';
+import {useTheme} from '@/Context/ThemeContext.tsx';
 import Badge from '../../../components/Badge/Badge';
-import {formatDate} from '../../../utils/formatDate';
+import {formatDate} from '@/utils/formatDate.ts';
+import {t} from '@/utils/i18n.ts';
 import './ReportCard.css';
 
 // 신고 사유 매핑
 const REASON_MAP = {
-    MODIFY: {variant: 'reason-modify', text: '수정 요청'},
-    DELETE: {variant: 'reason-delete', text: '삭제 요청'},
+    MODIFY: {variant: 'reason-modify', text: t('reportModify')},
+    DELETE: {variant: 'reason-delete', text: t('reportDelete')},
 };
 
 // 신고 상태 매핑
 const STATUS_MAP = {
-    PENDING: {variant: 'status-pending', text: '대기중'},
-    PROCESSED: {variant: 'status-processed', text: '처리완료'},
+    PENDING: {variant: 'status-pending', text: t('pending')},
+    PROCESSED: {variant: 'status-processed', text: t('processed')},
 };
 
 const ReportCard = ({report, onDelete}) => {
@@ -33,7 +34,7 @@ const ReportCard = ({report, onDelete}) => {
                     <button
                         className={`report-delete-btn ${isDark ? 'dark' : ''}`}
                         onClick={() => onDelete(report.id)}
-                        title="신고 취소"
+                        title={t('cancelReport')}
                     >
                         <FaTrash/>
                     </button>
@@ -43,7 +44,7 @@ const ReportCard = ({report, onDelete}) => {
             <div className={`report-quote ${report.quoteDeleted ? 'quote-deleted' : ''} ${isDark ? 'dark' : ''}`}>
                 <p className="report-sentence">
                     {report.quote?.sentence}
-                    {report.quoteDeleted && ' (삭제됨)'}
+                    {report.quoteDeleted && ` (${t('deleted')})`}
                 </p>
                 {report.quote?.author && (
                     <span className="report-author">- {report.quote.author}</span>
@@ -52,7 +53,7 @@ const ReportCard = ({report, onDelete}) => {
 
             {report.detail && (
                 <div className={`report-detail ${isDark ? 'dark' : ''}`}>
-                    <span className="report-detail-label">신고 내용</span>
+                    <span className="report-detail-label">{t('reportContent')}</span>
                     <p className="report-detail-text">{report.detail}</p>
                 </div>
             )}

--- a/tp-react/src/pages/MyReports/components/ReportFilters.jsx
+++ b/tp-react/src/pages/MyReports/components/ReportFilters.jsx
@@ -1,13 +1,14 @@
-import {useTheme} from '../../../Context/ThemeContext';
+import {useTheme} from '@/Context/ThemeContext.tsx';
+import {t} from '@/utils/i18n.ts';
 import './ReportFilters.css';
 
 const ReportFilters = ({statusFilter, onStatusChange}) => {
     const {isDark} = useTheme();
 
     const statusOptions = [
-        {value: 'all', label: '전체'},
-        {value: 'PENDING', label: '대기중'},
-        {value: 'PROCESSED', label: '처리완료'}
+        {value: 'all', label: t('all')},
+        {value: 'PENDING', label: t('pending')},
+        {value: 'PROCESSED', label: t('processed')}
     ];
 
     return (

--- a/tp-react/src/pages/QuoteUpload/QuoteUpload.jsx
+++ b/tp-react/src/pages/QuoteUpload/QuoteUpload.jsx
@@ -5,6 +5,7 @@ import {uploadQuote, extractQuoteErrorMessage} from '@/utils/quoteApi.ts';
 import {useAuth} from '../../Context/AuthContext';
 import {useError} from '../../Context/ErrorContext';
 import {MAX_AUTHOR_LENGTH, MAX_SENTENCE_LENGTH, MIN_SENTENCE_LENGTH} from '@/const/config.const.js';
+import {t} from '@/utils/i18n.ts';
 import UploadEntry from './components/UploadEntry';
 import ConfirmPopup from '../../components/ConfirmPopup/ConfirmPopup';
 import './QuoteUpload.css';
@@ -71,13 +72,13 @@ function QuoteUpload() {
         const sentence = entry.sentence.trim();
         if (!sentence) return '';
         if (sentence.length < MIN_SENTENCE_LENGTH) {
-            return `문장은 ${MIN_SENTENCE_LENGTH}자 이상이어야 합니다.`;
+            return t('minSentenceLength')(MIN_SENTENCE_LENGTH);
         }
         if (sentence.length > MAX_SENTENCE_LENGTH) {
-            return `문장은 ${MAX_SENTENCE_LENGTH}자 이하여야 합니다.`;
+            return t('maxSentenceLength')(MAX_SENTENCE_LENGTH);
         }
         if (entry.author && entry.author.length > MAX_AUTHOR_LENGTH) {
-            return `저자는 ${MAX_AUTHOR_LENGTH}자 이하여야 합니다.`;
+            return t('maxAuthorLength')(MAX_AUTHOR_LENGTH);
         }
         return '';
     };
@@ -90,7 +91,7 @@ function QuoteUpload() {
         const validEntries = getValidEntries();
 
         if (validEntries.length === 0) {
-            showError('최소 1개의 문장을 입력해주세요.');
+            showError(t('enterAtLeastOne'));
             return;
         }
 
@@ -112,11 +113,11 @@ function QuoteUpload() {
 
         let message;
         if (publicCount > 0 && privateCount > 0) {
-            message = `공개 ${publicCount}개, 비공개 ${privateCount}개의 문장을 업로드합니다.`;
+            message = t('uploadConfirmBoth')(publicCount, privateCount);
         } else if (publicCount > 0) {
-            message = `${publicCount}개의 문장을 공개로 업로드합니다.`;
+            message = t('uploadConfirmPublic')(publicCount);
         } else {
-            message = `${privateCount}개의 문장을 비공개로 업로드합니다.`;
+            message = t('uploadConfirmPrivate')(privateCount);
         }
 
         setConfirmMessage(message);
@@ -139,9 +140,9 @@ function QuoteUpload() {
                 successIds.push(entry.id);
             } catch (error) {
                 const similarMessage = entry.type === 'public'
-                    ? '공개 문장 내에 유사한 문장이 존재합니다.'
-                    : '내 문장 내에 유사한 문장이 존재합니다.';
-                const errorMessage = extractQuoteErrorMessage(error, similarMessage, '업로드에 실패했습니다.');
+                    ? t('similarPublic')
+                    : t('similarMy');
+                const errorMessage = extractQuoteErrorMessage(error, similarMessage, t('uploadFailed'));
                 setEntries(prev => prev.map(e =>
                     e.id === entry.id ? {...e, error: errorMessage} : e
                 ));
@@ -161,7 +162,7 @@ function QuoteUpload() {
             });
 
             // 결과 팝업
-            setConfirmMessage(`${successCount}개의 문장 업로드에 성공했습니다.`);
+            setConfirmMessage(t('uploadSuccess')(successCount));
             setIsResultPopup(true);
             setShowConfirm(true);
         }
@@ -185,11 +186,11 @@ function QuoteUpload() {
         return (
             <div className="quote-upload-container">
                 <div className="quote-upload-header">
-                    <h1 className="quote-upload-title">문장 업로드</h1>
+                    <h1 className="quote-upload-title">{t('uploadTitle')}</h1>
                 </div>
                 <div className="quote-upload-login-required">
-                    <p>로그인이 필요합니다.</p>
-                    <button onClick={() => navigate('/')}>홈으로 돌아가기</button>
+                    <p>{t('loginRequired')}</p>
+                    <button onClick={() => navigate('/')}>{t('backToHome')}</button>
                 </div>
             </div>
         );
@@ -198,17 +199,17 @@ function QuoteUpload() {
     return (
         <div className="quote-upload-container">
             <div className="quote-upload-header">
-                <h1 className="quote-upload-title">문장 업로드</h1>
+                <h1 className="quote-upload-title">{t('uploadTitle')}</h1>
             </div>
 
             <div className="quote-upload-type-info">
                 <span className="quote-upload-type-hint">
-                    각 문장마다 공개/비공개를 선택할 수 있습니다.
+                    {t('uploadTypeHint')}
                     <span className="quote-upload-tooltip-trigger">
                         <FaCircleInfo/>
                         <span className="quote-upload-tooltip">
-                            <p><strong>공개</strong>: 관리자 승인 후 모든 사용자에게 노출됩니다.</p>
-                            <p><strong>비공개</strong>: 본인만 사용할 수 있습니다.</p>
+                            <p><strong>{t('public')}</strong>: {t('uploadTooltipPublic')}</p>
+                            <p><strong>{t('private')}</strong>: {t('uploadTooltipPrivate')}</p>
                         </span>
                     </span>
                 </span>
@@ -235,14 +236,14 @@ function QuoteUpload() {
                 <FaPlus/>
                 <span>
                     {entries.length >= MAX_ENTRIES
-                        ? `최대 ${MAX_ENTRIES}개`
-                        : `문장 추가 (${entries.length}/${MAX_ENTRIES})`}
+                        ? t('maxEntries')(MAX_ENTRIES)
+                        : t('addSentence')(entries.length, MAX_ENTRIES)}
                 </span>
             </button>
 
             <div className="quote-upload-actions">
                 <button className="quote-upload-cancel-btn" onClick={() => navigate('/')}>
-                    취소
+                    {t('cancel')}
                 </button>
                 <button
                     className="quote-upload-submit-btn"
@@ -252,12 +253,12 @@ function QuoteUpload() {
                     {isUploading ? (
                         <>
                             <span className="quote-upload-spinner"></span>
-                            <span>업로드 중...</span>
+                            <span>{t('uploading')}</span>
                         </>
                     ) : (
                         <>
                             <FaUpload/>
-                            <span>업로드</span>
+                            <span>{t('upload')}</span>
                         </>
                     )}
                 </button>

--- a/tp-react/src/pages/QuoteUpload/components/UploadEntry.tsx
+++ b/tp-react/src/pages/QuoteUpload/components/UploadEntry.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {FaGlobe, FaLock, FaXmark} from 'react-icons/fa6';
 import {MAX_AUTHOR_LENGTH, MAX_SENTENCE_LENGTH, MIN_SENTENCE_LENGTH} from '@/const/config.const.ts';
+import {t} from '@/utils/i18n.ts';
 import './UploadEntry.css';
 
 export interface UploadEntryData {
@@ -48,21 +49,21 @@ const UploadEntry = ({entry, index, showDelete, onUpdate, onRemove}: UploadEntry
                     onClick={() => onUpdate(entry.id, 'type', 'public')}
                 >
                     <FaGlobe/>
-                    <span>공개</span>
+                    <span>{t('public')}</span>
                 </button>
                 <button
                     className={`quote-upload-entry-type-btn ${entry.type === 'private' ? 'active' : ''}`}
                     onClick={() => onUpdate(entry.id, 'type', 'private')}
                 >
                     <FaLock/>
-                    <span>비공개</span>
+                    <span>{t('private')}</span>
                 </button>
             </div>
             <div className="quote-upload-entry-inputs">
                 <div className="quote-upload-sentence-wrapper">
                     <textarea
                         className="quote-upload-input quote-upload-sentence"
-                        placeholder={`문장을 입력하세요 (${MIN_SENTENCE_LENGTH}-${MAX_SENTENCE_LENGTH}자)`}
+                        placeholder={t('sentencePlaceholder')(MIN_SENTENCE_LENGTH, MAX_SENTENCE_LENGTH)}
                         maxLength={MAX_SENTENCE_LENGTH}
                         value={entry.sentence}
                         onChange={(e) => handleTextareaChange(e, 'sentence')}
@@ -76,7 +77,7 @@ const UploadEntry = ({entry, index, showDelete, onUpdate, onRemove}: UploadEntry
                 <div className="quote-upload-author-wrapper">
                     <textarea
                         className="quote-upload-input quote-upload-author"
-                        placeholder="저자 (선택)"
+                        placeholder={t('authorPlaceholder')}
                         maxLength={MAX_AUTHOR_LENGTH}
                         value={entry.author}
                         onChange={(e) => handleTextareaChange(e, 'author')}

--- a/tp-react/src/pages/Stats/Stats.jsx
+++ b/tp-react/src/pages/Stats/Stats.jsx
@@ -4,6 +4,7 @@ import {FaRotateRight} from 'react-icons/fa6';
 import {useAuth} from '../../Context/AuthContext';
 import {useError} from '../../Context/ErrorContext';
 import {getDailyStats, getTypingStats, getTypoStats, refreshStats} from '@/utils/statsApi.ts';
+import {t} from '@/utils/i18n.ts';
 import StatsSummary from './components/StatsSummary';
 import DailyChart from './components/DailyChart';
 import TypoList from './components/TypoList';
@@ -52,7 +53,7 @@ function Stats() {
             setTypoStats(typoRes.data.data.content || []);
         } catch (error) {
             console.error('통계 로드 실패:', error);
-            showError('기록을 불러오는데 실패했습니다.');
+            showError(t('statsLoadFailed'));
         } finally {
             setIsLoading(false);
         }
@@ -74,9 +75,9 @@ function Stats() {
             await loadAllStats();
         } catch (error) {
             if (error.response?.status === 429) {
-                showError('새로고침은 1분에 한 번만 가능합니다.');
+                showError(t('refreshCooldown'));
             } else {
-                showError('새로고침에 실패했습니다.');
+                showError(t('refreshFailed'));
             }
         }
     };
@@ -87,7 +88,7 @@ function Stats() {
     return (
         <div className="stats-container">
             <div className="stats-header">
-                <h1 className="stats-title">내 타이핑 기록</h1>
+                <h1 className="stats-title">{t('myTypingRecords')}</h1>
                 <button className="stats-refresh-btn" onClick={handleRefresh} title="새로고침">
                     <FaRotateRight/>
                 </button>
@@ -112,7 +113,7 @@ function Stats() {
 
             <div className="stats-footer">
                 <button className="stats-back-btn" onClick={() => navigate('/')}>
-                    돌아가기
+                    {t('back')}
                 </button>
             </div>
         </div>

--- a/tp-react/src/pages/Stats/components/DailyChart.jsx
+++ b/tp-react/src/pages/Stats/components/DailyChart.jsx
@@ -1,4 +1,5 @@
 import {useState, useRef, useCallback} from 'react';
+import {t} from '@/utils/i18n.ts';
 import './DailyChart.css';
 
 const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
@@ -8,17 +9,8 @@ const formatDateLabel = (dateStr) => {
     return MONTH_NAMES[parseInt(parts[1]) - 1] + ' ' + parseInt(parts[2]);
 };
 
-const formatPopupTitle = (dateStr) => {
-    const parts = dateStr.split('-');
-    return parts[0] + '\uB144 ' + parseInt(parts[1]) + '\uC6D4 ' + parseInt(parts[2]) + '\uC77C';
-};
-
-const formatTime = (min) => {
-    if (!min || min <= 0) return '0\uBD84';
-    const h = Math.floor(min / 60);
-    const m = Math.round(min % 60);
-    return h > 0 ? h + '\uC2DC\uAC04 ' + m + '\uBD84' : m + '\uBD84';
-};
+const formatPopupTitle = t('formatPopupTitle');
+const formatTime = t('formatTime');
 
 const SVG_W = 600;
 const SVG_H = 180;
@@ -91,17 +83,17 @@ function DailyChart({dailyStats, dailyRange, onRangeChange}) {
     return (
         <div className="daily-chart-section">
             <div className="daily-chart-header">
-                <h3 className="daily-chart-title">{'\uC77C\uBCC4 \uCD94\uC774'}</h3>
+                <h3 className="daily-chart-title">{t('dailyTrend')}</h3>
                 <div className="daily-chart-tabs">
                     <button className={'daily-chart-tab' + (metric === 'cpm' ? ' active' : '')} onClick={() => setMetric('cpm')}>CPM</button>
-                    <button className={'daily-chart-tab' + (metric === 'acc' ? ' active' : '')} onClick={() => setMetric('acc')}>{'\uC815\uD655\uB3C4'}</button>
+                    <button className={'daily-chart-tab' + (metric === 'acc' ? ' active' : '')} onClick={() => setMetric('acc')}>{t('accuracyTab')}</button>
                     <span className="daily-chart-tab-divider"/>
-                    <button className={'daily-chart-tab' + (dailyRange === 7 ? ' active' : '')} onClick={() => onRangeChange(7)}>7{'\uC77C'}</button>
-                    <button className={'daily-chart-tab' + (dailyRange === 30 ? ' active' : '')} onClick={() => onRangeChange(30)}>30{'\uC77C'}</button>
+                    <button className={'daily-chart-tab' + (dailyRange === 7 ? ' active' : '')} onClick={() => onRangeChange(7)}>{t('days')(7)}</button>
+                    <button className={'daily-chart-tab' + (dailyRange === 30 ? ' active' : '')} onClick={() => onRangeChange(30)}>{t('days')(30)}</button>
                 </div>
             </div>
             {data.length === 0 ? (
-                <div className="daily-chart-empty">{'\uB370\uC774\uD130\uAC00 \uC5C6\uC2B5\uB2C8\uB2E4.'}</div>
+                <div className="daily-chart-empty">{t('noData')}</div>
             ) : (
                 <div className="daily-chart-area" ref={chartRef}>
                     <svg ref={svgRef} width="100%" height={SVG_H} viewBox={'0 0 ' + SVG_W + ' ' + SVG_H}>
@@ -142,28 +134,28 @@ function DailyChart({dailyStats, dailyRange, onRangeChange}) {
                             <div className="daily-chart-popup-title">{formatPopupTitle(popupData.date)}</div>
                             <div className="daily-chart-popup-grid">
                                 <div className="daily-chart-popup-item">
-                                    <span className="daily-chart-popup-label">{'\uC5F0\uC2B5 \uD69F\uC218'}</span>
-                                    <span className="daily-chart-popup-value">{popupData.attempts + '\uD68C'}</span>
+                                    <span className="daily-chart-popup-label">{t('attempts')}</span>
+                                    <span className="daily-chart-popup-value">{popupData.attempts + t('countUnit')}</span>
                                 </div>
                                 <div className="daily-chart-popup-item">
-                                    <span className="daily-chart-popup-label">{'\uC5F0\uC2B5 \uC2DC\uAC04'}</span>
+                                    <span className="daily-chart-popup-label">{t('practiceTime')}</span>
                                     <span className="daily-chart-popup-value">{formatTime(popupData.practiceTimeMin)}</span>
                                 </div>
                                 <div className="daily-chart-popup-item">
-                                    <span className="daily-chart-popup-label">{'\uD3C9\uADE0 \uD0C0\uC790 \uC18D\uB3C4'}</span>
+                                    <span className="daily-chart-popup-label">{t('avgSpeed')}</span>
                                     <span className="daily-chart-popup-value">{Math.round(popupData.avgCpm) + ' CPM'}</span>
                                 </div>
                                 <div className="daily-chart-popup-item">
-                                    <span className="daily-chart-popup-label">{'\uCD5C\uACE0 \uD0C0\uC790 \uC18D\uB3C4'}</span>
+                                    <span className="daily-chart-popup-label">{t('bestSpeed')}</span>
                                     <span className="daily-chart-popup-value">{popupData.bestCpm + ' CPM'}</span>
                                 </div>
                                 <div className="daily-chart-popup-item">
-                                    <span className="daily-chart-popup-label">{'\uD3C9\uADE0 \uC815\uD655\uB3C4'}</span>
+                                    <span className="daily-chart-popup-label">{t('avgAccuracy')}</span>
                                     <span className="daily-chart-popup-value">{Math.round(popupData.avgAcc * 100) + '%'}</span>
                                 </div>
                                 <div className="daily-chart-popup-item">
-                                    <span className="daily-chart-popup-label">{'\uD3C9\uADE0 \uCD08\uAE30\uD654 \uD69F\uC218'}</span>
-                                    <span className="daily-chart-popup-value">{(popupData.attempts > 0 ? (popupData.resetCount / popupData.attempts).toFixed(2) : '0') + '\uD68C'}</span>
+                                    <span className="daily-chart-popup-label">{t('avgResetCount')}</span>
+                                    <span className="daily-chart-popup-value">{(popupData.attempts > 0 ? (popupData.resetCount / popupData.attempts).toFixed(2) : '0') + t('countUnit')}</span>
                                 </div>
                             </div>
                         </div>

--- a/tp-react/src/pages/Stats/components/StatsSummary.jsx
+++ b/tp-react/src/pages/Stats/components/StatsSummary.jsx
@@ -1,11 +1,7 @@
+import {t} from '@/utils/i18n.ts';
 import './StatsSummary.css';
 
-const formatTime = (min) => {
-    if (!min || min <= 0) return '0분';
-    const h = Math.floor(min / 60);
-    const m = Math.round(min % 60);
-    return h > 0 ? h + '시간 ' + m + '분' : m + '분';
-};
+const formatTime = t('formatTime');
 
 const calcTrend = (recentAvg, totalAvg) => {
     if (!totalAvg || !recentAvg) return {text: '', className: ''};
@@ -41,37 +37,37 @@ function StatsSummary({typingStats, dailyStats}) {
     return (
         <div className="stats-summary">
             <div className="stats-main-card">
-                <span className="stats-main-label">최근 7일 평균</span>
+                <span className="stats-main-label">{t('recent7DayAvg')}</span>
                 <div className="stats-main-value">
                     <span className="stats-main-number">{recentAvg}</span>
                     <span className="stats-main-unit">CPM</span>
                     {trend.text && <span className={trend.className}>{trend.text}</span>}
                 </div>
                 <div className="stats-main-sub">
-                    최고 {typingStats.bestCpm} CPM · 정확도 {Math.round(typingStats.avgAcc * 100)}%
+                    {t('best')} {typingStats.bestCpm} CPM · {t('accuracy')} {Math.round(typingStats.avgAcc * 100)}%
                 </div>
             </div>
             <div className="stats-sub-grid">
                 <div className="stats-sub-card">
-                    <span className="stats-sub-label">연습 시간</span>
+                    <span className="stats-sub-label">{t('practiceTime')}</span>
                     <div className="stats-sub-value">{formatTime(typingStats.totalPracticeTimeMin)}</div>
                 </div>
                 <div className="stats-sub-card">
-                    <span className="stats-sub-label">연습 횟수</span>
+                    <span className="stats-sub-label">{t('practiceCount')}</span>
                     <div className="stats-sub-value">
-                        {typingStats.totalAttempts}<span className="stats-sub-unit">회</span>
+                        {typingStats.totalAttempts}<span className="stats-sub-unit">{t('times')}</span>
                     </div>
                 </div>
                 <div className="stats-sub-card">
-                    <span className="stats-sub-label">전체 평균</span>
+                    <span className="stats-sub-label">{t('totalAverage')}</span>
                     <div className="stats-sub-value">
                         {Math.round(typingStats.avgCpm)}<span className="stats-sub-unit">CPM</span>
                     </div>
                 </div>
                 <div className="stats-sub-card">
-                    <span className="stats-sub-label">평균 초기화</span>
+                    <span className="stats-sub-label">{t('avgReset')}</span>
                     <div className="stats-sub-value">
-                        {avgReset}<span className="stats-sub-unit">회</span>
+                        {avgReset}<span className="stats-sub-unit">{t('times')}</span>
                     </div>
                 </div>
             </div>

--- a/tp-react/src/pages/Stats/components/TypoList.jsx
+++ b/tp-react/src/pages/Stats/components/TypoList.jsx
@@ -1,5 +1,6 @@
 import {useState} from 'react';
 import {getTypoDetailStats} from '@/utils/statsApi.ts';
+import {t} from '@/utils/i18n.ts';
 import './TypoList.css';
 
 const displayChar = (ch) => {
@@ -17,9 +18,9 @@ function TypoList({typoStats}) {
         return (
             <div className="typo-section">
                 <div className="typo-section-header">
-                    <h3 className="typo-section-title">{'\uC790\uC8FC \uD2C0\uB9AC\uB294 \uAE00\uC790 TOP 10'}</h3>
+                    <h3 className="typo-section-title">{t('typoTop10')}</h3>
                 </div>
-                <div className="typo-empty">{'\uC624\uD0C0 \uB370\uC774\uD130\uAC00 \uC5C6\uC2B5\uB2C8\uB2E4.'}</div>
+                <div className="typo-empty">{t('noTypoData')}</div>
             </div>
         );
     }
@@ -38,7 +39,7 @@ function TypoList({typoStats}) {
             const res = await getTypoDetailStats('KOREAN', expected);
             setTypoDetail(res.data.data.content || []);
         } catch (error) {
-            console.error('\uC624\uD0C0 \uC0C1\uC138 \uB85C\uB4DC \uC2E4\uD328:', error);
+            console.error('typo detail load failed:', error);
             setTypoDetail([]);
         } finally {
             setDetailLoading(false);
@@ -49,7 +50,7 @@ function TypoList({typoStats}) {
         <div className="typo-area">
             <div className="typo-section">
                 <div className="typo-section-header">
-                    <h3 className="typo-section-title">{'\uC790\uC8FC \uD2C0\uB9AC\uB294 \uAE00\uC790 TOP 10'}</h3>
+                    <h3 className="typo-section-title">{t('typoTop10')}</h3>
                 </div>
                 <div className="typo-list">
                     {typoStats.map((item, i) => (
@@ -72,13 +73,13 @@ function TypoList({typoStats}) {
                 <div className="typo-section">
                     <div className="typo-section-header">
                         <h3 className="typo-section-title">
-                            &lsquo;<span className="typo-detail-char">{displayChar(selectedTypo)}</span>&rsquo; {'\uC624\uD0C0 \uC0C1\uC138'}
+                            &lsquo;<span className="typo-detail-char">{displayChar(selectedTypo)}</span>&rsquo; {t('typoDetailTitle')}
                         </h3>
                     </div>
                     {detailLoading ? (
-                        <div className="typo-empty">{'\uB85C\uB529 \uC911...'}</div>
+                        <div className="typo-empty">{t('loading')}</div>
                     ) : typoDetail.length === 0 ? (
-                        <div className="typo-empty">{'\uC0C1\uC138 \uB370\uC774\uD130\uAC00 \uC5C6\uC2B5\uB2C8\uB2E4.'}</div>
+                        <div className="typo-empty">{t('noDetailData')}</div>
                     ) : (
                         <div className="typo-detail-list">
                             {typoDetail.map((d, i) => (
@@ -86,7 +87,7 @@ function TypoList({typoStats}) {
                                     <span className="typo-detail-expected">{displayChar(d.expected)}</span>
                                     <span className="typo-detail-arrow">{'\u2192'}</span>
                                     <span className="typo-detail-actual">{displayChar(d.actual)}</span>
-                                    <span className="typo-detail-count">{d.typoCount + '\uD68C'}</span>
+                                    <span className="typo-detail-count">{d.typoCount + t('countUnit')}</span>
                                 </div>
                             ))}
                         </div>

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -1,0 +1,199 @@
+const isKorean = navigator.language.startsWith('ko');
+const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+
+const translations = {
+    // 공통
+    confirm: isKorean ? '확인' : 'OK',
+    cancel: isKorean ? '취소' : 'Cancel',
+    back: isKorean ? '돌아가기' : 'Back',
+    delete: isKorean ? '삭제' : 'Delete',
+    save: isKorean ? '저장' : 'Save',
+    saving: isKorean ? '저장 중...' : 'Saving...',
+    saveChanges: isKorean ? '저장하기' : 'Save',
+    close: isKorean ? '닫기' : 'Close',
+    loading: isKorean ? '로딩 중...' : 'Loading...',
+    edit: isKorean ? '수정' : 'Edit',
+
+    // 로그인/인증
+    googleLogin: isKorean ? '구글 로그인' : 'Sign in with Google',
+    loginRequired: isKorean ? '로그인이 필요합니다.' : 'Login required.',
+    logout: isKorean ? '로그아웃' : 'Logout',
+    backToHome: isKorean ? '홈으로 돌아가기' : 'Back to Home',
+
+    // 닉네임
+    welcome: isKorean ? '환영합니다! 🎉' : 'Welcome! 🎉',
+    setNickname: isKorean ? '닉네임을 설정해주세요. (2-10자)' : 'Please set your nickname. (2-10 characters)',
+    nicknamePlaceholder: isKorean ? '닉네임 입력' : 'Enter nickname',
+    nicknameLength: isKorean ? '닉네임은 2-10자여야 합니다.' : 'Nickname must be 2-10 characters.',
+    nicknameDuplicate: isKorean ? '이미 사용 중인 닉네임입니다.' : 'This nickname is already taken.',
+    nicknameCheckFailed: isKorean ? '중복 확인에 실패했습니다.' : 'Failed to check nickname.',
+    nicknameCheckFirst: isKorean ? '닉네임 중복 확인을 먼저 해주세요.' : 'Please check nickname availability first.',
+    nicknameAvailable: isKorean ? '사용 가능한 닉네임입니다.' : 'Nickname is available.',
+    nicknameHelper: isKorean ? '한글, 영문, 숫자 사용 가능' : 'Korean, English, numbers allowed',
+    checkDuplicate: isKorean ? '중복확인' : 'Check',
+    checking: isKorean ? '확인 중...' : 'Checking...',
+    nicknameSetFailed: isKorean ? '닉네임 설정에 실패했습니다.' : 'Failed to set nickname.',
+    nicknameEditFailed: isKorean ? '닉네임 수정에 실패했습니다.' : 'Failed to update nickname.',
+    start: isKorean ? '시작하기' : 'Start',
+    setting: isKorean ? '설정 중...' : 'Setting...',
+    setNicknameBtn: isKorean ? '닉네임 설정' : 'Set Nickname',
+
+    // 프로필
+    profile: isKorean ? '프로필' : 'Profile',
+    profileLoadFailed: isKorean ? '프로필을 불러오는데 실패했습니다.' : 'Failed to load profile.',
+    email: isKorean ? '이메일' : 'Email',
+    nickname: isKorean ? '닉네임' : 'Nickname',
+    joinDate: isKorean ? '가입일' : 'Joined',
+    user: isKorean ? '사용자' : 'User',
+
+    // 프로필 드롭다운
+    mySentences: isKorean ? '내 문장' : 'My Sentences',
+    records: isKorean ? '기록' : 'Records',
+    reportHistory: isKorean ? '신고 내역' : 'Report History',
+
+    // 헤더
+    uploadSentence: isKorean ? '문장 업로드' : 'Upload',
+    uploadLoginRequired: isKorean ? '문장을 업로드하려면 로그인이 필요합니다.' : 'Login required to upload sentences.',
+    loginFailed: isKorean ? '로그인에 실패했습니다. 다시 시도해주세요.' : 'Login failed. Please try again.',
+    googleLoginFailed: isKorean ? '구글 로그인에 실패했습니다.' : 'Google login failed.',
+
+    // 타이핑 입력
+    inputPlaceholder: isKorean ? '위 문장을 입력하세요.' : 'Type the sentence above.',
+    pasteBlocked: isKorean ? '붙여넣기가 금지되어 있습니다!' : 'Pasting is not allowed!',
+
+    // 문장 소스
+    allSentences: isKorean ? '전체 문장' : 'All',
+    mySentencesOnly: isKorean ? '내 문장만' : 'Mine',
+    mySentencesLoginRequired: isKorean ? '내 문장을 사용하려면 로그인이 필요합니다.' : 'Login required to use your sentences.',
+
+    // 문장 로딩/비어있음
+    loadingSentences: isKorean ? '문장을 불러오는 중...' : 'Loading sentences...',
+    noSentences: isKorean ? '등록된 문장이 없습니다.' : 'No sentences found.',
+    sentenceLoadFailed: isKorean ? '문장을 불러오는데 실패했습니다.' : 'Failed to load sentences.',
+
+    // 신고
+    report: isKorean ? '신고' : 'Report',
+    reportSentence: isKorean ? '문장 신고' : 'Report Sentence',
+    reportTarget: isKorean ? '신고 대상' : 'Target',
+    reportReason: isKorean ? '신고 사유' : 'Reason',
+    reportDetail: isKorean ? '상세 설명' : 'Details',
+    reportDetailPlaceholder: isKorean ? '신고 사유를 자세히 설명해주세요.' : 'Please describe the reason in detail.',
+    optional: isKorean ? '선택' : 'optional',
+    reportModify: isKorean ? '수정 요청' : 'Request Edit',
+    reportModifyDesc: isKorean ? '오타, 맞춤법 오류 등' : 'Typos, grammar errors, etc.',
+    reportDelete: isKorean ? '삭제 요청' : 'Request Delete',
+    reportDeleteDesc: isKorean ? '부적절한 내용, 저작권 위반 등' : 'Inappropriate content, copyright, etc.',
+    reporting: isKorean ? '신고 중...' : 'Reporting...',
+    reportFailed: isKorean ? '신고 접수에 실패했습니다.' : 'Failed to submit report.',
+    reportLoginRequired: isKorean ? '문장을 신고하려면 로그인이 필요합니다.' : 'Login required to report.',
+    cancelReport: isKorean ? '신고 취소' : 'Cancel Report',
+
+    // 내 문장 페이지
+    mySentencesTitle: isKorean ? '내 문장' : 'My Sentences',
+    noMySentences: isKorean ? '등록한 문장이 없습니다.' : 'No sentences registered.',
+    deleteSentenceConfirm: isKorean ? '이 문장을 삭제하시겠습니까?' : 'Delete this sentence?',
+    editSentence: isKorean ? '문장 수정' : 'Edit Sentence',
+    sentence: isKorean ? '문장' : 'Sentence',
+    authorOptional: isKorean ? '저자 (선택)' : 'Author (optional)',
+    makePublic: isKorean ? '공개전환' : 'Make Public',
+    cancelPublic: isKorean ? '공개취소' : 'Cancel Public',
+
+    // 필터
+    all: isKorean ? '전체' : 'All',
+    public: isKorean ? '공개' : 'Public',
+    private: isKorean ? '비공개' : 'Private',
+    pending: isKorean ? '대기중' : 'Pending',
+    active: isKorean ? '활성' : 'Active',
+    processed: isKorean ? '처리완료' : 'Processed',
+
+    // 신고 내역 페이지
+    reportHistoryTitle: isKorean ? '신고 내역' : 'Report History',
+    noReports: isKorean ? '신고 내역이 없습니다.' : 'No reports found.',
+    deleteReportConfirm: isKorean ? '이 신고를 취소하시겠습니까?' : 'Cancel this report?',
+    reportContent: isKorean ? '신고 내용' : 'Report Details',
+    deleted: isKorean ? '삭제됨' : 'Deleted',
+
+    // 업로드 페이지
+    uploadTitle: isKorean ? '문장 업로드' : 'Upload Sentences',
+    uploadTypeHint: isKorean ? '각 문장마다 공개/비공개를 선택할 수 있습니다.' : 'You can set each sentence as public or private.',
+    uploadTooltipPublic: isKorean ? '관리자 승인 후 모든 사용자에게 노출됩니다.' : 'Visible to all users after admin approval.',
+    uploadTooltipPrivate: isKorean ? '본인만 사용할 수 있습니다.' : 'Only visible to you.',
+    sentencePlaceholder: (min: number, max: number) => isKorean ? `문장을 입력하세요 (${min}-${max}자)` : `Enter a sentence (${min}-${max} characters)`,
+    authorPlaceholder: isKorean ? '저자 (선택)' : 'Author (optional)',
+    addSentence: (cur: number, max: number) => isKorean ? `문장 추가 (${cur}/${max})` : `Add sentence (${cur}/${max})`,
+    maxEntries: (max: number) => isKorean ? `최대 ${max}개` : `Max ${max}`,
+    upload: isKorean ? '업로드' : 'Upload',
+    uploading: isKorean ? '업로드 중...' : 'Uploading...',
+    minSentenceLength: (min: number) => isKorean ? `문장은 ${min}자 이상이어야 합니다.` : `Sentence must be at least ${min} characters.`,
+    maxSentenceLength: (max: number) => isKorean ? `문장은 ${max}자 이하여야 합니다.` : `Sentence must be at most ${max} characters.`,
+    maxAuthorLength: (max: number) => isKorean ? `저자는 ${max}자 이하여야 합니다.` : `Author must be at most ${max} characters.`,
+    enterAtLeastOne: isKorean ? '최소 1개의 문장을 입력해주세요.' : 'Please enter at least one sentence.',
+    uploadConfirmBoth: (pub: number, priv: number) => isKorean ? `공개 ${pub}개, 비공개 ${priv}개의 문장을 업로드합니다.` : `Upload ${pub} public and ${priv} private sentences.`,
+    uploadConfirmPublic: (n: number) => isKorean ? `${n}개의 문장을 공개로 업로드합니다.` : `Upload ${n} public sentences.`,
+    uploadConfirmPrivate: (n: number) => isKorean ? `${n}개의 문장을 비공개로 업로드합니다.` : `Upload ${n} private sentences.`,
+    uploadSuccess: (n: number) => isKorean ? `${n}개의 문장 업로드에 성공했습니다.` : `${n} sentences uploaded successfully.`,
+    uploadFailed: isKorean ? '업로드에 실패했습니다.' : 'Upload failed.',
+    similarPublic: isKorean ? '공개 문장 내에 유사한 문장이 존재합니다.' : 'A similar public sentence already exists.',
+    similarMy: isKorean ? '내 문장 내에 유사한 문장이 존재합니다.' : 'A similar sentence already exists in your sentences.',
+    editSentenceFailed: isKorean ? '문장 수정에 실패했습니다.' : 'Failed to edit sentence.',
+    deleteSentenceFailed: isKorean ? '문장 삭제에 실패했습니다.' : 'Failed to delete sentence.',
+    makePublicFailed: isKorean ? '공개 전환에 실패했습니다.' : 'Failed to make public.',
+    cancelPublicFailed: isKorean ? '공개 취소에 실패했습니다.' : 'Failed to cancel public.',
+    deleteReportFailed: isKorean ? '신고 삭제에 실패했습니다.' : 'Failed to delete report.',
+
+    // 기록 페이지
+    myTypingRecords: isKorean ? '내 타이핑 기록' : 'My Typing Records',
+    statsLoadFailed: isKorean ? '기록을 불러오는데 실패했습니다.' : 'Failed to load records.',
+    refreshCooldown: isKorean ? '새로고침은 1분에 한 번만 가능합니다.' : 'Refresh is available once per minute.',
+    refreshFailed: isKorean ? '새로고침에 실패했습니다.' : 'Refresh failed.',
+
+    // 종합 통계
+    recent7DayAvg: isKorean ? '최근 7일 평균' : '7-Day Average',
+    best: isKorean ? '최고' : 'Best',
+    accuracy: isKorean ? '정확도' : 'Accuracy',
+    practiceTime: isKorean ? '연습 시간' : 'Practice Time',
+    practiceCount: isKorean ? '연습 횟수' : 'Practices',
+    totalAverage: isKorean ? '전체 평균' : 'Overall Avg',
+    avgReset: isKorean ? '평균 초기화' : 'Avg Resets',
+    times: isKorean ? '회' : '',
+    formatTime: (min: number) => {
+        if (!min || min <= 0) return isKorean ? '0분' : '0m';
+        const h = Math.floor(min / 60);
+        const m = Math.round(min % 60);
+        if (isKorean) return h > 0 ? `${h}시간 ${m}분` : `${m}분`;
+        return h > 0 ? `${h}h ${m}m` : `${m}m`;
+    },
+
+    // 에러 컨텍스트
+    errorConfirm: isKorean ? '확인' : 'OK',
+
+    // 일별 추이 차트
+    dailyTrend: isKorean ? '일별 추이' : 'Daily Trend',
+    accuracyTab: isKorean ? '정확도' : 'Accuracy',
+    days: (n: number) => isKorean ? `${n}일` : `${n}d`,
+    noData: isKorean ? '데이터가 없습니다.' : 'No data available.',
+    formatPopupTitle: (dateStr: string) => {
+        const parts = dateStr.split('-');
+        if (isKorean) return parts[0] + '년 ' + parseInt(parts[1]) + '월 ' + parseInt(parts[2]) + '일';
+        return MONTH_NAMES[parseInt(parts[1]) - 1] + ' ' + parseInt(parts[2]) + ', ' + parts[0];
+    },
+    attempts: isKorean ? '연습 횟수' : 'Attempts',
+    avgSpeed: isKorean ? '평균 타자 속도' : 'Avg Speed',
+    bestSpeed: isKorean ? '최고 타자 속도' : 'Best Speed',
+    avgAccuracy: isKorean ? '평균 정확도' : 'Avg Accuracy',
+    avgResetCount: isKorean ? '평균 초기화 횟수' : 'Avg Resets',
+    countUnit: isKorean ? '회' : '',
+
+    // 오타 통계
+    typoTop10: isKorean ? '자주 틀리는 글자 TOP 10' : 'Most Missed Characters TOP 10',
+    noTypoData: isKorean ? '오타 데이터가 없습니다.' : 'No typo data available.',
+    typoDetailTitle: isKorean ? '오타 상세' : 'Typo Details',
+    noDetailData: isKorean ? '상세 데이터가 없습니다.' : 'No detail data available.',
+} as const;
+
+type TranslationKey = keyof typeof translations;
+type TranslationValue<K extends TranslationKey> = (typeof translations)[K];
+
+export function t<K extends TranslationKey>(key: K): TranslationValue<K> {
+    return translations[key];
+}

--- a/tp-react/src/utils/typoUtils.ts
+++ b/tp-react/src/utils/typoUtils.ts
@@ -49,35 +49,6 @@ const getMidIndex = (charCode: number): number => {
 };
 
 /**
- * 두 자모 분리 배열을 비교하여 첫 번째 불일치 자모의 TypoType을 반환한다.
- */
-export const determineTypoType = (
-    originalChar: string,
-    separatedSentence: string[],
-    separatedInput: string[],
-): TypoType => {
-    if (!isKoreanChar(originalChar)) {
-        return 'LETTER';
-    }
-
-    const midIndex = getMidIndex(originalChar.charCodeAt(0));
-    const medialLength = getMedialLength(midIndex);
-
-    // 자모 비교하여 첫 번째 불일치 위치 찾기
-    const maxLen = Math.max(separatedSentence.length, separatedInput.length);
-    for (let i = 0; i < maxLen; i++) {
-        const expected = separatedSentence[i] ?? '';
-        const actual = separatedInput[i] ?? '';
-        if (expected !== actual) {
-            return getTypoTypeByJamoIndex(i, medialLength);
-        }
-    }
-
-    // 모든 자모가 일치하는데 호출된 경우 (길이 차이 등) — FINAL로 폴백
-    return 'FINAL';
-};
-
-/**
  * flat 자모 인덱스에서 오타 엔트리를 생성한다.
  * 예문과 입력을 각각 flat 자모 배열로 비교하여 불일치 시 호출.
  */


### PR DESCRIPTION
- i18n.ts 번역 사전 (한국어/영어, 브라우저 언어 자동 감지)
- 28개 컴포넌트의 한국어 하드코딩을 t() 호출로 변경
- PrivacyPolicy, ConsentBanner는 기존 inline isKorean 방식 유지