### PR TITLE
fix: 페이지 이동 시 세션 통계 초기화 방지

### DIFF
--- a/tp-react/src/App.jsx
+++ b/tp-react/src/App.jsx
@@ -4,6 +4,7 @@ import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { ThemeContextProvider } from "./Context/ThemeContext";
 import { AuthProvider } from "./Context/AuthContext";
 import { ErrorProvider } from "./Context/ErrorContext";
+import { ScoreContextProvider } from "./Context/ScoreContext";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import Head from "./components/Head/Head";
 import AppDiv from "./components/AppDiv/AppDiv";
@@ -24,6 +25,7 @@ function App() {
         <ThemeContextProvider>
           <ErrorProvider>
             <AuthProvider>
+              <ScoreContextProvider>
               <AppDiv>
                 <Head />
                 <Routes>
@@ -39,6 +41,7 @@ function App() {
                 <Contact />
                 <Analytics/>
               </AppDiv>
+              </ScoreContextProvider>
             </AuthProvider>
           </ErrorProvider>
         </ThemeContextProvider>

--- a/tp-react/src/pages/Home/Home.jsx
+++ b/tp-react/src/pages/Home/Home.jsx
@@ -5,7 +5,6 @@ import AverageScorePopUp from './components/AverageScorePopUp/AverageScorePopUp'
 import Info from './components/Info/Info';
 import Quote from './components/Quote/Quote';
 import {SettingContextProvider} from '../../Context/SettingContext';
-import {ScoreContextProvider} from '../../Context/ScoreContext';
 import {QuoteContextProvider} from '../../Context/QuoteContext';
 
 function Home() {
@@ -16,13 +15,11 @@ function Home() {
                 <ModeToggle/>
             </div>
             <UpdatePopup/>
-            <ScoreContextProvider>
-                <AverageScorePopUp/>
-                <Info/>
-                <QuoteContextProvider>
-                    <Quote/>
-                </QuoteContextProvider>
-            </ScoreContextProvider>
+            <AverageScorePopUp/>
+            <Info/>
+            <QuoteContextProvider>
+                <Quote/>
+            </QuoteContextProvider>
         </SettingContextProvider>
     );
 }


### PR DESCRIPTION
- ScoreContextProvider를 Home.jsx에서 App.jsx로 이동
- 통계/업로드 등 다른 페이지 방문 후 돌아와도 세션 데이터 유지