### PR TITLE
feat: 첫 방문 사용자 기능 가이드 추가

### DIFF
--- a/tp-react/src/components/FeatureGuide/FeatureGuide.css
+++ b/tp-react/src/components/FeatureGuide/FeatureGuide.css
@@ -1,0 +1,57 @@
+.feature-guide {
+    position: absolute;
+    top: calc(100% + 0.5rem);
+    right: 2rem;
+    width: 320px;
+    padding: 1.25rem;
+    background: var(--color-popup-bg);
+    border: 2px solid var(--color-primary);
+    border-radius: 0.75rem;
+    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.12);
+    z-index: 1000;
+}
+
+.feature-guide::before {
+    content: '';
+    position: absolute;
+    top: -8px;
+    right: 24px;
+    width: 14px;
+    height: 14px;
+    background: var(--color-popup-bg);
+    border-top: 2px solid var(--color-primary);
+    border-left: 2px solid var(--color-primary);
+    transform: rotate(45deg);
+}
+
+.feature-guide-title {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0 0 0.5rem 0;
+}
+
+.feature-guide-desc {
+    font-size: 0.8125rem;
+    line-height: 1.65;
+    color: var(--color-text-muted);
+    margin: 0 0 1rem 0;
+}
+
+.feature-guide-confirm {
+    display: block;
+    width: 100%;
+    padding: 0.5rem;
+    border: none;
+    border-radius: 0.375rem;
+    background: var(--color-primary);
+    color: var(--color-white);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: background-color 0.15s;
+}
+
+.feature-guide-confirm:hover {
+    background: var(--color-primary-dark);
+}

--- a/tp-react/src/components/FeatureGuide/FeatureGuide.jsx
+++ b/tp-react/src/components/FeatureGuide/FeatureGuide.jsx
@@ -1,0 +1,27 @@
+import {useState} from 'react';
+import {Storage_Feature_Guide} from '@/const/config.const.ts';
+import {t} from '@/utils/i18n.ts';
+import './FeatureGuide.css';
+
+function FeatureGuide() {
+    const [visible, setVisible] = useState(() => !localStorage.getItem(Storage_Feature_Guide));
+
+    if (!visible) return null;
+
+    const dismiss = () => {
+        localStorage.setItem(Storage_Feature_Guide, 'true');
+        setVisible(false);
+    };
+
+    return (
+        <div className="feature-guide">
+            <h4 className="feature-guide-title">{t('featureGuideTitle')}</h4>
+            <p className="feature-guide-desc">{t('featureGuideDesc')}</p>
+            <button className="feature-guide-confirm" onClick={dismiss}>
+                {t('featureGuideConfirm')}
+            </button>
+        </div>
+    );
+}
+
+export default FeatureGuide;

--- a/tp-react/src/components/Head/Head.css
+++ b/tp-react/src/components/Head/Head.css
@@ -10,6 +10,7 @@
 }
 
 .head-right {
+    position: relative;
     display: flex;
     align-items: center;
     gap: 1rem;

--- a/tp-react/src/components/Head/Head.jsx
+++ b/tp-react/src/components/Head/Head.jsx
@@ -14,6 +14,7 @@ import {useGoogleLogin} from "@react-oauth/google";
 import {loginWithGoogle} from "@/utils/authApi.ts";
 import {FaPlus} from "react-icons/fa";
 import {t} from "@/utils/i18n.ts";
+import FeatureGuide from "../FeatureGuide/FeatureGuide";
 import "./Head.css";
 
 // UUID 형식 체크 함수
@@ -119,6 +120,7 @@ const Head = () => {
                     </button>
                     {user ? <ProfileDropdown/> : <LoginButton onClick={handleLogin}/>}
                     <DarkModeButton/>
+                    {!user && <FeatureGuide/>}
                 </div>
             </div>
 

--- a/tp-react/src/const/config.const.ts
+++ b/tp-react/src/const/config.const.ts
@@ -8,6 +8,7 @@ export const Storage_Compact_Mode = "Typing-Practice-compactMode" as const;
 export const Storage_Last_Seen_Version = "Typing-Practice-lastSeenVersion" as const;
 export const Storage_Refresh_Token = "Typing-Practice-refreshToken" as const;
 export const Storage_Consent = "Typing-Practice-storageConsent" as const;
+export const Storage_Feature_Guide = "Typing-Practice-featureGuide" as const;
 
 // Quote 관련 상수
 export const MIN_SENTENCE_LENGTH = 5 as const;

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -189,6 +189,13 @@ const translations = {
     noTypoData: isKorean ? '오타 데이터가 없습니다.' : 'No typo data available.',
     typoDetailTitle: isKorean ? '오타 상세' : 'Typo Details',
     noDetailData: isKorean ? '상세 데이터가 없습니다.' : 'No detail data available.',
+
+    // 기능 가이드
+    featureGuideTitle: isKorean ? '이런 기능이 있어요!' : 'Check out these features!',
+    featureGuideDesc: isKorean
+        ? '로그인하면 원하는 문장을 직접 업로드하고, 타이핑 기록과 오타 분석을 확인할 수 있어요.'
+        : 'Sign in to upload your own sentences and track your typing speed, accuracy, and typo patterns.',
+    featureGuideConfirm: isKorean ? '확인' : 'Got it',
 } as const;
 
 type TranslationKey = keyof typeof translations;


### PR DESCRIPTION
- 비로그인 상태에서 헤더 우측 하단에 안내 카드 표시
- 로그인/업로드/기록 기능 홍보
- 확인 버튼으로만 닫힘, localStorage에 기록하여 재방문 시 미표시
- 한국어/영어 자동 전환