### PR TITLE
feat: 결과 팝업 디자인 개편 및 로그인 유도

### DIFF
--- a/tp-react/src/pages/Home/components/AverageScorePopUp/AverageScorePopUp.css
+++ b/tp-react/src/pages/Home/components/AverageScorePopUp/AverageScorePopUp.css
@@ -16,44 +16,130 @@
     transform: translate(-50%, -50%);
     background-color: var(--color-popup-bg);
     color: var(--color-text);
-    width: 25rem;
-    height: 25rem;
-    border-radius: 0.5rem;
+    width: 22rem;
+    border-radius: 1rem;
     display: flex;
     flex-direction: column;
-    padding: 2rem 1.5rem;
+    padding: 2rem;
     z-index: 1000;
     border: 1px solid var(--color-border);
 }
 
-.popup-title {
-    font-size: 1.5rem;
-    color: var(--color-text);
-    margin-bottom: 3rem;
-    text-align: center;
-    font-weight: 600;
-    background-color: transparent;
+/* 메인 영역 */
+.popup-main {
+    margin-bottom: 1.5rem;
 }
 
-.popup-info {
+.popup-main-label {
+    font-size: 0.875rem;
+    color: var(--color-text-placeholder);
+    display: block;
+    margin-bottom: 0.125rem;
+}
+
+.popup-main-row {
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+}
+
+.popup-main-value {
+    font-size: 3rem;
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.popup-main-unit {
+    font-size: 1rem;
+    color: var(--color-text-placeholder);
+}
+
+.popup-main-diff {
+    font-size: 0.9375rem;
+    font-weight: 500;
+    margin-left: auto;
+}
+
+.popup-main-diff.up {
+    color: #22c55e;
+}
+
+.popup-main-diff.down {
+    color: #ef4444;
+}
+
+.popup-main-diff.neutral {
+    color: var(--color-text-placeholder);
+}
+
+/* 보조 통계 리스트 */
+.popup-details {
+    display: flex;
+    flex-direction: column;
+    gap: 0.625rem;
+    margin-bottom: 1.5rem;
+}
+
+.popup-detail-row {
     display: flex;
     justify-content: space-between;
-    margin-bottom: 2rem;
-    font-size: 1.5rem;
-    color: var(--color-text-muted);
-    background-color: transparent;
+    font-size: 1rem;
 }
 
-.popup-value {
-    font-weight: 600;
+.popup-detail-label {
+    color: var(--color-text-muted);
+}
+
+.popup-detail-value {
+    font-weight: 500;
     color: var(--color-text);
-    background-color: transparent;
+}
+
+.popup-detail-value.cumulative {
+    font-weight: 400;
+    color: var(--color-text-placeholder);
+}
+
+/* 하단 영역 */
+.popup-bottom {
+    border-top: 1px solid var(--color-border);
+    padding-top: 0.875rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
 }
 
 .popup-close {
-    margin-top: auto;
     text-align: center;
-    font-size: 0.9rem;
+    font-size: 0.875rem;
     color: var(--color-text-placeholder);
-    background-color: transparent;
+}
+
+.popup-stats-link {
+    border: none;
+    background: transparent;
+    color: var(--color-primary);
+    font-size: 0.9375rem;
+    cursor: pointer;
+    padding: 0;
+    transition: opacity 0.15s;
+}
+
+.popup-stats-link:hover {
+    opacity: 0.7;
+}
+
+.popup-login-prompt {
+    border: none;
+    background: transparent;
+    color: var(--color-primary);
+    font-size: 0.9375rem;
+    cursor: pointer;
+    padding: 0;
+    transition: opacity 0.15s;
+}
+
+.popup-login-prompt:hover {
+    opacity: 0.7;
 }

--- a/tp-react/src/pages/Home/components/AverageScorePopUp/AverageScorePopUp.jsx
+++ b/tp-react/src/pages/Home/components/AverageScorePopUp/AverageScorePopUp.jsx
@@ -1,10 +1,35 @@
+import {useEffect, useRef} from "react";
+import {useNavigate} from "react-router-dom";
 import "./AverageScorePopUp.css";
 import {useScore} from "@/Context/ScoreContext.tsx";
 import {useTheme} from "@/Context/ThemeContext.tsx";
+import {useAuth} from "@/Context/AuthContext.tsx";
+import {getTypingStats} from "@/utils/statsApi.ts";
+import {t} from "@/utils/i18n.ts";
 
 const AverageScorePopUp = () => {
     const {showPopup, setShowPopup, popupData} = useScore();
     const {isDark} = useTheme();
+    const {user, triggerLogin} = useAuth();
+    const navigate = useNavigate();
+    const cumulativeStatsRef = useRef(null);
+    const fetchedRef = useRef(false);
+
+    // 로그인 사용자: 누적 통계를 한 번만 가져옴
+    useEffect(() => {
+        if (user && !fetchedRef.current) {
+            fetchedRef.current = true;
+            getTypingStats('KOREAN')
+                .then(res => {
+                    cumulativeStatsRef.current = res.data.data;
+                })
+                .catch(() => {});
+        }
+        if (!user) {
+            fetchedRef.current = false;
+            cumulativeStatsRef.current = null;
+        }
+    }, [user]);
 
     if (!showPopup) {
         return null;
@@ -14,25 +39,71 @@ const AverageScorePopUp = () => {
         setShowPopup(false);
     };
 
+    const handleLoginClick = () => {
+        setShowPopup(false);
+        triggerLogin();
+    };
+
+    const handleViewStats = () => {
+        setShowPopup(false);
+        navigate('/stats');
+    };
+
+    const cumulative = cumulativeStatsRef.current;
+    const cpmDiff = cumulative && cumulative.totalAttempts > 0
+        ? popupData.avgCpm - Math.round(cumulative.avgCpm)
+        : null;
+
     return (
         <>
             <div className="popup-background" onClick={handleBackgroundClick}/>
             <div className={`popup ${isDark ? "popup-dark" : ""}`}>
-                <h1 className={`popup-title ${isDark ? "dark" : ""}`}>Typing Practice</h1>
-                <div className={`popup-info ${isDark ? "dark" : ""}`}>
-                    <span>Avg CPM</span>
-                    <span className={`popup-value ${isDark ? "dark" : ""}`}>{popupData.avgCpm}</span>
+                {/* 메인: Avg CPM */}
+                <div className="popup-main">
+                    <span className="popup-main-label">Session result</span>
+                    <div className="popup-main-row">
+                        <span className="popup-main-value">{popupData.avgCpm}</span>
+                        <span className="popup-main-unit">Avg CPM</span>
+                        {user && cpmDiff !== null && (
+                            <span className={`popup-main-diff ${cpmDiff > 0 ? 'up' : cpmDiff < 0 ? 'down' : 'neutral'}`}>
+                                {cpmDiff > 0 ? `+${cpmDiff}` : cpmDiff === 0 ? '±0' : cpmDiff} vs avg
+                            </span>
+                        )}
+                    </div>
                 </div>
-                <div className={`popup-info ${isDark ? "dark" : ""}`}>
-                    <span>Max CPM</span>
-                    <span className={`popup-value ${isDark ? "dark" : ""}`}>{popupData.maxCpm}</span>
+
+                {/* 보조 통계 */}
+                <div className="popup-details">
+                    <div className="popup-detail-row">
+                        <span className="popup-detail-label">Max CPM</span>
+                        <span className="popup-detail-value">{popupData.maxCpm}</span>
+                    </div>
+                    <div className="popup-detail-row">
+                        <span className="popup-detail-label">Accuracy</span>
+                        <span className="popup-detail-value">{popupData.acc}%</span>
+                    </div>
+                    {user && cumulative && cumulative.totalAttempts > 0 && (
+                        <div className="popup-detail-row">
+                            <span className="popup-detail-label">{t('popupCumulativeAvg')}</span>
+                            <span className="popup-detail-value cumulative">{Math.round(cumulative.avgCpm)} CPM</span>
+                        </div>
+                    )}
                 </div>
-                <div className={`popup-info ${isDark ? "dark" : ""}`}>
-                    <span>ACC</span>
-                    <span className={`popup-value ${isDark ? "dark" : ""}`}>{popupData.acc}%</span>
-                </div>
-                <div className={`popup-close ${isDark ? "dark" : ""}`}>
-                    <span>press ESC to continue</span>
+
+                <div className="popup-bottom">
+                    {user && (
+                        <button className="popup-stats-link" onClick={handleViewStats}>
+                            {t('popupViewStats')}
+                        </button>
+                    )}
+                    {!user && (
+                        <button className="popup-login-prompt" onClick={handleLoginClick}>
+                            {t('popupLoginPrompt')}
+                        </button>
+                    )}
+                    <div className="popup-close">
+                        <span>press ESC to continue</span>
+                    </div>
                 </div>
             </div>
         </>

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -196,6 +196,11 @@ const translations = {
         ? '로그인하면 원하는 문장을 직접 업로드하고, 타이핑 기록과 오타 분석을 확인할 수 있어요.'
         : 'Sign in to upload your own sentences and track your typing speed, accuracy, and typo patterns.',
     featureGuideConfirm: isKorean ? '확인' : 'Got it',
+
+    // 결과 팝업
+    popupLoginPrompt: isKorean ? '이 기록을 저장할까요?' : 'Save this record?',
+    popupCumulativeAvg: isKorean ? 'Overall avg' : 'Overall avg',
+    popupViewStats: isKorean ? '자세한 통계 보기 →' : 'View detailed stats →',
 } as const;
 
 type TranslationKey = keyof typeof translations;


### PR DESCRIPTION
- 결과 팝업 왼쪽 정렬 리스트형 디자인으로 변경
- 로그인 사용자: 누적 평균 CPM 비교 + 통계 페이지 링크
- 비로그인 사용자: "이 기록을 저장할까요?" 로그인 유도