### PR TITLE
feat: 서비스 이용약관 페이지 추가

### DIFF
--- a/tp-react/src/App.jsx
+++ b/tp-react/src/App.jsx
@@ -14,6 +14,7 @@ import MyQuotes from "./pages/MyQuotes/MyQuotes";
 import MyReports from "./pages/MyReports/MyReports";
 import Stats from "./pages/Stats/Stats";
 import PrivacyPolicy from "./pages/PrivacyPolicy/PrivacyPolicy";
+import TermsOfService from "./pages/TermsOfService/TermsOfService";
 import {Analytics} from "@vercel/analytics/react";
 
 function App() {
@@ -32,6 +33,7 @@ function App() {
                   <Route path="/quote/report" element={<MyReports />} />
                   <Route path="/stats" element={<Stats />} />
                   <Route path="/privacy" element={<PrivacyPolicy />} />
+                  <Route path="/terms" element={<TermsOfService />} />
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
                 <Contact />

--- a/tp-react/src/components/AppDiv/AppDiv.jsx
+++ b/tp-react/src/components/AppDiv/AppDiv.jsx
@@ -7,7 +7,7 @@ const AppDiv = ({ children }) => {
   const location = useLocation();
   
   // 상단 여백이 필요 없는 페이지
-  const isCompactPage = location.pathname.startsWith('/quote/') || location.pathname === '/stats' || location.pathname === '/privacy';
+  const isCompactPage = location.pathname.startsWith('/quote/') || location.pathname === '/stats' || location.pathname === '/privacy' || location.pathname === '/terms';
   
   return (
     <div className={`background ${isDark ? "dark" : ""} ${isCompactPage ? "compact" : ""}`}>

--- a/tp-react/src/components/Contact/Contact.jsx
+++ b/tp-react/src/components/Contact/Contact.jsx
@@ -18,6 +18,9 @@ const Contact = () => {
       <Link to="/privacy" className={`contact ${isDark && "dark"}`}>
         Privacy Policy
       </Link>
+      <Link to="/terms" className={`contact ${isDark && "dark"}`}>
+        Terms
+      </Link>
     </div>
   );
 };

--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -10,7 +10,7 @@ interface UpdateEntry {
 export const updateHistory: UpdateEntry[] = [
     {
         version: "1.2.0",
-        date: "2026년 3월 X일",
+        date: "2026년 3월 29일",
         showPopup: true,
         hidden: false,
         features: [

--- a/tp-react/src/pages/TermsOfService/TermsOfService.css
+++ b/tp-react/src/pages/TermsOfService/TermsOfService.css
@@ -1,0 +1,80 @@
+.terms-container {
+    width: 80%;
+    max-width: 800px;
+    min-width: 600px;
+    margin: 0 auto;
+    padding: 2rem;
+}
+
+.terms-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--color-primary);
+    margin: 0 0 0.25rem 0;
+}
+
+.terms-updated {
+    font-size: 0.8125rem;
+    color: var(--color-text-placeholder);
+    margin: 0 0 2rem 0;
+}
+
+.terms-section {
+    margin-bottom: 1.75rem;
+}
+
+.terms-section h2 {
+    font-size: 1.1rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0 0 0.5rem 0;
+}
+
+.terms-section p {
+    font-size: 0.875rem;
+    line-height: 1.7;
+    color: var(--color-text-muted);
+    margin: 0 0 0.5rem 0;
+}
+
+.terms-section ul {
+    margin: 0.25rem 0 0.5rem 1.25rem;
+    padding: 0;
+}
+
+.terms-section li {
+    font-size: 0.875rem;
+    line-height: 1.7;
+    color: var(--color-text-muted);
+}
+
+.terms-section a {
+    color: var(--color-primary);
+    text-decoration: none;
+}
+
+.terms-section a:hover {
+    text-decoration: underline;
+}
+
+.terms-footer {
+    margin-top: 1.75rem;
+    display: flex;
+    justify-content: center;
+}
+
+.terms-back-btn {
+    padding: 0.75rem 2rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    background-color: transparent;
+    color: var(--color-text-muted);
+    font-size: 1rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.terms-back-btn:hover {
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text);
+}

--- a/tp-react/src/pages/TermsOfService/TermsOfService.jsx
+++ b/tp-react/src/pages/TermsOfService/TermsOfService.jsx
@@ -1,0 +1,105 @@
+import {useNavigate} from 'react-router-dom';
+import {useTheme} from '../../Context/ThemeContext';
+import './TermsOfService.css';
+
+const isKorean = navigator.language.startsWith('ko');
+
+function TermsOfService() {
+    const navigate = useNavigate();
+    const {isDark} = useTheme();
+
+    return (
+        <div className={`terms-container ${isDark ? 'dark' : ''}`}>
+            <h1 className="terms-title">{isKorean ? '서비스 이용약관' : 'Terms of Service'}</h1>
+            <p className="terms-updated">{isKorean ? '최종 수정일: 2026년 3월 29일' : 'Last updated: March 29, 2026'}</p>
+
+            <section className="terms-section">
+                <h2>{isKorean ? '1. 서비스 소개' : '1. About the Service'}</h2>
+                <p>
+                    {isKorean
+                        ? 'Typing Practice는 무료로 제공되는 타이핑 연습 서비스입니다. 누구나 회원가입 없이 기본 기능을 이용할 수 있으며, Google 로그인을 통해 추가 기능을 이용할 수 있습니다.'
+                        : 'Typing Practice is a free typing practice service. Anyone can use basic features without an account, and additional features are available by signing in with Google.'}
+                </p>
+            </section>
+
+            <section className="terms-section">
+                <h2>{isKorean ? '2. 이용 조건' : '2. Terms of Use'}</h2>
+                <p>{isKorean ? '서비스를 이용함으로써 다음 사항에 동의합니다:' : 'By using the service, you agree to the following:'}</p>
+                <ul>
+                    <li>{isKorean ? '서비스를 합법적인 목적으로만 사용합니다.' : 'Use the service only for lawful purposes.'}</li>
+                    <li>{isKorean ? '다른 사용자에게 피해를 주는 행위를 하지 않습니다.' : 'Do not engage in activities that harm other users.'}</li>
+                    <li>{isKorean ? '부적절한 내용의 문장을 업로드하지 않습니다.' : 'Do not upload sentences with inappropriate content.'}</li>
+                    <li>{isKorean ? '서비스의 정상적인 운영을 방해하지 않습니다.' : 'Do not interfere with the normal operation of the service.'}</li>
+                    <li>{isKorean ? '허위 신고 등 기능을 악용하지 않습니다.' : 'Do not abuse features such as filing false reports.'}</li>
+                </ul>
+                <p>
+                    {isKorean
+                        ? '위 사항을 위반하는 경우 문장 업로드, 신고 등의 기능 이용이 제한되거나 계정이 정지될 수 있습니다.'
+                        : 'Violations may result in restrictions on features such as sentence uploads and reports, or suspension of your account.'}
+                </p>
+            </section>
+
+            <section className="terms-section">
+                <h2>{isKorean ? '3. 사용자 콘텐츠' : '3. User Content'}</h2>
+                <p>
+                    {isKorean
+                        ? '사용자가 업로드한 문장은 공개 설정 시 다른 사용자에게 노출될 수 있습니다. 저작권이 있는 문장을 업로드하는 경우 그에 대한 책임은 업로드한 사용자에게 있습니다. 부적절한 문장은 관리자에 의해 삭제될 수 있습니다.'
+                        : 'Sentences uploaded by users may be visible to other users when set to public. Users are responsible for any copyrighted content they upload. Inappropriate sentences may be removed by administrators.'}
+                </p>
+            </section>
+
+            <section className="terms-section">
+                <h2>{isKorean ? '4. 계정' : '4. Accounts'}</h2>
+                <p>
+                    {isKorean
+                        ? 'Google OAuth를 통해 로그인하며, 별도의 비밀번호를 저장하지 않습니다. 계정 삭제를 원하시면 문의해 주세요.'
+                        : 'You sign in through Google OAuth, and we do not store any passwords. If you wish to delete your account, please contact us.'}
+                </p>
+            </section>
+
+            <section className="terms-section">
+                <h2>{isKorean ? '5. 서비스 변경 및 중단' : '5. Service Changes and Termination'}</h2>
+                <p>
+                    {isKorean
+                        ? '서비스는 사전 공지 없이 변경되거나 중단될 수 있습니다. 무료 서비스이므로 서비스 중단으로 인한 책임을 지지 않습니다.'
+                        : 'The service may be changed or discontinued without prior notice. As a free service, we are not liable for any service interruptions.'}
+                </p>
+            </section>
+
+            <section className="terms-section">
+                <h2>{isKorean ? '6. 면책 조항' : '6. Disclaimer'}</h2>
+                <p>
+                    {isKorean
+                        ? '서비스는 "있는 그대로" 제공되며, 명시적이거나 묵시적인 어떠한 보증도 하지 않습니다. 서비스 이용으로 인해 발생하는 손해에 대해 책임을 지지 않습니다.'
+                        : 'The service is provided "as is" without any warranties, express or implied. We are not liable for any damages arising from the use of the service.'}
+                </p>
+            </section>
+
+            <section className="terms-section">
+                <h2>{isKorean ? '7. 약관 변경' : '7. Changes to These Terms'}</h2>
+                <p>
+                    {isKorean
+                        ? '이 약관은 수시로 업데이트될 수 있습니다. 변경 사항은 이 페이지에 수정 날짜와 함께 반영됩니다.'
+                        : 'These terms may be updated from time to time. Changes will be reflected on this page with an updated date.'}
+                </p>
+            </section>
+
+            <section className="terms-section">
+                <h2>{isKorean ? '8. 문의' : '8. Contact'}</h2>
+                <p>
+                    {isKorean
+                        ? <>서비스 이용에 관한 문의는 <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">카카오톡</a>으로 연락해 주세요.</>
+                        : <>For inquiries about the service, please contact us at <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">KakaoTalk</a>.</>}
+                </p>
+            </section>
+
+            <div className="terms-footer">
+                <button className="terms-back-btn" onClick={() => navigate('/')}>
+                    {isKorean ? '돌아가기' : 'Back'}
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export default TermsOfService;

--- a/tp-react/vercel.json
+++ b/tp-react/vercel.json
@@ -1,0 +1,8 @@
+{
+  "rewrites": [
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ]
+}


### PR DESCRIPTION
- /terms 라우트 및 이용약관 페이지 (한국어/영어 전환)
- 악의적 활동 시 기능 제한/계정 정지 제재 조항 포함
- Contact 영역에 Terms 링크 추가