### PR TITLE
feat: Nginx 리버스 프록시 및 HTTPS 설정, 운영 보안 강화

### DIFF
--- a/typing-practice-be/.gitignore
+++ b/typing-practice-be/.gitignore
@@ -12,6 +12,8 @@ data.mv.db
 .env.local
 .env.prod
 
+nginx/nginx.conf
+
 # application-local.yaml (민감정보 포함)
 src/main/resources/application-local.yaml
 src/main/resources/application-prod.yaml

--- a/typing-practice-be/docker-compose.prod.yaml
+++ b/typing-practice-be/docker-compose.prod.yaml
@@ -41,5 +41,24 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
 
+  nginx:
+    image: nginx:alpine
+    restart: always
+    ports:
+      - '80:80'
+      - '443:443'
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+      - ./certbot/www:/var/www/certbot
+      - ./certbot/conf:/etc/letsencrypt
+    depends_on:
+      - app
+
+  certbot:
+    image: certbot/certbot
+    volumes:
+      - ./certbot/www:/var/www/certbot
+      - ./certbot/conf:/etc/letsencrypt
+
 volumes:
   grafana-data:

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/AuthController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/AuthController.java
@@ -1,10 +1,10 @@
 package com.typingpractice.typing_practice_be.auth.controller;
 
+import com.typingpractice.typing_practice_be.auth.dto.*;
 import com.typingpractice.typing_practice_be.auth.dto.google.GoogleLoginRequest;
 import com.typingpractice.typing_practice_be.auth.dto.google.GoogleTokenResponse;
 import com.typingpractice.typing_practice_be.auth.dto.google.GoogleUserInfo;
 import com.typingpractice.typing_practice_be.auth.service.AuthService;
-import com.typingpractice.typing_practice_be.auth.dto.*;
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.jwt.JwtTokenProvider;
 import com.typingpractice.typing_practice_be.member.domain.Member;
@@ -13,8 +13,6 @@ import com.typingpractice.typing_practice_be.member.service.MemberService;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.UUID;
 
 @RestController
 @RequestMapping("/auth")
@@ -25,24 +23,24 @@ public class AuthController {
   private final MemberService memberService;
   private final JwtTokenProvider jwtTokenProvider;
 
-  @PostMapping("/test")
-  public ApiResponse<LoginResponse> testLogin(@RequestBody TestLoginRequest request) {
-
-    LoginResult loginResult =
-        memberService.loginOrSignIn(
-            GoogleUserInfo.create(
-                request.getProviderId(),
-                "email",
-                "user_" + UUID.randomUUID().toString().substring(0, 8),
-                "picture"));
-
-    Member member = loginResult.getMember();
-
-    String token = jwtTokenProvider.createToken(member.getId(), member.getRole());
-    String refreshToken = authService.createRefreshToken(member);
-
-    return ApiResponse.ok(LoginResponse.from(loginResult, token, refreshToken));
-  }
+  //	@PostMapping("/test")
+  //	public ApiResponse<LoginResponse> testLogin(@RequestBody TestLoginRequest request) {
+  //
+  //		LoginResult loginResult =
+  //						memberService.loginOrSignIn(
+  //										GoogleUserInfo.create(
+  //														request.getProviderId(),
+  //														"email",
+  //														"user_" + UUID.randomUUID().toString().substring(0, 8),
+  //														"picture"));
+  //
+  //		Member member = loginResult.getMember();
+  //
+  //		String token = jwtTokenProvider.createToken(member.getId(), member.getRole());
+  //		String refreshToken = authService.createRefreshToken(member);
+  //
+  //		return ApiResponse.ok(LoginResponse.from(loginResult, token, refreshToken));
+  //	}
 
   @PostMapping("/google")
   public ApiResponse<LoginResponse> googleLogin(@RequestBody GoogleLoginRequest request) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -48,13 +48,13 @@ public class SecurityConfig {
 										auth ->
 														auth
 																		// 인증 불필요
-																		.requestMatchers("/swagger-ui/**", "/api-docs/**")
-																		.permitAll()
-																		.requestMatchers("/h2-console/**")
-																		.permitAll()
+																		// .requestMatchers("/swagger-ui/**", "/api-docs/**")
+																		// .permitAll()
+																		// .requestMatchers("/h2-console/**")
+																		// .permitAll()
+																		// .requestMatchers("/auth/test")
+																		// .permitAll()
 																		.requestMatchers("/auth/google")
-																		.permitAll()
-																		.requestMatchers("/auth/test")
 																		.permitAll()
 																		.requestMatchers("/auth/refresh")
 																		.permitAll()
@@ -93,7 +93,11 @@ public class SecurityConfig {
 	@Bean
 	public CorsConfigurationSource corsConfigurationSource() {
 		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(List.of("http://localhost:3000", "http://localhost:3001"));
+		configuration.setAllowedOrigins(
+						List.of(
+										"https://typing-practice-omega.vercel.app",
+										"http://localhost:3000",
+										"http://localhost:3001"));
 		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
 		configuration.setAllowedHeaders(List.of("*"));
 


### PR DESCRIPTION
- docker-compose.prod.yaml에 Nginx, certbot 컨테이너 추가
- Let's Encrypt SSL 인증서 적용 (api.typing-practice.com)
- CORS에 Vercel 배포 도메인 추가
- 운영 환경 불필요 엔드포인트 차단 (Swagger UI, h2-console, /auth/test)