### PR TITLE
fix: 배치 전 통계 조회 시 어제 데이터 공백 해결

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -27,82 +27,82 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-	private final JwtTokenProvider jwtTokenProvider;
-	private final AuthService authService;
-	private final CustomAuthenticationEntryPoint authenticationEntryPoint;
-	private final CustomAccessDeniedHandler accessDeniedHandler;
+  private final JwtTokenProvider jwtTokenProvider;
+  private final AuthService authService;
+  private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+  private final CustomAccessDeniedHandler accessDeniedHandler;
 
-	@Bean
-	public JwtAuthenticationFilter jwtAuthenticationFilter(
-					JwtTokenProvider jwtTokenProvider, AuthService authService) {
-		return new JwtAuthenticationFilter(jwtTokenProvider, authService);
-	}
+  @Bean
+  public JwtAuthenticationFilter jwtAuthenticationFilter(
+      JwtTokenProvider jwtTokenProvider, AuthService authService) {
+    return new JwtAuthenticationFilter(jwtTokenProvider, authService);
+  }
 
-	@Bean
-	public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-		http.cors(Customizer.withDefaults())
-						.csrf(AbstractHttpConfigurer::disable)
-						.sessionManagement(
-										session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 안 씀
-						.authorizeHttpRequests(
-										auth ->
-														auth
-																		// 인증 불필요
-																		// .requestMatchers("/swagger-ui/**", "/api-docs/**")
-																		// .permitAll()
-																		// .requestMatchers("/h2-console/**")
-																		// .permitAll()
-																		// .requestMatchers("/auth/test")
-																		// .permitAll()
-																		.requestMatchers("/auth/google")
-																		.permitAll()
-																		.requestMatchers("/auth/refresh")
-																		.permitAll()
-																		.requestMatchers(HttpMethod.GET, "/quotes")
-																		.permitAll()
-																		.requestMatchers("/error")
-																		.permitAll()
-																		.requestMatchers(HttpMethod.POST, "/typing-records")
-																		.permitAll()
-																		.requestMatchers("/actuator/prometheus")
-																		.permitAll()
-																		// 관리자 전용
-																		.requestMatchers("/admin/**")
-																		.hasRole("ADMIN")
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.cors(Customizer.withDefaults())
+        .csrf(AbstractHttpConfigurer::disable)
+        .sessionManagement(
+            session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 안 씀
+        .authorizeHttpRequests(
+            auth ->
+                auth
+                    // 인증 불필요
+                    // .requestMatchers("/swagger-ui/**", "/api-docs/**")
+                    // .permitAll()
+                    // .requestMatchers("/h2-console/**")
+                    // .permitAll()
+                    // .requestMatchers("/auth/test")
+                    // .permitAll()
+                    .requestMatchers("/auth/google")
+                    .permitAll()
+                    .requestMatchers("/auth/refresh")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/quotes")
+                    .permitAll()
+                    .requestMatchers("/error")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.POST, "/typing-records")
+                    .permitAll()
+                    .requestMatchers("/actuator/prometheus")
+                    .permitAll()
+                    // 관리자 전용
+                    .requestMatchers("/admin/**")
+                    .hasRole("ADMIN")
 
-																		// BANNED 제외 (USER, ADMIN만)
-																		.requestMatchers(HttpMethod.POST, "/quotes/public")
-																		.hasAnyRole("USER", "ADMIN")
-																		.requestMatchers(HttpMethod.POST, "/quotes/*/publish")
-																		.hasAnyRole("USER", "ADMIN")
-																		.requestMatchers(HttpMethod.POST, "/reports")
-																		.hasAnyRole("USER", "ADMIN")
-																		.anyRequest()
-																		.authenticated())
-						.exceptionHandling(
-										ex ->
-														ex.authenticationEntryPoint(authenticationEntryPoint)
-																		.accessDeniedHandler(accessDeniedHandler))
-						.addFilterBefore(
-										jwtAuthenticationFilter(jwtTokenProvider, authService),
-										UsernamePasswordAuthenticationFilter.class);
+                    // BANNED 제외 (USER, ADMIN만)
+                    .requestMatchers(HttpMethod.POST, "/quotes/public")
+                    .hasAnyRole("USER", "ADMIN")
+                    .requestMatchers(HttpMethod.POST, "/quotes/*/publish")
+                    .hasAnyRole("USER", "ADMIN")
+                    .requestMatchers(HttpMethod.POST, "/reports")
+                    .hasAnyRole("USER", "ADMIN")
+                    .anyRequest()
+                    .authenticated())
+        .exceptionHandling(
+            ex ->
+                ex.authenticationEntryPoint(authenticationEntryPoint)
+                    .accessDeniedHandler(accessDeniedHandler))
+        .addFilterBefore(
+            jwtAuthenticationFilter(jwtTokenProvider, authService),
+            UsernamePasswordAuthenticationFilter.class);
 
-		return http.build();
-	}
+    return http.build();
+  }
 
-	@Bean
-	public CorsConfigurationSource corsConfigurationSource() {
-		CorsConfiguration configuration = new CorsConfiguration();
-		configuration.setAllowedOrigins(
-						List.of(
-										"https://typing-practice-omega.vercel.app",
-										"http://localhost:3000",
-										"http://localhost:3001"));
-		configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-		configuration.setAllowedHeaders(List.of("*"));
+  @Bean
+  public CorsConfigurationSource corsConfigurationSource() {
+    CorsConfiguration configuration = new CorsConfiguration();
+    configuration.setAllowedOrigins(
+        List.of(
+            "https://typing-practice-omega.vercel.app",
+            "http://localhost:3000",
+            "http://localhost:3001"));
+    configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
+    configuration.setAllowedHeaders(List.of("*"));
 
-		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-		source.registerCorsConfiguration("/**", configuration);
-		return source;
-	}
+    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+    source.registerCorsConfiguration("/**", configuration);
+    return source;
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
@@ -7,13 +7,15 @@ import com.typingpractice.typing_practice_be.typingrecord.dto.MemberDailyStatsRe
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypingStatsResponse;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypoDetailStatsResponse;
 import com.typingpractice.typing_practice_be.typingrecord.dto.MemberTypoStatsResponse;
+import com.typingpractice.typing_practice_be.typingrecord.repository.MemberDailyAggregationRepository;
+import com.typingpractice.typing_practice_be.typingrecord.repository.MemberTypingAggregationRepository;
+import com.typingpractice.typing_practice_be.typingrecord.repository.MemberTypoAggregationRepository;
+import com.typingpractice.typing_practice_be.typingrecord.repository.TypingRecordRepository;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberDailyStats;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypoDetailStats;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypoStats;
-import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypingSnapshot;
-import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypoDetailSnapshot;
-import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypoSnapshot;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.*;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberDailyStatsRepository;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypingStatsRepository;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypoDetailStatsRepository;
@@ -26,12 +28,18 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Duration;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class MemberStatisticsService {
+  private final TypingRecordRepository typingRecordRepository;
+  private final MemberTypingAggregationRepository memberTypingAggregationRepository;
+  private final MemberDailyAggregationRepository memberDailyAggregationRepository;
+  private final MemberTypoAggregationRepository memberTypoAggregationRepository;
+
   private final MemberTypingStatsRepository memberTypingStatsRepository;
   private final MemberDailyStatsRepository memberDailyStatsRepository;
   private final MemberTypoStatsRepository memberTypoStatsRepository;
@@ -43,22 +51,55 @@ public class MemberStatisticsService {
   private static final String COOLDOWN_KEY_PREFIX = "cooldown:refresh:";
   private static final Duration COOLDOWN_DURATION = Duration.ofMinutes(1);
 
+  private boolean isYesterdayBatchPending(Long memberId, QuoteLanguage language) {
+    LocalDate yesterday = LocalDate.now(TimeUtils.KST).minusDays(1);
+
+    // PostgreSQL 에 어제 DailyStats 있으면 배치 완료
+    if (memberDailyStatsRepository
+        .findByMemberIdAndDateAndLanguage(memberId, yesterday, language)
+        .isPresent()) {
+      return false;
+    }
+
+    // MongoDB에 어제 기록 있으면 배치 미완료
+    LocalDateTime from = TimeUtils.startOfDayKstToUtc(yesterday);
+    LocalDateTime to = TimeUtils.endOfDayKstToUtc(yesterday);
+    return typingRecordRepository.existsByMemberIdBetween(memberId, from, to);
+  }
+
   public MemberTypingStatsResponse getTypingStats(Long memberId, QuoteLanguage language) {
     MemberTypingStats pg =
         memberTypingStatsRepository.findByMemberIdAndLanguage(memberId, language).orElse(null);
     TodayTypingSnapshot today = todayTypingStatsRedisService.getTyping(memberId, language);
 
-    if (pg == null && today.getTotalAttempts() == 0) {
-      return MemberTypingStatsResponse.empty();
-    }
-    if (pg == null) {
-      return MemberTypingStatsResponse.from(today);
-    }
-    if (today.getTotalAttempts() == 0) {
-      return MemberTypingStatsResponse.from(pg);
+    MemberTypingAggregation yesterday = null;
+    if (isYesterdayBatchPending(memberId, language)) {
+      LocalDate yesterdayDate = LocalDate.now(TimeUtils.KST).minusDays(1);
+      LocalDateTime from = TimeUtils.startOfDayKstToUtc(yesterdayDate);
+      LocalDateTime to = TimeUtils.endOfDayKstToUtc(yesterdayDate);
+
+      List<MemberTypingAggregation> agg =
+          memberTypingAggregationRepository.aggregateByMemberIdsAndLanguageBetween(
+              List.of(memberId), language, from, to);
+
+      if (!agg.isEmpty()) {
+        yesterday = agg.getFirst();
+      }
     }
 
-    return MemberTypingStatsResponse.merge(pg, today);
+    //    if (pg == null && today.getTotalAttempts() == 0) {
+    //      return MemberTypingStatsResponse.empty();
+    //    }
+    //    if (pg == null) {
+    //      return MemberTypingStatsResponse.from(today);
+    //    }
+    //    if (today.getTotalAttempts() == 0) {
+    //      return MemberTypingStatsResponse.from(pg);
+    //    }
+    //
+    //    return MemberTypingStatsResponse.merge(pg, today);
+
+    return MemberTypingStatsResponse.of(pg, yesterday, today);
   }
 
   public MemberDailyStatsResponse getDailyStats(Long memberId, QuoteLanguage language, int days) {
@@ -72,7 +113,21 @@ public class MemberStatisticsService {
 
     TodayTypingSnapshot today = todayTypingStatsRedisService.getTyping(memberId, language);
 
-    return MemberDailyStatsResponse.of(days, pgList, today, todayKst);
+    MemberDailyAggregation yesterdayAgg = null;
+    if (isYesterdayBatchPending(memberId, language)) {
+      LocalDateTime yesterdayFrom = TimeUtils.startOfDayKstToUtc(yesterday);
+      LocalDateTime yesterdayTo = TimeUtils.endOfDayKstToUtc(yesterday);
+
+      List<MemberDailyAggregation> agg =
+          memberDailyAggregationRepository.aggregateByMemberIdsAndLanguageBetween(
+              List.of(memberId), language, yesterdayFrom, yesterdayTo);
+
+      if (!agg.isEmpty()) {
+        yesterdayAgg = agg.getFirst();
+      }
+    }
+
+    return MemberDailyStatsResponse.of(days, pgList, yesterdayAgg, today, todayKst);
   }
 
   public MemberTypoStatsResponse getTypoStats(Long memberId, QuoteLanguage language) {
@@ -81,7 +136,18 @@ public class MemberStatisticsService {
 
     TodayTypoSnapshot today = todayTypingStatsRedisService.getTypoByLanguage(memberId, language);
 
-    return MemberTypoStatsResponse.of(language, pgList, today);
+    List<MemberTypoAggregation> yesterdayList = List.of();
+    if (isYesterdayBatchPending(memberId, language)) {
+      LocalDate yesterday = LocalDate.now(TimeUtils.KST).minusDays(1);
+      LocalDateTime from = TimeUtils.startOfDayKstToUtc(yesterday);
+      LocalDateTime to = TimeUtils.endOfDayKstToUtc(yesterday);
+
+      yesterdayList =
+          memberTypoAggregationRepository.aggregateByMemberIdsBetween(List.of(memberId), from, to);
+    }
+
+    return MemberTypoStatsResponse.of(language, pgList, yesterdayList, today);
+    // return MemberTypoStatsResponse.of(language, pgList, today);
   }
 
   public MemberTypoDetailStatsResponse getTypoDetailStats(
@@ -94,7 +160,22 @@ public class MemberStatisticsService {
         todayTypingStatsRedisService.getTypoDetailByLanguageAndExpected(
             memberId, language, expected);
 
-    return MemberTypoDetailStatsResponse.of(language, expected, pgList, todayFiltered);
+    List<MemberTypoAggregation> yesterdayList = List.of();
+    if (isYesterdayBatchPending(memberId, language)) {
+      LocalDate yesterday = LocalDate.now(TimeUtils.KST).minusDays(1);
+      LocalDateTime from = TimeUtils.startOfDayKstToUtc(yesterday);
+      LocalDateTime to = TimeUtils.endOfDayKstToUtc(yesterday);
+
+      yesterdayList =
+          memberTypoAggregationRepository
+              .aggregateByMemberIdsBetween(List.of(memberId), from, to)
+              .stream()
+              .filter(agg -> agg.getExpected().equals(expected))
+              .toList();
+    }
+    return MemberTypoDetailStatsResponse.of(
+        language, expected, pgList, yesterdayList, todayFiltered);
+    // return MemberTypoDetailStatsResponse.of(language, expected, pgList, todayFiltered);
   }
 
   public MemberTypingStatsResponse refreshStats(Long memberId, QuoteLanguage language) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberDailyStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberDailyStatsResponse.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.typingrecord.dto;
 
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberDailyStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberDailyAggregation;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypingSnapshot;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -23,6 +24,30 @@ public class MemberDailyStatsResponse {
     response.days = days;
     response.content = content;
     return response;
+  }
+
+  public static MemberDailyStatsResponse of(
+      int days,
+      List<MemberDailyStats> pgList,
+      MemberDailyAggregation yesterday,
+      TodayTypingSnapshot today,
+      LocalDate todayDate) {
+
+    List<DayEntry> content = new ArrayList<>();
+
+    for (MemberDailyStats stats : pgList) {
+      content.add(DayEntry.from(stats));
+    }
+
+    if (yesterday != null) {
+      content.add(DayEntry.from(yesterday));
+    }
+
+    if (today.getTotalAttempts() > 0) {
+      content.add(DayEntry.fromToday(today, todayDate));
+    }
+
+    return create(days, content);
   }
 
   public static MemberDailyStatsResponse of(
@@ -50,6 +75,18 @@ public class MemberDailyStatsResponse {
     private int bestCpm;
     private int resetCount;
     private float practiceTimeMin;
+
+    public static DayEntry from(MemberDailyAggregation agg) {
+      DayEntry entry = new DayEntry();
+      entry.date = agg.getDateAsLocalDate();
+      entry.attempts = agg.getAttempts();
+      entry.avgCpm = agg.getAvgCpm();
+      entry.avgAcc = agg.getAvgAcc();
+      entry.bestCpm = agg.getBestCpm();
+      entry.resetCount = agg.getResetCount();
+      entry.practiceTimeMin = agg.getPracticeTimeMin();
+      return entry;
+    }
 
     public static DayEntry from(MemberDailyStats stats) {
       DayEntry entry = new DayEntry();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberTypingStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberTypingStatsResponse.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.typingrecord.dto;
 
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypingAggregation;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypingSnapshot;
 import lombok.Getter;
 import lombok.ToString;
@@ -72,5 +73,52 @@ public class MemberTypingStatsResponse {
         Math.max(pg.getBestCpm(), today.getBestCpm()),
         pg.getTotalPracticeTimeMin() + today.getTotalPracticeTimeMin(),
         pg.getTotalResetCount() + today.getTotalResetCount());
+  }
+
+  public static MemberTypingStatsResponse of(
+      MemberTypingStats pg, MemberTypingAggregation yesterday, TodayTypingSnapshot today) {
+
+    int totalAttempts = 0;
+    float sumCpm = 0, sumAcc = 0;
+    int bestCpm = 0;
+    float totalPracticeTimeMin = 0;
+    int totalResetCount = 0;
+
+    if (pg != null) {
+      totalAttempts += pg.getTotalAttempts();
+      sumCpm += pg.getAvgCpm() * pg.getTotalAttempts();
+      sumAcc += pg.getAvgAcc() * pg.getTotalAttempts();
+      bestCpm = pg.getBestCpm();
+      totalPracticeTimeMin += pg.getTotalPracticeTimeMin();
+      totalResetCount += pg.getTotalResetCount();
+    }
+
+    if (yesterday != null) {
+      totalAttempts += yesterday.getTotalAttempts();
+      sumCpm += yesterday.getAvgCpm() * yesterday.getTotalAttempts();
+      sumAcc += yesterday.getAvgAcc() * yesterday.getTotalAttempts();
+      bestCpm = Math.max(bestCpm, yesterday.getBestCpm());
+      totalPracticeTimeMin += yesterday.getTotalPracticeTimeMin();
+      totalResetCount += yesterday.getTotalResetCount();
+    }
+
+    if (today.getTotalAttempts() > 0) {
+      totalAttempts += today.getTotalAttempts();
+      sumCpm += today.getAvgCpm() * today.getTotalAttempts();
+      sumAcc += today.getAvgAcc() * today.getTotalAttempts();
+      bestCpm = Math.max(bestCpm, today.getBestCpm());
+      totalPracticeTimeMin += today.getTotalPracticeTimeMin();
+      totalResetCount += today.getTotalResetCount();
+    }
+
+    if (totalAttempts == 0) return empty();
+
+    return create(
+        totalAttempts,
+        sumCpm / totalAttempts,
+        sumAcc / totalAttempts,
+        bestCpm,
+        totalPracticeTimeMin,
+        totalResetCount);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberTypoDetailStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberTypoDetailStatsResponse.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.typingrecord.dto;
 
 import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypoDetailStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypoAggregation;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypoDetailEntry;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypoDetailSnapshot;
 import lombok.AccessLevel;
@@ -16,6 +17,44 @@ import java.util.Map;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberTypoDetailStatsResponse {
   private List<DetailEntry> content;
+
+  public static MemberTypoDetailStatsResponse of(
+      QuoteLanguage language,
+      String expected,
+      List<MemberTypoDetailStats> pgList,
+      List<MemberTypoAggregation> yesterdayList,
+      TodayTypoDetailSnapshot todayFiltered) {
+
+    Map<String, DetailEntry> mergedMap = new HashMap<>();
+
+    for (MemberTypoDetailStats stats : pgList) {
+      String key =
+          TodayTypoDetailSnapshot.toKey(
+              stats.getLanguage(), stats.getExpected(), stats.getActual());
+      mergedMap.put(key, DetailEntry.from(stats));
+    }
+
+    for (MemberTypoAggregation agg : yesterdayList) {
+      String key =
+          TodayTypoDetailSnapshot.toKey(agg.getLanguage(), agg.getExpected(), agg.getActual());
+      mergedMap.merge(key, DetailEntry.from(agg), DetailEntry::merge);
+    }
+
+    for (Map.Entry<String, TodayTypoDetailEntry> entry : todayFiltered.getDetailMap().entrySet()) {
+      mergedMap.merge(
+          entry.getKey(),
+          DetailEntry.fromToday(language, expected, entry.getKey(), entry.getValue()),
+          DetailEntry::merge);
+    }
+
+    MemberTypoDetailStatsResponse response = new MemberTypoDetailStatsResponse();
+    response.content =
+        mergedMap.values().stream()
+            .sorted((a, b) -> Integer.compare(b.getTypoCount(), a.getTypoCount()))
+            .toList();
+
+    return response;
+  }
 
   public static MemberTypoDetailStatsResponse of(
       QuoteLanguage language,
@@ -60,6 +99,19 @@ public class MemberTypoDetailStatsResponse {
     private int medialCount;
     private int finalCount;
     private int letterCount;
+
+    public static DetailEntry from(MemberTypoAggregation agg) {
+      DetailEntry entry = new DetailEntry();
+      entry.language = agg.getLanguage();
+      entry.expected = agg.getExpected();
+      entry.actual = agg.getActual();
+      entry.typoCount = agg.getCount();
+      entry.initialCount = agg.getInitialCount();
+      entry.medialCount = agg.getMedialCount();
+      entry.finalCount = agg.getFinalCount();
+      entry.letterCount = agg.getLetterCount();
+      return entry;
+    }
 
     public static DetailEntry from(MemberTypoDetailStats stats) {
       DetailEntry entry = new DetailEntry();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberTypoStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/MemberTypoStatsResponse.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.typingrecord.dto;
 
 import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypoStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.MemberTypoAggregation;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.dto.TodayTypoSnapshot;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,6 +18,45 @@ import java.util.Map;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MemberTypoStatsResponse {
   private List<TypoEntry> content;
+
+  public static MemberTypoStatsResponse of(
+      QuoteLanguage language,
+      List<MemberTypoStats> pgList,
+      List<MemberTypoAggregation> yesterdayList,
+      TodayTypoSnapshot today) {
+
+    Map<String, Integer> mergedMap = new HashMap<>();
+
+    for (MemberTypoStats stats : pgList) {
+      String key = TodayTypoSnapshot.toKey(stats.getLanguage(), stats.getExpected());
+      mergedMap.put(key, stats.getTypoCount());
+    }
+
+    // 어제 MongoDB 데이터 (expected별 합산)
+    for (MemberTypoAggregation agg : yesterdayList) {
+      String key = TodayTypoSnapshot.toKey(agg.getLanguage(), agg.getExpected());
+      mergedMap.merge(key, agg.getCount(), Integer::sum);
+    }
+
+    for (Map.Entry<String, Integer> entry : today.getTypoCountMap().entrySet()) {
+      mergedMap.merge(entry.getKey(), entry.getValue(), Integer::sum);
+    }
+
+    String prefix = language + ":";
+    MemberTypoStatsResponse response = new MemberTypoStatsResponse();
+    response.content =
+        mergedMap.entrySet().stream()
+            .map(
+                e -> {
+                  String expected = e.getKey().substring(prefix.length());
+                  return TypoEntry.create(language, expected, e.getValue());
+                })
+            .sorted((a, b) -> Integer.compare(b.getCount(), a.getCount()))
+            .limit(10)
+            .toList();
+
+    return response;
+  }
 
   public static MemberTypoStatsResponse of(
       QuoteLanguage language, List<MemberTypoStats> pgList, TodayTypoSnapshot today) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
@@ -6,6 +6,7 @@ import org.bson.Document;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
@@ -18,6 +19,16 @@ public class TypingRecordRepository {
 
   public TypingRecord save(TypingRecord record) {
     return mongoTemplate.save(record);
+  }
+
+  public boolean existsByMemberIdBetween(Long memberId, LocalDateTime from, LocalDateTime to) {
+    long count =
+        mongoTemplate.count(
+            Query.query(
+                Criteria.where("memberId").is(memberId).and("completedAt").gte(from).lt(to)),
+            "typingRecord");
+
+    return count > 0;
   }
 
   public List<Long> findDistinctMemberIds() {


### PR DESCRIPTION
- Redis TTL 만료(00:00) ~ 배치 실행(03:00) 사이 어제 데이터 누락 문제 해결
- isYesterdayBatchPending: PostgreSQL에 어제 DailyStats 없고 MongoDB에 어제 기록 있으면 배치 미완료로 판단
- TypingRecordRepository: existsByMemberIdBetween 추가
- getTypingStats: PostgreSQL + MongoDB 어제치 + Redis 오늘 3개 소스 합산
- getDailyStats: 배치 미완료 시 MongoDB 어제 DayEntry 추가
- getTypoStats: 배치 미완료 시 MongoDB 어제 오타 합산
- getTypoDetailStats: 배치 미완료 시 MongoDB 어제 오타 상세 합산 (expected 필터링)