### PR TITLE
feat: i18n 일본어 지원 및 로그인 유도 / GDPR 동의 배너 추가

### DIFF
--- a/tp-react/src/App.jsx
+++ b/tp-react/src/App.jsx
@@ -19,7 +19,6 @@ import Updates from "./pages/Updates/Updates";
 import PrivacyPolicy from "./pages/PrivacyPolicy/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService/TermsOfService";
 import {Analytics} from "@vercel/analytics/react";
-import ConsentBanner from "./components/ConsentBanner/ConsentBanner";
 
 function App() {
   return (
@@ -44,7 +43,6 @@ function App() {
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
                 <Contact />
-                <ConsentBanner/>
                 <Analytics/>
               </AppDiv>
               </ScoreContextProvider>

--- a/tp-react/src/components/ConsentBanner/ConsentBanner.css
+++ b/tp-react/src/components/ConsentBanner/ConsentBanner.css
@@ -1,119 +1,120 @@
-.consent-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.4);
-    backdrop-filter: blur(4px);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 9999;
-}
-
-.consent-banner {
-    background: var(--color-popup-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 1rem;
-    padding: 2rem;
-    width: 90%;
-    max-width: 400px;
-}
-
-.consent-title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    color: var(--color-text);
-    margin: 0 0 0.5rem 0;
-}
-
-.consent-desc {
-    font-size: 0.875rem;
-    line-height: 1.6;
-    color: var(--color-text-muted);
-    margin: 0 0 1.25rem 0;
-}
-
-.consent-details {
-    display: flex;
-    flex-direction: column;
-    gap: 0.875rem;
-    padding: 1rem;
-    margin-bottom: 1.25rem;
+.consent-inline {
+    margin-top: 2.5rem;
+    padding: 1rem 1.25rem;
     background: var(--color-bg-secondary);
     border-radius: 0.5rem;
 }
 
-.consent-detail-item {
+/* login-prompt-wrapper 안에서는 겹침 */
+.login-prompt-wrapper .consent-inline {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1;
+    margin-top: 0;
+}
+
+.consent-inline-main {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.consent-inline-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.consent-inline-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.consent-inline-desc {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+}
+
+.consent-inline-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}
+
+.consent-inline-btn {
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 0.15s;
+}
+
+.consent-inline-accept {
+    border: none;
+    background: var(--color-primary);
+    color: white;
+}
+
+.consent-inline-accept:hover {
+    background: var(--color-primary-dark);
+}
+
+.consent-inline-reject {
+    border: 1px solid var(--color-border);
+    background: var(--color-popup-bg);
+    color: var(--color-text-muted);
+}
+
+.consent-inline-reject:hover {
+    border-color: var(--color-text-placeholder);
+    color: var(--color-text);
+}
+
+.consent-inline-details {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+    margin-top: 1rem;
+    padding: 0.875rem 0 0;
+}
+
+.consent-inline-detail-item {
     display: flex;
     flex-direction: column;
     gap: 0.125rem;
 }
 
-.consent-detail-label {
-    font-size: 0.8125rem;
+.consent-inline-detail-label {
+    font-size: 0.75rem;
     font-weight: 500;
     color: var(--color-primary);
 }
 
-.consent-detail-desc {
-    font-size: 0.75rem;
-    line-height: 1.5;
+.consent-inline-detail-desc {
+    font-size: 0.7rem;
+    line-height: 1.4;
     color: var(--color-text-muted);
 }
 
-.consent-actions {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.consent-btn {
-    width: 100%;
-    padding: 0.625rem;
-    border-radius: 0.5rem;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.15s;
-}
-
-.consent-btn-accept {
-    border: none;
-    background: var(--color-primary);
-    color: var(--color-white);
-}
-
-.consent-btn-accept:hover {
-    background: var(--color-primary-dark);
-}
-
-.consent-btn-reject {
-    border: 1px solid var(--color-border);
-    background: transparent;
-    color: var(--color-text-muted);
-}
-
-.consent-btn-reject:hover {
-    background: var(--color-bg-secondary);
-    color: var(--color-text);
-}
-
-.consent-more-btn {
+.consent-inline-more {
     display: block;
     width: 100%;
-    margin-top: 0.75rem;
+    margin-top: 0.5rem;
     padding: 0;
     border: none;
     background: transparent;
     color: var(--color-text-placeholder);
-    font-size: 0.8125rem;
+    font-size: 0.75rem;
     cursor: pointer;
     text-align: center;
     transition: color 0.15s;
 }
 
-.consent-more-btn:hover {
+.consent-inline-more:hover {
     color: var(--color-text-muted);
 }

--- a/tp-react/src/components/ConsentBanner/ConsentBanner.jsx
+++ b/tp-react/src/components/ConsentBanner/ConsentBanner.jsx
@@ -1,16 +1,33 @@
-import {useState} from 'react';
-import {useTheme} from '../../Context/ThemeContext';
-import {Storage_Anonymous_Id, Storage_Consent} from '@/const/config.const.ts';
+import {useEffect, useState} from 'react';
+import {Storage_Anonymous_Id, Storage_Consent, Session_Typing_Count, CONSENT_BANNER_THRESHOLD} from '@/const/config.const.ts';
+import {t} from '@/utils/i18n.ts';
 import './ConsentBanner.css';
 
 export const hasConsent = () => localStorage.getItem(Storage_Consent);
 
-const isKorean = navigator.language.startsWith('ko');
-
 function ConsentBanner() {
-    const {isDark} = useTheme();
-    const [visible, setVisible] = useState(() => !hasConsent());
+    const [visible, setVisible] = useState(false);
     const [showDetails, setShowDetails] = useState(false);
+
+    useEffect(() => {
+        if (hasConsent()) return;
+
+        // 마운트 시 현재 카운트 확인
+        const currentCount = parseInt(sessionStorage.getItem(Session_Typing_Count) || '0', 10);
+        if (currentCount >= CONSENT_BANNER_THRESHOLD) {
+            setVisible(true);
+            return;
+        }
+
+        const handleTypingCount = (e) => {
+            if (e.detail >= CONSENT_BANNER_THRESHOLD && !hasConsent()) {
+                setVisible(true);
+            }
+        };
+
+        window.addEventListener('typing-count-update', handleTypingCount);
+        return () => window.removeEventListener('typing-count-update', handleTypingCount);
+    }, []);
 
     if (!visible) return null;
 
@@ -28,79 +45,44 @@ function ConsentBanner() {
     };
 
     return (
-        <div className="consent-overlay">
-            <div className={`consent-banner ${isDark ? 'dark' : ''}`}>
-                <p className="consent-title">
-                    {isKorean ? '더 나은 서비스를 위해' : 'Help us improve'}
-                </p>
-                <p className="consent-desc">
-                    {isKorean
-                        ? '서비스 개선을 위해 익명 사용 데이터를 수집합니다. 개인을 식별할 수 없습니다.'
-                        : 'We collect anonymous usage data to improve the service. It cannot identify you personally.'}
-                </p>
-
-                {showDetails && (
-                    <div className="consent-details">
-                        <div className="consent-detail-item">
-                            <span className="consent-detail-label">
-                                {isKorean ? '익명 식별자' : 'Anonymous ID'}
-                            </span>
-                            <span className="consent-detail-desc">
-                                {isKorean
-                                    ? '이름, 이메일 등 개인정보와 연결되지 않습니다.'
-                                    : 'Not linked to any personal information like name or email.'}
-                            </span>
-                        </div>
-                        <div className="consent-detail-item">
-                            <span className="consent-detail-label">
-                                {isKorean ? '기기 유형' : 'Device type'}
-                            </span>
-                            <span className="consent-detail-desc">
-                                {isKorean
-                                    ? '모바일 / 태블릿 / 데스크톱 중 어떤 환경인지 확인합니다.'
-                                    : 'Whether you\'re on mobile, tablet, or desktop.'}
-                            </span>
-                        </div>
-                        <div className="consent-detail-item">
-                            <span className="consent-detail-label">
-                                {isKorean ? '유입 경로' : 'Referrer'}
-                            </span>
-                            <span className="consent-detail-desc">
-                                {isKorean
-                                    ? '어떤 사이트에서 방문했는지 확인합니다.'
-                                    : 'Which site you came from.'}
-                            </span>
-                        </div>
-                        <div className="consent-detail-item">
-                            <span className="consent-detail-label">
-                                {isKorean ? '세션 정보' : 'Session info'}
-                            </span>
-                            <span className="consent-detail-desc">
-                                {isKorean
-                                    ? '한 번의 방문 동안만 유지되며, 탭을 닫으면 자동으로 삭제됩니다.'
-                                    : 'Only kept during your visit. Automatically deleted when you close the tab.'}
-                            </span>
-                        </div>
-                    </div>
-                )}
-
-                <div className="consent-actions">
-                    <button className="consent-btn consent-btn-accept" onClick={handleAccept}>
-                        {isKorean ? '동의' : 'Accept'}
+        <div className="consent-inline">
+            <div className="consent-inline-main">
+                <div className="consent-inline-text">
+                    <span className="consent-inline-title">{t('consentTitle')}</span>
+                    <span className="consent-inline-desc">{t('consentDesc')}</span>
+                </div>
+                <div className="consent-inline-actions">
+                    <button className="consent-inline-btn consent-inline-accept" onClick={handleAccept}>
+                        {t('consentAccept')}
                     </button>
-                    <button className="consent-btn consent-btn-reject" onClick={handleReject}>
-                        {isKorean ? '거절' : 'Reject'}
+                    <button className="consent-inline-btn consent-inline-reject" onClick={handleReject}>
+                        {t('consentReject')}
                     </button>
                 </div>
-                <button
-                    className="consent-more-btn"
-                    onClick={() => setShowDetails(!showDetails)}
-                >
-                    {showDetails
-                        ? (isKorean ? '접기' : 'Less')
-                        : (isKorean ? '자세히 보기' : 'More info')}
-                </button>
             </div>
+            {showDetails && (
+                <div className="consent-inline-details">
+                    <div className="consent-inline-detail-item">
+                        <span className="consent-inline-detail-label">{t('consentAnonymousId')}</span>
+                        <span className="consent-inline-detail-desc">{t('consentAnonymousIdDesc')}</span>
+                    </div>
+                    <div className="consent-inline-detail-item">
+                        <span className="consent-inline-detail-label">{t('consentDeviceType')}</span>
+                        <span className="consent-inline-detail-desc">{t('consentDeviceTypeDesc')}</span>
+                    </div>
+                    <div className="consent-inline-detail-item">
+                        <span className="consent-inline-detail-label">{t('consentReferrer')}</span>
+                        <span className="consent-inline-detail-desc">{t('consentReferrerDesc')}</span>
+                    </div>
+                    <div className="consent-inline-detail-item">
+                        <span className="consent-inline-detail-label">{t('consentSession')}</span>
+                        <span className="consent-inline-detail-desc">{t('consentSessionDesc')}</span>
+                    </div>
+                </div>
+            )}
+            <button className="consent-inline-more" onClick={() => setShowDetails(!showDetails)}>
+                {showDetails ? t('consentLess') : t('consentMore')}
+            </button>
         </div>
     );
 }

--- a/tp-react/src/const/config.const.ts
+++ b/tp-react/src/const/config.const.ts
@@ -23,5 +23,11 @@ export const Storage_Word_Difficulty = "Typing-Practice-wordDifficulty" as const
 export const Storage_Word_Count = "Typing-Practice-wordCount" as const;
 export const Storage_Last_Mode = "Typing-Practice-lastMode" as const;
 
+// 로그인 유도
+export const Session_Typing_Count = "Typing-Practice-sessionTypingCount" as const;
+export const LOGIN_PROMPT_THRESHOLD = 3 as const;
+export const CONSENT_BANNER_THRESHOLD = 3 as const;
+export const Session_Login_Prompt_Dismissed = "Typing-Practice-loginPromptDismissed" as const;
+
 // Typing Record 관련 상수
 export const RESET_COUNT_THRESHOLD_RATIO = 0.3 as const;

--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -1,5 +1,6 @@
 interface LocalizedText {
     ko: string;
+    ja: string;
     en: string;
 }
 
@@ -13,19 +14,24 @@ interface UpdateEntry {
     improvements?: LocalizedText[];
 }
 
-const isKorean = navigator.language.startsWith('ko');
+const lang = navigator.language.startsWith('ko') ? 'ko' : navigator.language.startsWith('ja') ? 'ja' : 'en';
 
 export function formatUpdateDate(isoDate: string): string {
     const [year, month, day] = isoDate.split('-').map(Number);
-    if (isKorean) {
+    if (lang === 'ko') {
         return `${year}년 ${month}월 ${day}일`;
+    }
+    if (lang === 'ja') {
+        return `${year}年${month}月${day}日`;
     }
     const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
     return `${months[month - 1]} ${day}, ${year}`;
 }
 
 export function localize(item: LocalizedText): string {
-    return isKorean ? item.ko : item.en;
+    if (lang === 'ko') return item.ko;
+    if (lang === 'ja') return item.ja;
+    return item.en;
 }
 
 export const updateHistory: UpdateEntry[] = [
@@ -35,18 +41,15 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: true,
         hidden: false,
         features: [
-            {ko: "상단 네비게이션 바 디자인 변경", en: "Redesigned top navigation bar"},
-            {ko: "업데이트 내역 페이지 추가", en: "Added update history page"},
-            {ko: "타이핑 속도/정확도 표시 및 설정 영역 디자인 변경", en: "Redesigned typing stats and settings area"},
-            {
-                ko: "단어 연습에 실시간 WPM, 난이도, 단어수, 폰트 크기 설정 추가",
-                en: "Added real-time WPM, difficulty, word count, font size settings to word mode"
-            },
-            {ko: "문장 소스 선택 탭 디자인 변경", en: "Redesigned sentence source selector tabs"},
+            {ko: "상단 네비게이션 바 디자인 변경", ja: "上部ナビゲーションバーのデザイン変更", en: "Redesigned top navigation bar"},
+            {ko: "업데이트 내역 페이지 추가", ja: "アップデート履歴ページ追加", en: "Added update history page"},
+            {ko: "타이핑 속도/정확도 표시 및 설정 영역 디자인 변경", ja: "タイピング速度・正確度表示と設定エリアのデザイン変更", en: "Redesigned typing stats and settings area"},
+            {ko: "단어 연습에 실시간 WPM, 난이도, 단어수, 폰트 크기 설정 추가", ja: "単語練習にリアルタイムWPM・難易度・単語数・フォントサイズ設定を追加", en: "Added real-time WPM, difficulty, word count, font size settings to word mode"},
+            {ko: "문장 소스 선택 탭 디자인 변경", ja: "文章ソース選択タブのデザイン変更", en: "Redesigned sentence source selector tabs"},
         ],
         improvements: [
-            {ko: "다크모드 배경 및 보라색(primary) 색상 개선", en: "Improved dark mode background and primary colors"},
-            {ko: "좁은 화면에서 컨트롤 영역 자동 접기/오버레이 지원", en: "Auto-collapse controls on narrow screens with overlay support"},
+            {ko: "다크모드 배경 및 보라색(primary) 색상 개선", ja: "ダークモードの背景とプライマリカラーの改善", en: "Improved dark mode background and primary colors"},
+            {ko: "좁은 화면에서 컨트롤 영역 자동 접기/오버레이 지원", ja: "狭い画面でコントロールエリアの自動折りたたみ・オーバーレイ対応", en: "Auto-collapse controls on narrow screens with overlay support"},
         ]
     },
     {
@@ -55,13 +58,13 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: true,
         hidden: false,
         features: [
-            {ko: "단어 모드 추가 (beta)", en: "Word mode added (beta)"},
-            {ko: "난이도 선택 (Random, Easy, Normal, Hard)", en: "Difficulty selection (Random, Easy, Normal, Hard)"},
-            {ko: "단어 수 선택 (15, 25, 50)", en: "Word count selection (15, 25, 50)"},
-            {ko: "문장/단어 모드 전환 기능 추가", en: "Sentence/Word mode switch"},
+            {ko: "단어 모드 추가 (beta)", ja: "単語モード追加（beta）", en: "Word mode added (beta)"},
+            {ko: "난이도 선택 (Random, Easy, Normal, Hard)", ja: "難易度選択（Random, Easy, Normal, Hard）", en: "Difficulty selection (Random, Easy, Normal, Hard)"},
+            {ko: "단어 수 선택 (15, 25, 50)", ja: "単語数選択（15, 25, 50）", en: "Word count selection (15, 25, 50)"},
+            {ko: "문장/단어 모드 전환 기능 추가", ja: "文章・単語モード切り替え機能追加", en: "Sentence/Word mode switch"},
         ],
         improvements: [
-            {ko: "마지막 사용 모드 자동 기억", en: "Auto-remember last used mode"},
+            {ko: "마지막 사용 모드 자동 기억", ja: "最後に使用したモードを自動記憶", en: "Auto-remember last used mode"},
         ]
     },
     {
@@ -70,18 +73,9 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: false,
         hidden: true,
         notices: [
-            {
-                ko: "4월 2일 00:48 ~ 15:00 사이에 서버 문제로 타이핑 기록이 저장되지 않았습니다.",
-                en: "Due to a server issue, typing records were not saved between Apr 2, 00:48 – 15:00 KST."
-            },
-            {
-                ko: "해당 시간대의 기록은 복구가 불가능합니다.",
-                en: "Records from that period cannot be recovered."
-            },
-            {
-                ko: "불편을 드려 죄송합니다. 현재는 정상 동작 중입니다.",
-                en: "We apologize for the inconvenience. The service is now operating normally."
-            }
+            {ko: "4월 2일 00:48 ~ 15:00 사이에 서버 문제로 타이핑 기록이 저장되지 않았습니다.", ja: "4月2日 00:48〜15:00の間、サーバーの問題によりタイピング記録が保存されませんでした。", en: "Due to a server issue, typing records were not saved between Apr 2, 00:48 – 15:00 KST."},
+            {ko: "해당 시간대의 기록은 복구가 불가능합니다.", ja: "該当時間帯の記録は復旧できません。", en: "Records from that period cannot be recovered."},
+            {ko: "불편을 드려 죄송합니다. 현재는 정상 동작 중입니다.", ja: "ご不便をおかけして申し訳ございません。現在は正常に動作しています。", en: "We apologize for the inconvenience. The service is now operating normally."}
         ]
     },
     {
@@ -90,16 +84,16 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: true,
         hidden: false,
         features: [
-            {ko: "문장 업로드 기능 추가", en: "Upload your own sentences"},
-            {ko: "내 문장 관리 페이지 추가 (수정, 삭제, 공개전환)", en: "My sentences page (edit, delete, toggle visibility)"},
-            {ko: "전체 문장 / 내 문장 전환 기능 추가", en: "Switch between all sentences and my sentences"},
-            {ko: "문장 신고 기능 및 신고 내역 페이지 추가", en: "Report sentences and view report history"},
-            {ko: "타이핑 기록 페이지 추가 (종합 통계, 일별 추이, 오타 분석)", en: "Typing stats page (summary, daily trends, typo analysis)"},
-            {ko: "타이핑 연습 완료 시 기록 자동 저장", en: "Auto-save typing records on completion"},
+            {ko: "문장 업로드 기능 추가", ja: "文章アップロード機能追加", en: "Upload your own sentences"},
+            {ko: "내 문장 관리 페이지 추가 (수정, 삭제, 공개전환)", ja: "マイ文章管理ページ追加（編集・削除・公開切替）", en: "My sentences page (edit, delete, toggle visibility)"},
+            {ko: "전체 문장 / 내 문장 전환 기능 추가", ja: "すべての文章・マイ文章の切り替え機能追加", en: "Switch between all sentences and my sentences"},
+            {ko: "문장 신고 기능 및 신고 내역 페이지 추가", ja: "文章の報告機能と報告履歴ページ追加", en: "Report sentences and view report history"},
+            {ko: "타이핑 기록 페이지 추가 (종합 통계, 일별 추이, 오타 분석)", ja: "タイピング記録ページ追加（総合統計・日別推移・誤字分析）", en: "Typing stats page (summary, daily trends, typo analysis)"},
+            {ko: "타이핑 연습 완료 시 기록 자동 저장", ja: "タイピング練習完了時に記録を自動保存", en: "Auto-save typing records on completion"},
         ],
         improvements: [
-            {ko: "타이핑 채점 색상 표시 방식 개선", en: "Improved typing grading color display"},
-            {ko: "결과 표시 주기 선택 버그 수정", en: "Fixed result display interval selection bug"},
+            {ko: "타이핑 채점 색상 표시 방식 개선", ja: "タイピング採点の色表示方法を改善", en: "Improved typing grading color display"},
+            {ko: "결과 표시 주기 선택 버그 수정", ja: "結果表示間隔の選択バグを修正", en: "Fixed result display interval selection bug"},
         ]
     },
     {
@@ -108,7 +102,7 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: true,
         hidden: false,
         improvements: [
-            {ko: "일반 모드에서 입력 시 예문이 변경되지 않고 원본 유지되도록 개선", en: "Fixed sentence changing during input in normal mode"}
+            {ko: "일반 모드에서 입력 시 예문이 변경되지 않고 원본 유지되도록 개선", ja: "通常モードで入力中に例文が変わらず原文を維持するよう改善", en: "Fixed sentence changing during input in normal mode"}
         ]
     },
     {
@@ -117,10 +111,7 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: false,
         hidden: false,
         improvements: [
-            {
-                ko: "브라우저 높이가 낮을 때 예문과 Contact가 겹치는 문제 수정",
-                en: "Fixed sentence and contact section overlap on short browser windows"
-            }
+            {ko: "브라우저 높이가 낮을 때 예문과 Contact가 겹치는 문제 수정", ja: "ブラウザの高さが低い時に例文とContactが重なる問題を修正", en: "Fixed sentence and contact section overlap on short browser windows"}
         ]
     },
     {
@@ -129,14 +120,14 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: true,
         hidden: false,
         features: [
-            {ko: "평균점수 영역 접기/펼치기 기능 추가", en: "Collapsible average score section"},
-            {ko: "Default/Compact 모드 전환 기능 추가", en: "Default/Compact mode toggle"},
-            {ko: "업데이트 알림 팝업 추가", en: "Update notification popup"},
-            {ko: "업데이트 내역 보기 기능 추가 (우측 상단)", en: "Update history viewer (top right)"}
+            {ko: "평균점수 영역 접기/펼치기 기능 추가", ja: "平均スコアエリアの折りたたみ・展開機能追加", en: "Collapsible average score section"},
+            {ko: "Default/Compact 모드 전환 기능 추가", ja: "Default/Compactモード切り替え機能追加", en: "Default/Compact mode toggle"},
+            {ko: "업데이트 알림 팝업 추가", ja: "アップデート通知ポップアップ追加", en: "Update notification popup"},
+            {ko: "업데이트 내역 보기 기능 추가 (우측 상단)", ja: "アップデート履歴表示機能追加（右上）", en: "Update history viewer (top right)"}
         ],
         improvements: [
-            {ko: "문장 셔플 알고리즘 개선", en: "Improved sentence shuffle algorithm"},
-            {ko: "예문 101개 추가 (총 1,138개)", en: "Added 101 sentences (1,138 total)"}
+            {ko: "문장 셔플 알고리즘 개선", ja: "文章シャッフルアルゴリズム改善", en: "Improved sentence shuffle algorithm"},
+            {ko: "예문 101개 추가 (총 1,138개)", ja: "例文101個追加（合計1,138個）", en: "Added 101 sentences (1,138 total)"}
         ]
     },
     {
@@ -145,12 +136,12 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: true,
         hidden: false,
         features: [
-            {ko: "새로운 디자인 적용", en: "New design"},
-            {ko: "폰트 크기 조절 기능 추가", en: "Font size adjustment"},
-            {ko: "예문과 입력 영역 통합", en: "Unified sentence and input area"}
+            {ko: "새로운 디자인 적용", ja: "新しいデザインを適用", en: "New design"},
+            {ko: "폰트 크기 조절 기능 추가", ja: "フォントサイズ調整機能追加", en: "Font size adjustment"},
+            {ko: "예문과 입력 영역 통합", ja: "例文と入力エリアを統合", en: "Unified sentence and input area"}
         ],
         improvements: [
-            {ko: "타이핑 중인 글자까지 실시간 채점", en: "Real-time grading while typing"}
+            {ko: "타이핑 중인 글자까지 실시간 채점", ja: "タイピング中の文字までリアルタイム採点", en: "Real-time grading while typing"}
         ]
     }
 ];

--- a/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
+++ b/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
@@ -15,6 +15,7 @@ import {
     KEY_ESC,
 } from "@/const/key.const.js";
 import {RESET_COUNT_THRESHOLD_RATIO} from "@/const/config.const.ts";
+import {incrementSessionTypingCount} from "@/utils/sessionUtils.ts";
 import {koreanSeparator} from "@/utils/koreanSeparator.ts";
 import {createFlatTypoEntry, isLanguageSwitchMistake} from "@/utils/typoUtils.ts";
 import {saveTypingRecord} from "@/utils/typingRecordApi.ts";
@@ -278,6 +279,9 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
         // typos, resetCount 초기화
         typosRef.current = [];
         resetCountRef.current = 0;
+
+        // 세션 타이핑 카운트 증가 (동의 배너, 로그인 유도에 사용)
+        incrementSessionTypingCount();
     };
 
     const onInputChange = (e) => {

--- a/tp-react/src/pages/Home/components/Quote/Quote.css
+++ b/tp-react/src/pages/Home/components/Quote/Quote.css
@@ -65,3 +65,77 @@
     position: relative;
     min-height: auto;
 }
+
+/* 로그인 유도 */
+.login-prompt-wrapper {
+    position: relative;
+    margin-top: 4.5rem;
+}
+
+.login-prompt {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.25rem;
+    background: var(--color-bg-secondary);
+    border-radius: 0.5rem;
+}
+
+.login-prompt-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.login-prompt-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.login-prompt-desc {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+}
+
+.login-prompt-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    background: var(--color-popup-bg);
+    color: var(--color-text);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: border-color 0.15s;
+}
+
+.login-prompt-btn:hover {
+    border-color: var(--color-primary);
+}
+
+.login-prompt-actions {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    flex-shrink: 0;
+}
+
+.login-prompt-close {
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--color-text-placeholder);
+    font-size: 0.875rem;
+    cursor: pointer;
+    line-height: 1;
+    transition: color 0.15s;
+}
+
+.login-prompt-close:hover {
+    color: var(--color-text-muted);
+}

--- a/tp-react/src/pages/Home/components/Quote/Quote.jsx
+++ b/tp-react/src/pages/Home/components/Quote/Quote.jsx
@@ -2,6 +2,7 @@ import "./Quote.css";
 import {useEffect, useState} from "react";
 import {useNavigate} from "react-router-dom";
 import {FaPlus} from "react-icons/fa";
+import {FaXmark} from "react-icons/fa6";
 import Sentence from "./Sentence/Sentence";
 import Author from "./Author/Author";
 import Input from "./Input/Input";
@@ -10,19 +11,38 @@ import QuoteSourceSelector from "./QuoteSourceSelector/QuoteSourceSelector";
 import QuoteMoreMenu from "./QuoteMoreMenu/QuoteMoreMenu";
 import QuoteLoading from "./QuoteLoading/QuoteLoading";
 import QuoteEmpty from "./QuoteEmpty/QuoteEmpty";
+import GoogleLogo from "@/components/GoogleLogo/GoogleLogo.jsx";
+import ConsentBanner from "@/components/ConsentBanner/ConsentBanner.jsx";
 import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useQuote} from "@/Context/QuoteContext.tsx";
 import {useSetting} from "@/Context/SettingContext.tsx";
 import {useAuth} from "@/Context/AuthContext.tsx";
+import {Session_Typing_Count, LOGIN_PROMPT_THRESHOLD, Session_Login_Prompt_Dismissed} from "@/const/config.const.ts";
 import {t} from "@/utils/i18n.ts";
 
 const Quote = () => {
     const navigate = useNavigate();
     const {isDark} = useTheme();
     const {user, triggerLogin} = useAuth();
-    const {author, sentence, isLoading, isEmpty} = useQuote();
+    const {author, sentence, isLoading, isEmpty, quotesIndex} = useQuote();
     const {isCompactMode} = useSetting();
     const [inputValue, setInputValue] = useState("");
+    const [showLoginPrompt, setShowLoginPrompt] = useState(false);
+
+    // 비로그인 시 타이핑 완료 횟수 체크
+    useEffect(() => {
+        if (user || sessionStorage.getItem(Session_Login_Prompt_Dismissed)) {
+            setShowLoginPrompt(false);
+            return;
+        }
+        const count = parseInt(sessionStorage.getItem(Session_Typing_Count) || '0', 10);
+        setShowLoginPrompt(count >= LOGIN_PROMPT_THRESHOLD);
+    }, [user, quotesIndex]);
+
+    const dismissLoginPrompt = () => {
+        sessionStorage.setItem(Session_Login_Prompt_Dismissed, 'true');
+        setShowLoginPrompt(false);
+    };
 
     useEffect(() => {
         setInputValue("");
@@ -73,6 +93,25 @@ const Quote = () => {
                         <Input onInputChange={setInputValue}/>
                     </div>
                 )}
+                {showLoginPrompt && (
+                    <div className="login-prompt-wrapper">
+                        <div className="login-prompt">
+                            <div className="login-prompt-text">
+                                <span className="login-prompt-title">{t('loginPromptTitle')}</span>
+                                <span className="login-prompt-desc">{t('loginPromptDesc')}</span>
+                            </div>
+                            <div className="login-prompt-actions">
+                                <button className="login-prompt-btn" onClick={triggerLogin}>
+                                    <GoogleLogo/>
+                                    <span>{t('googleLogin')}</span>
+                                </button>
+                                <button className="login-prompt-close" onClick={dismissLoginPrompt}><FaXmark/></button>
+                            </div>
+                        </div>
+                        <ConsentBanner/>
+                    </div>
+                )}
+                {!showLoginPrompt && <ConsentBanner/>}
             </div>
         </div>
     );

--- a/tp-react/src/pages/Stats/components/DailyChart.css
+++ b/tp-react/src/pages/Stats/components/DailyChart.css
@@ -53,6 +53,7 @@
 }
 
 .daily-chart-area {
+    position: relative;
     height: 11.25rem;
 }
 

--- a/tp-react/src/pages/Stats/components/DailyChart.jsx
+++ b/tp-react/src/pages/Stats/components/DailyChart.jsx
@@ -56,24 +56,18 @@ function DailyChart({dailyStats, dailyRange, onRangeChange}) {
 
     const labelInterval = data.length > 14 ? Math.ceil(data.length / 6) : 1;
 
-    const handleMouseEnter = useCallback((i) => {
+    const handleMouseEnter = useCallback((e, i) => {
         setHoverIndex(i);
         setPopupData(data[i]);
-        if (svgRef.current && chartRef.current) {
-            const svg = svgRef.current;
-            const section = chartRef.current.closest('.daily-chart-section');
-            if (!svg || !section) return;
-            const svgRect = svg.getBoundingClientRect();
-            const sectionRect = section.getBoundingClientRect();
-            const vb = svg.viewBox.baseVal;
-            const sx = svgRect.width / vb.width;
-            const sy = svgRect.height / vb.height;
+        if (chartRef.current) {
+            const circle = e.target.getBoundingClientRect();
+            const area = chartRef.current.getBoundingClientRect();
             setPopupPos({
-                x: svgRect.left - sectionRect.left + points[i].x * sx,
-                y: svgRect.top - sectionRect.top + points[i].y * sy + 16,
+                x: circle.left - area.left + circle.width / 2 + 8,
+                y: circle.top - area.top + circle.height / 2 + 20,
             });
         }
-    }, [data, points]);
+    }, [data]);
 
     const handleMouseLeave = useCallback(() => {
         setHoverIndex(null);
@@ -119,7 +113,7 @@ function DailyChart({dailyStats, dailyRange, onRangeChange}) {
                                         <text x={p.x} y={p.y - 16} className="daily-chart-tooltip-text">{displayVal}</text>
                                     </g>
                                     <circle cx={p.x} cy={p.y} r={16} style={{fill: 'transparent', cursor: 'pointer'}}
-                                        onMouseEnter={() => handleMouseEnter(i)} onMouseLeave={handleMouseLeave}/>
+                                        onMouseEnter={(e) => handleMouseEnter(e, i)} onMouseLeave={handleMouseLeave}/>
                                     {showLabel && (
                                         <text x={p.x} y={PAD.top + CHART_H + 16} className="daily-chart-date-label" textAnchor={textAnchor}>
                                             {formatDateLabel(data[i].date)}

--- a/tp-react/src/pages/WordMode/components/WordTyping/WordInput.jsx
+++ b/tp-react/src/pages/WordMode/components/WordTyping/WordInput.jsx
@@ -2,6 +2,7 @@ import {useEffect, useRef, useState, useCallback, forwardRef, useImperativeHandl
 import {useWord} from "../../context/WordContext";
 import {koreanSeparator} from "@/utils/koreanSeparator.ts";
 import {areJamoEqual} from "@/pages/Home/components/Quote/Input/InputUtils";
+import {incrementSessionTypingCount} from "@/utils/sessionUtils.ts";
 import "./WordInput.css";
 
 const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocusChange}, ref) => {
@@ -70,7 +71,7 @@ const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocus
     }, []);
 
     // 전체 입력에 대한 글자 채점 (InputDisplay용)
-    const computeFullGrades = useCallback((input, confirmedCount) => {
+    const computeFullGrades = useCallback((input) => {
         const segments = input.split(' ');
         const allGrades = [];
 
@@ -105,6 +106,9 @@ const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocus
             timeMs: 0,
             elapsedMs,
         });
+
+        // 세션 타이핑 카운트 증가
+        incrementSessionTypingCount();
     }, [dispatch, gradeWord, words, startTimeRef]);
 
     const handleInput = (e) => {
@@ -162,7 +166,7 @@ const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocus
         }
 
         // 현재 단어 채점 + 전체 채점
-        const fullGrades = computeFullGrades(newValue, newConfirmedCount);
+        const fullGrades = computeFullGrades(newValue);
         onCurrentGradesChange?.(fullGrades);
         onFullInputChange?.(newValue);
     };

--- a/tp-react/src/pages/WordMode/components/WordTyping/WordTyping.jsx
+++ b/tp-react/src/pages/WordMode/components/WordTyping/WordTyping.jsx
@@ -7,6 +7,7 @@ import {VscDebugRestart} from "react-icons/vsc";
 import WordSentence from "./WordSentence";
 import WordInputDisplay from "./WordInputDisplay";
 import WordInput from "./WordInput";
+import ConsentBanner from "@/components/ConsentBanner/ConsentBanner.jsx";
 import "./WordTyping.css";
 
 const WordTyping = () => {
@@ -79,6 +80,8 @@ const WordTyping = () => {
                 </button>
                 <span className="word-typing-bottom-hint">{t('retryHint')}</span>
             </div>
+
+            <ConsentBanner/>
         </div>
     );
 };

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -203,6 +203,50 @@ const translations = {
     ),
     featureGuideConfirm: l('확인', 'OK', 'Got it'),
 
+    // 로그인 유도
+    loginPromptTitle: l('타이핑 기록을 저장해보세요', 'タイピング記録を保存しましょう', 'Save your typing records'),
+    loginPromptDesc: l(
+        '로그인하면 타이핑 속도, 정확도, 오타 분석을 확인할 수 있어요.',
+        'ログインすると、タイピング速度・正確度・誤字分析を確認できます。',
+        'Sign in to track your typing speed, accuracy, and typo analysis.'
+    ),
+
+    // 동의 배너
+    consentTitle: l('더 나은 서비스를 위해', 'より良いサービスのために', 'Help us improve'),
+    consentDesc: l(
+        '서비스 개선을 위해 익명 사용 데이터를 수집합니다. 개인을 식별할 수 없습니다.',
+        'サービス改善のため匿名の使用データを収集します。個人を特定することはできません。',
+        'We collect anonymous usage data to improve the service. It cannot identify you personally.'
+    ),
+    consentAnonymousId: l('익명 식별자', '匿名識別子', 'Anonymous ID'),
+    consentAnonymousIdDesc: l(
+        '이름, 이메일 등 개인정보와 연결되지 않습니다.',
+        '名前やメールなどの個人情報とは関連付けられません。',
+        'Not linked to any personal information like name or email.'
+    ),
+    consentDeviceType: l('기기 유형', 'デバイスタイプ', 'Device type'),
+    consentDeviceTypeDesc: l(
+        '모바일 / 태블릿 / 데스크톱 중 어떤 환경인지 확인합니다.',
+        'モバイル/タブレット/デスクトップのどの環境かを確認します。',
+        'Whether you\'re on mobile, tablet, or desktop.'
+    ),
+    consentReferrer: l('유입 경로', '流入経路', 'Referrer'),
+    consentReferrerDesc: l(
+        '어떤 사이트에서 방문했는지 확인합니다.',
+        'どのサイトからアクセスしたかを確認します。',
+        'Which site you came from.'
+    ),
+    consentSession: l('세션 정보', 'セッション情報', 'Session info'),
+    consentSessionDesc: l(
+        '한 번의 방문 동안만 유지되며, 탭을 닫으면 자동으로 삭제됩니다.',
+        '1回の訪問中のみ保持され、タブを閉じると自動的に削除されます。',
+        'Only kept during your visit. Automatically deleted when you close the tab.'
+    ),
+    consentAccept: l('동의', '同意', 'Accept'),
+    consentReject: l('거절', '拒否', 'Reject'),
+    consentMore: l('자세히 보기', '詳しく見る', 'More info'),
+    consentLess: l('접기', '閉じる', 'Less'),
+
     // 결과 팝업
     popupLoginPrompt: l('이 기록을 저장할까요?', 'この記録を保存しますか？', 'Save this record?'),
     popupCumulativeAvg: l('Overall avg', 'Overall avg', 'Overall avg'),

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -1,210 +1,216 @@
-const isKorean = navigator.language.startsWith('ko');
+type Lang = 'ko' | 'ja' | 'en';
+const lang: Lang = navigator.language.startsWith('ko') ? 'ko' : navigator.language.startsWith('ja') ? 'ja' : 'en';
+const l = (ko: string, ja: string, en: string) => lang === 'ko' ? ko : lang === 'ja' ? ja : en;
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 const translations = {
     // 공통
-    confirm: isKorean ? '확인' : 'OK',
-    cancel: isKorean ? '취소' : 'Cancel',
-    back: isKorean ? '돌아가기' : 'Back',
-    delete: isKorean ? '삭제' : 'Delete',
-    save: isKorean ? '저장' : 'Save',
-    saving: isKorean ? '저장 중...' : 'Saving...',
-    saveChanges: isKorean ? '저장하기' : 'Save',
-    close: isKorean ? '닫기' : 'Close',
-    loading: isKorean ? '로딩 중...' : 'Loading...',
-    edit: isKorean ? '수정' : 'Edit',
+    confirm: l('확인', '確認', 'OK'),
+    cancel: l('취소', 'キャンセル', 'Cancel'),
+    back: l('돌아가기', '戻る', 'Back'),
+    delete: l('삭제', '削除', 'Delete'),
+    save: l('저장', '保存', 'Save'),
+    saving: l('저장 중...', '保存中...', 'Saving...'),
+    saveChanges: l('저장하기', '保存する', 'Save'),
+    close: l('닫기', '閉じる', 'Close'),
+    loading: l('로딩 중...', '読み込み中...', 'Loading...'),
+    edit: l('수정', '編集', 'Edit'),
 
     // 로그인/인증
-    googleLogin: isKorean ? '구글 로그인' : 'Sign in with Google',
-    loginRequired: isKorean ? '로그인이 필요합니다.' : 'Login required.',
-    logout: isKorean ? '로그아웃' : 'Logout',
-    backToHome: isKorean ? '홈으로 돌아가기' : 'Back to Home',
+    googleLogin: l('구글 로그인', 'Googleでログイン', 'Sign in with Google'),
+    loginRequired: l('로그인이 필요합니다.', 'ログインが必要です。', 'Login required.'),
+    logout: l('로그아웃', 'ログアウト', 'Logout'),
+    backToHome: l('홈으로 돌아가기', 'ホームに戻る', 'Back to Home'),
 
     // 닉네임
-    welcome: isKorean ? '환영합니다!' : 'Welcome!',
-    setNickname: isKorean ? '닉네임을 설정해주세요. (2-10자)' : 'Please set your nickname. (2-10 characters)',
-    nicknamePlaceholder: isKorean ? '닉네임 입력' : 'Enter nickname',
-    nicknameLength: isKorean ? '닉네임은 2-10자여야 합니다.' : 'Nickname must be 2-10 characters.',
-    nicknameDuplicate: isKorean ? '이미 사용 중인 닉네임입니다.' : 'This nickname is already taken.',
-    nicknameCheckFailed: isKorean ? '중복 확인에 실패했습니다.' : 'Failed to check nickname.',
-    nicknameCheckFirst: isKorean ? '닉네임 중복 확인을 먼저 해주세요.' : 'Please check nickname availability first.',
-    nicknameAvailable: isKorean ? '사용 가능한 닉네임입니다.' : 'Nickname is available.',
-    nicknameHelper: isKorean ? '한글, 영문, 숫자 사용 가능' : 'Korean, English, numbers allowed',
-    checkDuplicate: isKorean ? '중복확인' : 'Check',
-    checking: isKorean ? '확인 중...' : 'Checking...',
-    nicknameSetFailed: isKorean ? '닉네임 설정에 실패했습니다.' : 'Failed to set nickname.',
-    nicknameEditFailed: isKorean ? '닉네임 수정에 실패했습니다.' : 'Failed to update nickname.',
-    start: isKorean ? '시작하기' : 'Start',
-    setting: isKorean ? '설정 중...' : 'Setting...',
-    setNicknameBtn: isKorean ? '닉네임 설정' : 'Set Nickname',
+    welcome: l('환영합니다!', 'ようこそ！', 'Welcome!'),
+    setNickname: l('닉네임을 설정해주세요. (2-10자)', 'ニックネームを設定してください（2〜10文字）', 'Please set your nickname. (2-10 characters)'),
+    nicknamePlaceholder: l('닉네임 입력', 'ニックネーム入力', 'Enter nickname'),
+    nicknameLength: l('닉네임은 2-10자여야 합니다.', 'ニックネームは2〜10文字です。', 'Nickname must be 2-10 characters.'),
+    nicknameDuplicate: l('이미 사용 중인 닉네임입니다.', 'このニックネームは既に使用されています。', 'This nickname is already taken.'),
+    nicknameCheckFailed: l('중복 확인에 실패했습니다.', '確認に失敗しました。', 'Failed to check nickname.'),
+    nicknameCheckFirst: l('닉네임 중복 확인을 먼저 해주세요.', '先にニックネームの重複確認をしてください。', 'Please check nickname availability first.'),
+    nicknameAvailable: l('사용 가능한 닉네임입니다.', '使用可能なニックネームです。', 'Nickname is available.'),
+    nicknameHelper: l('한글, 영문, 숫자 사용 가능', '韓国語、英語、数字が使用可能', 'Korean, English, numbers allowed'),
+    checkDuplicate: l('중복확인', '確認', 'Check'),
+    checking: l('확인 중...', '確認中...', 'Checking...'),
+    nicknameSetFailed: l('닉네임 설정에 실패했습니다.', 'ニックネームの設定に失敗しました。', 'Failed to set nickname.'),
+    nicknameEditFailed: l('닉네임 수정에 실패했습니다.', 'ニックネームの変更に失敗しました。', 'Failed to update nickname.'),
+    start: l('시작하기', '始める', 'Start'),
+    setting: l('설정 중...', '設定中...', 'Setting...'),
+    setNicknameBtn: l('닉네임 설정', 'ニックネーム設定', 'Set Nickname'),
 
     // 프로필
-    profile: isKorean ? '프로필' : 'Profile',
-    profileLoadFailed: isKorean ? '프로필을 불러오는데 실패했습니다.' : 'Failed to load profile.',
-    email: isKorean ? '이메일' : 'Email',
-    nickname: isKorean ? '닉네임' : 'Nickname',
-    joinDate: isKorean ? '가입일' : 'Joined',
-    user: isKorean ? '사용자' : 'User',
+    profile: l('프로필', 'プロフィール', 'Profile'),
+    profileLoadFailed: l('프로필을 불러오는데 실패했습니다.', 'プロフィールの読み込みに失敗しました。', 'Failed to load profile.'),
+    email: l('이메일', 'メール', 'Email'),
+    nickname: l('닉네임', 'ニックネーム', 'Nickname'),
+    joinDate: l('가입일', '登録日', 'Joined'),
+    user: l('사용자', 'ユーザー', 'User'),
 
     // 프로필 드롭다운
-    mySentences: isKorean ? '내 문장' : 'My Sentences',
-    records: isKorean ? '기록' : 'Records',
-    reportHistory: isKorean ? '신고 내역' : 'Report History',
+    mySentences: l('내 문장', 'マイ文章', 'My Sentences'),
+    records: l('기록', '記録', 'Records'),
+    reportHistory: l('신고 내역', '報告履歴', 'Report History'),
 
     // 헤더
-    uploadSentence: isKorean ? '문장 업로드' : 'Upload',
-    uploadLoginRequired: isKorean ? '문장을 업로드하려면 로그인이 필요합니다.' : 'Login required to upload sentences.',
-    loginFailed: isKorean ? '로그인에 실패했습니다. 다시 시도해주세요.' : 'Login failed. Please try again.',
-    googleLoginFailed: isKorean ? '구글 로그인에 실패했습니다.' : 'Google login failed.',
+    uploadSentence: l('문장 업로드', '文章アップロード', 'Upload'),
+    uploadLoginRequired: l('문장을 업로드하려면 로그인이 필요합니다.', '文章をアップロードするにはログインが必要です。', 'Login required to upload sentences.'),
+    loginFailed: l('로그인에 실패했습니다. 다시 시도해주세요.', 'ログインに失敗しました。もう一度お試しください。', 'Login failed. Please try again.'),
+    googleLoginFailed: l('구글 로그인에 실패했습니다.', 'Googleログインに失敗しました。', 'Google login failed.'),
 
     // 타이핑 입력
-    inputPlaceholder: isKorean ? '위 문장을 입력하세요.' : 'Type the sentence above.',
-    pasteBlocked: isKorean ? '붙여넣기가 금지되어 있습니다!' : 'Pasting is not allowed!',
+    inputPlaceholder: l('타이핑을 시작하세요.', 'タイピングを始めましょう。', 'Start typing.'),
+    pasteBlocked: l('붙여넣기가 금지되어 있습니다!', '貼り付けは禁止されています！', 'Pasting is not allowed!'),
 
     // 문장 소스
-    allSentences: isKorean ? '전체 문장' : 'All',
-    mySentencesOnly: isKorean ? '내 문장만' : 'Mine',
-    mySentencesLoginRequired: isKorean ? '내 문장을 사용하려면 로그인이 필요합니다.' : 'Login required to use your sentences.',
+    allSentences: l('전체 문장', 'すべての文章', 'All'),
+    mySentencesOnly: l('내 문장만', 'マイ文章のみ', 'Mine'),
+    mySentencesLoginRequired: l('내 문장을 사용하려면 로그인이 필요합니다.', 'マイ文章を使用するにはログインが必要です。', 'Login required to use your sentences.'),
 
     // 문장 로딩/비어있음
-    loadingSentences: isKorean ? '문장을 불러오는 중...' : 'Loading sentences...',
-    noSentences: isKorean ? '등록된 문장이 없습니다.' : 'No sentences found.',
-    sentenceLoadFailed: isKorean ? '문장을 불러오는데 실패했습니다.' : 'Failed to load sentences.',
+    loadingSentences: l('문장을 불러오는 중...', '文章を読み込み中...', 'Loading sentences...'),
+    noSentences: l('등록된 문장이 없습니다.', '登録された文章がありません。', 'No sentences found.'),
+    sentenceLoadFailed: l('문장을 불러오는데 실패했습니다.', '文章の読み込みに失敗しました。', 'Failed to load sentences.'),
 
     // 신고
-    report: isKorean ? '신고' : 'Report',
-    reportSentence: isKorean ? '문장 신고' : 'Report Sentence',
-    reportTarget: isKorean ? '신고 대상' : 'Target',
-    reportReason: isKorean ? '신고 사유' : 'Reason',
-    reportDetail: isKorean ? '상세 설명' : 'Details',
-    reportDetailPlaceholder: isKorean ? '신고 사유를 자세히 설명해주세요.' : 'Please describe the reason in detail.',
-    optional: isKorean ? '선택' : 'optional',
-    reportModify: isKorean ? '수정 요청' : 'Request Edit',
-    reportModifyDesc: isKorean ? '오타, 맞춤법 오류 등' : 'Typos, grammar errors, etc.',
-    reportDelete: isKorean ? '삭제 요청' : 'Request Delete',
-    reportDeleteDesc: isKorean ? '부적절한 내용, 저작권 위반 등' : 'Inappropriate content, copyright, etc.',
-    reporting: isKorean ? '신고 중...' : 'Reporting...',
-    reportFailed: isKorean ? '신고 접수에 실패했습니다.' : 'Failed to submit report.',
-    reportLoginRequired: isKorean ? '문장을 신고하려면 로그인이 필요합니다.' : 'Login required to report.',
-    cancelReport: isKorean ? '신고 취소' : 'Cancel Report',
+    report: l('신고', '報告', 'Report'),
+    reportSentence: l('문장 신고', '文章を報告', 'Report Sentence'),
+    reportTarget: l('신고 대상', '対象', 'Target'),
+    reportReason: l('신고 사유', '理由', 'Reason'),
+    reportDetail: l('상세 설명', '詳細', 'Details'),
+    reportDetailPlaceholder: l('신고 사유를 자세히 설명해주세요.', '報告理由を詳しく説明してください。', 'Please describe the reason in detail.'),
+    optional: l('선택', '任意', 'optional'),
+    reportModify: l('수정 요청', '修正リクエスト', 'Request Edit'),
+    reportModifyDesc: l('오타, 맞춤법 오류 등', '誤字、スペルミスなど', 'Typos, grammar errors, etc.'),
+    reportDelete: l('삭제 요청', '削除リクエスト', 'Request Delete'),
+    reportDeleteDesc: l('부적절한 내용, 저작권 위반 등', '不適切な内容、著作権侵害など', 'Inappropriate content, copyright, etc.'),
+    reporting: l('신고 중...', '報告中...', 'Reporting...'),
+    reportFailed: l('신고 접수에 실패했습니다.', '報告の送信に失敗しました。', 'Failed to submit report.'),
+    reportLoginRequired: l('문장을 신고하려면 로그인이 필요합니다.', '報告するにはログインが必要です。', 'Login required to report.'),
+    cancelReport: l('신고 취소', '報告取消', 'Cancel Report'),
 
     // 내 문장 페이지
-    mySentencesTitle: isKorean ? '내 문장' : 'My Sentences',
-    noMySentences: isKorean ? '등록한 문장이 없습니다.' : 'No sentences registered.',
-    deleteSentenceConfirm: isKorean ? '이 문장을 삭제하시겠습니까?' : 'Delete this sentence?',
-    editSentence: isKorean ? '문장 수정' : 'Edit Sentence',
-    sentence: isKorean ? '문장' : 'Sentence',
-    authorOptional: isKorean ? '저자 (선택)' : 'Author (optional)',
-    makePublic: isKorean ? '공개전환' : 'Make Public',
-    cancelPublic: isKorean ? '공개취소' : 'Cancel Public',
+    mySentencesTitle: l('내 문장', 'マイ文章', 'My Sentences'),
+    noMySentences: l('등록한 문장이 없습니다.', '登録した文章がありません。', 'No sentences registered.'),
+    deleteSentenceConfirm: l('이 문장을 삭제하시겠습니까?', 'この文章を削除しますか？', 'Delete this sentence?'),
+    editSentence: l('문장 수정', '文章を編集', 'Edit Sentence'),
+    sentence: l('문장', '文章', 'Sentence'),
+    authorOptional: l('저자 (선택)', '著者（任意）', 'Author (optional)'),
+    makePublic: l('공개전환', '公開する', 'Make Public'),
+    cancelPublic: l('공개취소', '公開取消', 'Cancel Public'),
 
     // 필터
-    all: isKorean ? '전체' : 'All',
-    public: isKorean ? '공개' : 'Public',
-    private: isKorean ? '비공개' : 'Private',
-    pending: isKorean ? '대기중' : 'Pending',
-    active: isKorean ? '활성' : 'Active',
-    processed: isKorean ? '처리완료' : 'Processed',
+    all: l('전체', 'すべて', 'All'),
+    public: l('공개', '公開', 'Public'),
+    private: l('비공개', '非公開', 'Private'),
+    pending: l('대기중', '保留中', 'Pending'),
+    active: l('활성', 'アクティブ', 'Active'),
+    processed: l('처리완료', '処理済み', 'Processed'),
 
     // 신고 내역 페이지
-    reportHistoryTitle: isKorean ? '신고 내역' : 'Report History',
-    noReports: isKorean ? '신고 내역이 없습니다.' : 'No reports found.',
-    deleteReportConfirm: isKorean ? '이 신고를 취소하시겠습니까?' : 'Cancel this report?',
-    reportContent: isKorean ? '신고 내용' : 'Report Details',
-    deleted: isKorean ? '삭제됨' : 'Deleted',
+    reportHistoryTitle: l('신고 내역', '報告履歴', 'Report History'),
+    noReports: l('신고 내역이 없습니다.', '報告履歴がありません。', 'No reports found.'),
+    deleteReportConfirm: l('이 신고를 취소하시겠습니까?', 'この報告を取り消しますか？', 'Cancel this report?'),
+    reportContent: l('신고 내용', '報告内容', 'Report Details'),
+    deleted: l('삭제됨', '削除済み', 'Deleted'),
 
     // 업로드 페이지
-    uploadTitle: isKorean ? '문장 업로드' : 'Upload Sentences',
-    uploadTypeHint: isKorean ? '각 문장마다 공개/비공개를 선택할 수 있습니다.' : 'You can set each sentence as public or private.',
-    uploadTooltipPublic: isKorean ? '관리자 승인 후 모든 사용자에게 노출됩니다.' : 'Visible to all users after admin approval.',
-    uploadTooltipPrivate: isKorean ? '본인만 사용할 수 있습니다.' : 'Only visible to you.',
-    sentencePlaceholder: (min: number, max: number) => isKorean ? `문장을 입력하세요 (${min}-${max}자)` : `Enter a sentence (${min}-${max} characters)`,
-    authorPlaceholder: isKorean ? '저자 (선택)' : 'Author (optional)',
-    addSentence: (cur: number, max: number) => isKorean ? `문장 추가 (${cur}/${max})` : `Add sentence (${cur}/${max})`,
-    maxEntries: (max: number) => isKorean ? `최대 ${max}개` : `Max ${max}`,
-    upload: isKorean ? '업로드' : 'Upload',
-    uploading: isKorean ? '업로드 중...' : 'Uploading...',
-    minSentenceLength: (min: number) => isKorean ? `문장은 ${min}자 이상이어야 합니다.` : `Sentence must be at least ${min} characters.`,
-    maxSentenceLength: (max: number) => isKorean ? `문장은 ${max}자 이하여야 합니다.` : `Sentence must be at most ${max} characters.`,
-    maxAuthorLength: (max: number) => isKorean ? `저자는 ${max}자 이하여야 합니다.` : `Author must be at most ${max} characters.`,
-    enterAtLeastOne: isKorean ? '최소 1개의 문장을 입력해주세요.' : 'Please enter at least one sentence.',
-    uploadConfirmBoth: (pub: number, priv: number) => isKorean ? `공개 ${pub}개, 비공개 ${priv}개의 문장을 업로드합니다.` : `Upload ${pub} public and ${priv} private sentences.`,
-    uploadConfirmPublic: (n: number) => isKorean ? `${n}개의 문장을 공개로 업로드합니다.` : `Upload ${n} public sentences.`,
-    uploadConfirmPrivate: (n: number) => isKorean ? `${n}개의 문장을 비공개로 업로드합니다.` : `Upload ${n} private sentences.`,
-    uploadSuccess: (n: number) => isKorean ? `${n}개의 문장 업로드에 성공했습니다.` : `${n} sentences uploaded successfully.`,
-    uploadFailed: isKorean ? '업로드에 실패했습니다.' : 'Upload failed.',
-    similarPublic: isKorean ? '공개 문장 내에 유사한 문장이 존재합니다.' : 'A similar public sentence already exists.',
-    similarMy: isKorean ? '내 문장 내에 유사한 문장이 존재합니다.' : 'A similar sentence already exists in your sentences.',
-    editSentenceFailed: isKorean ? '문장 수정에 실패했습니다.' : 'Failed to edit sentence.',
-    deleteSentenceFailed: isKorean ? '문장 삭제에 실패했습니다.' : 'Failed to delete sentence.',
-    makePublicFailed: isKorean ? '공개 전환에 실패했습니다.' : 'Failed to make public.',
-    cancelPublicFailed: isKorean ? '공개 취소에 실패했습니다.' : 'Failed to cancel public.',
-    deleteReportFailed: isKorean ? '신고 삭제에 실패했습니다.' : 'Failed to delete report.',
+    uploadTitle: l('문장 업로드', '文章アップロード', 'Upload Sentences'),
+    uploadTypeHint: l('각 문장마다 공개/비공개를 선택할 수 있습니다.', '各文章ごとに公開/非公開を選択できます。', 'You can set each sentence as public or private.'),
+    uploadTooltipPublic: l('관리자 승인 후 모든 사용자에게 노출됩니다.', '管理者の承認後、すべてのユーザーに公開されます。', 'Visible to all users after admin approval.'),
+    uploadTooltipPrivate: l('본인만 사용할 수 있습니다.', '自分だけが使用できます。', 'Only visible to you.'),
+    sentencePlaceholder: (min: number, max: number) => l(`문장을 입력하세요 (${min}-${max}자)`, `文章を入力してください（${min}〜${max}文字）`, `Enter a sentence (${min}-${max} characters)`),
+    authorPlaceholder: l('저자 (선택)', '著者（任意）', 'Author (optional)'),
+    addSentence: (cur: number, max: number) => l(`문장 추가 (${cur}/${max})`, `文章追加（${cur}/${max}）`, `Add sentence (${cur}/${max})`),
+    maxEntries: (max: number) => l(`최대 ${max}개`, `最大${max}件`, `Max ${max}`),
+    upload: l('업로드', 'アップロード', 'Upload'),
+    uploading: l('업로드 중...', 'アップロード中...', 'Uploading...'),
+    minSentenceLength: (min: number) => l(`문장은 ${min}자 이상이어야 합니다.`, `文章は${min}文字以上必要です。`, `Sentence must be at least ${min} characters.`),
+    maxSentenceLength: (max: number) => l(`문장은 ${max}자 이하여야 합니다.`, `文章は${max}文字以下にしてください。`, `Sentence must be at most ${max} characters.`),
+    maxAuthorLength: (max: number) => l(`저자는 ${max}자 이하여야 합니다.`, `著者は${max}文字以下にしてください。`, `Author must be at most ${max} characters.`),
+    enterAtLeastOne: l('최소 1개의 문장을 입력해주세요.', '少なくとも1つの文章を入力してください。', 'Please enter at least one sentence.'),
+    uploadConfirmBoth: (pub: number, priv: number) => l(`공개 ${pub}개, 비공개 ${priv}개의 문장을 업로드합니다.`, `公開${pub}件、非公開${priv}件の文章をアップロードします。`, `Upload ${pub} public and ${priv} private sentences.`),
+    uploadConfirmPublic: (n: number) => l(`${n}개의 문장을 공개로 업로드합니다.`, `${n}件の文章を公開でアップロードします。`, `Upload ${n} public sentences.`),
+    uploadConfirmPrivate: (n: number) => l(`${n}개의 문장을 비공개로 업로드합니다.`, `${n}件の文章を非公開でアップロードします。`, `Upload ${n} private sentences.`),
+    uploadSuccess: (n: number) => l(`${n}개의 문장 업로드에 성공했습니다.`, `${n}件の文章をアップロードしました。`, `${n} sentences uploaded successfully.`),
+    uploadFailed: l('업로드에 실패했습니다.', 'アップロードに失敗しました。', 'Upload failed.'),
+    similarPublic: l('공개 문장 내에 유사한 문장이 존재합니다.', '公開文章に類似する文章が既に存在します。', 'A similar public sentence already exists.'),
+    similarMy: l('내 문장 내에 유사한 문장이 존재합니다.', 'マイ文章に類似する文章が既に存在します。', 'A similar sentence already exists in your sentences.'),
+    editSentenceFailed: l('문장 수정에 실패했습니다.', '文章の編集に失敗しました。', 'Failed to edit sentence.'),
+    deleteSentenceFailed: l('문장 삭제에 실패했습니다.', '文章の削除に失敗しました。', 'Failed to delete sentence.'),
+    makePublicFailed: l('공개 전환에 실패했습니다.', '公開への切り替えに失敗しました。', 'Failed to make public.'),
+    cancelPublicFailed: l('공개 취소에 실패했습니다.', '公開の取り消しに失敗しました。', 'Failed to cancel public.'),
+    deleteReportFailed: l('신고 삭제에 실패했습니다.', '報告の削除に失敗しました。', 'Failed to delete report.'),
 
     // 기록 페이지
-    myTypingRecords: isKorean ? '내 타이핑 기록' : 'My Typing Records',
-    statsLoadFailed: isKorean ? '기록을 불러오는데 실패했습니다.' : 'Failed to load records.',
-    refreshCooldown: isKorean ? '새로고침은 1분에 한 번만 가능합니다.' : 'Refresh is available once per minute.',
-    refreshFailed: isKorean ? '새로고침에 실패했습니다.' : 'Refresh failed.',
+    myTypingRecords: l('내 타이핑 기록', 'マイタイピング記録', 'My Typing Records'),
+    statsLoadFailed: l('기록을 불러오는데 실패했습니다.', '記録の読み込みに失敗しました。', 'Failed to load records.'),
+    refreshCooldown: l('새로고침은 1분에 한 번만 가능합니다.', '更新は1分に1回のみ可能です。', 'Refresh is available once per minute.'),
+    refreshFailed: l('새로고침에 실패했습니다.', '更新に失敗しました。', 'Refresh failed.'),
 
     // 종합 통계
-    recent7DayAvg: isKorean ? '최근 7일 평균' : '7-Day Average',
-    best: isKorean ? '최고' : 'Best',
-    accuracy: isKorean ? '정확도' : 'Accuracy',
-    practiceTime: isKorean ? '연습 시간' : 'Practice Time',
-    practiceCount: isKorean ? '연습 횟수' : 'Practices',
-    totalAverage: isKorean ? '전체 평균' : 'Overall Avg',
-    avgReset: isKorean ? '평균 초기화' : 'Avg Resets',
-    times: isKorean ? '회' : '',
+    recent7DayAvg: l('최근 7일 평균', '直近7日間の平均', '7-Day Average'),
+    best: l('최고', '最高', 'Best'),
+    accuracy: l('정확도', '正確度', 'Accuracy'),
+    practiceTime: l('연습 시간', '練習時間', 'Practice Time'),
+    practiceCount: l('연습 횟수', '練習回数', 'Practices'),
+    totalAverage: l('전체 평균', '全体平均', 'Overall Avg'),
+    avgReset: l('평균 초기화', '平均リセット', 'Avg Resets'),
+    times: l('회', '回', ''),
     formatTime: (min: number) => {
-        if (!min || min <= 0) return isKorean ? '0분' : '0m';
+        if (!min || min <= 0) return l('0분', '0分', '0m');
         const h = Math.floor(min / 60);
         const m = Math.round(min % 60);
-        if (isKorean) return h > 0 ? `${h}시간 ${m}분` : `${m}분`;
+        if (lang === 'ko') return h > 0 ? `${h}시간 ${m}분` : `${m}분`;
+        if (lang === 'ja') return h > 0 ? `${h}時間${m}分` : `${m}分`;
         return h > 0 ? `${h}h ${m}m` : `${m}m`;
     },
 
     // 에러 컨텍스트
-    errorConfirm: isKorean ? '확인' : 'OK',
+    errorConfirm: l('확인', '確認', 'OK'),
 
     // 일별 추이 차트
-    dailyTrend: isKorean ? '일별 추이' : 'Daily Trend',
-    accuracyTab: isKorean ? '정확도' : 'Accuracy',
-    days: (n: number) => isKorean ? `${n}일` : `${n}d`,
-    noData: isKorean ? '데이터가 없습니다.' : 'No data available.',
+    dailyTrend: l('일별 추이', '日別推移', 'Daily Trend'),
+    accuracyTab: l('정확도', '正確度', 'Accuracy'),
+    days: (n: number) => l(`${n}일`, `${n}日`, `${n}d`),
+    noData: l('데이터가 없습니다.', 'データがありません。', 'No data available.'),
     formatPopupTitle: (dateStr: string) => {
         const parts = dateStr.split('-');
-        if (isKorean) return parts[0] + '년 ' + parseInt(parts[1]) + '월 ' + parseInt(parts[2]) + '일';
+        if (lang === 'ko') return parts[0] + '년 ' + parseInt(parts[1]) + '월 ' + parseInt(parts[2]) + '일';
+        if (lang === 'ja') return parts[0] + '年' + parseInt(parts[1]) + '月' + parseInt(parts[2]) + '日';
         return MONTH_NAMES[parseInt(parts[1]) - 1] + ' ' + parseInt(parts[2]) + ', ' + parts[0];
     },
-    attempts: isKorean ? '연습 횟수' : 'Attempts',
-    avgSpeed: isKorean ? '평균 타자 속도' : 'Avg Speed',
-    bestSpeed: isKorean ? '최고 타자 속도' : 'Best Speed',
-    avgAccuracy: isKorean ? '평균 정확도' : 'Avg Accuracy',
-    avgResetCount: isKorean ? '평균 초기화 횟수' : 'Avg Resets',
-    countUnit: isKorean ? '회' : '',
+    attempts: l('연습 횟수', '練習回数', 'Attempts'),
+    avgSpeed: l('평균 타자 속도', '平均タイピング速度', 'Avg Speed'),
+    bestSpeed: l('최고 타자 속도', '最高タイピング速度', 'Best Speed'),
+    avgAccuracy: l('평균 정확도', '平均正確度', 'Avg Accuracy'),
+    avgResetCount: l('평균 초기화 횟수', '平均リセット回数', 'Avg Resets'),
+    countUnit: l('회', '回', ''),
 
     // 오타 통계
-    typoTop10: isKorean ? '자주 틀리는 글자 TOP 10' : 'Most Missed Characters TOP 10',
-    noTypoData: isKorean ? '오타 데이터가 없습니다.' : 'No typo data available.',
-    typoDetailTitle: isKorean ? '오타 상세' : 'Typo Details',
-    noDetailData: isKorean ? '상세 데이터가 없습니다.' : 'No detail data available.',
+    typoTop10: l('자주 틀리는 글자 TOP 10', 'よく間違える文字 TOP 10', 'Most Missed Characters TOP 10'),
+    noTypoData: l('오타 데이터가 없습니다.', '誤字データがありません。', 'No typo data available.'),
+    typoDetailTitle: l('오타 상세', '誤字の詳細', 'Typo Details'),
+    noDetailData: l('상세 데이터가 없습니다.', '詳細データがありません。', 'No detail data available.'),
 
     // 기능 가이드
-    featureGuideTitle: isKorean ? '이런 기능이 있어요!' : 'Check out these features!',
-    featureGuideDesc: isKorean
-        ? '로그인하면 원하는 문장을 직접 업로드하고, 타이핑 기록과 오타 분석을 확인할 수 있어요.'
-        : 'Sign in to upload your own sentences and track your typing speed, accuracy, and typo patterns.',
-    featureGuideConfirm: isKorean ? '확인' : 'Got it',
+    featureGuideTitle: l('이런 기능이 있어요!', 'こんな機能があります！', 'Check out these features!'),
+    featureGuideDesc: l(
+        '로그인하면 원하는 문장을 직접 업로드하고, 타이핑 기록과 오타 분석을 확인할 수 있어요.',
+        'ログインすると、好きな文章をアップロードしたり、タイピング記録や誤字分析を確認できます。',
+        'Sign in to upload your own sentences and track your typing speed, accuracy, and typo patterns.'
+    ),
+    featureGuideConfirm: l('확인', 'OK', 'Got it'),
 
     // 결과 팝업
-    popupLoginPrompt: isKorean ? '이 기록을 저장할까요?' : 'Save this record?',
-    popupCumulativeAvg: isKorean ? 'Overall avg' : 'Overall avg',
-    popupViewStats: isKorean ? '자세한 통계 보기 →' : 'View detailed stats →',
+    popupLoginPrompt: l('이 기록을 저장할까요?', 'この記録を保存しますか？', 'Save this record?'),
+    popupCumulativeAvg: l('Overall avg', 'Overall avg', 'Overall avg'),
+    popupViewStats: l('자세한 통계 보기 →', '詳しい統計を見る →', 'View detailed stats →'),
 
-    // 모드 전환 (영어 고정)
-    sentenceMode: isKorean ? '문장 연습' : 'Sentence',
-    wordMode: isKorean ? '단어 연습' : 'Word',
+    // 모드 전환
+    sentenceMode: l('문장 연습', '文章練習', 'Sentence'),
+    wordMode: l('단어 연습', '単語練習', 'Word'),
 
     // 단어 모드 설정 (영어 고정)
     difficulty: 'Difficulty',
@@ -232,14 +238,14 @@ const translations = {
     },
 
     // 업데이트 팝업
-    updateNotice: isKorean ? '업데이트 안내' : 'Update',
-    updateHistory: isKorean ? '업데이트 내역' : 'Update History',
-    updateClose: isKorean ? '확인' : 'OK',
-    updateViewHistory: isKorean ? '지난 업데이트 보기' : 'View past updates',
-    updateDontShow: isKorean ? '다시 보지 않기' : 'Don\'t show again',
-    updateNotices: isKorean ? '공지 사항' : 'Notices',
-    updateFeatures: isKorean ? '새로운 기능' : 'New features',
-    updateImprovements: isKorean ? '개선사항' : 'Improvements',
+    updateNotice: l('업데이트 안내', 'アップデート情報', 'Update'),
+    updateHistory: l('업데이트', 'アップデート', 'Updates'),
+    updateClose: l('확인', '確認', 'OK'),
+    updateViewHistory: l('지난 업데이트 보기', '過去のアップデートを見る', 'View past updates'),
+    updateDontShow: l('다시 보지 않기', '次から表示しない', 'Don\'t show again'),
+    updateNotices: l('공지 사항', 'お知らせ', 'Notices'),
+    updateFeatures: l('새로운 기능', '新機能', 'New features'),
+    updateImprovements: l('개선사항', '改善点', 'Improvements'),
 } as const;
 
 type TranslationKey = keyof typeof translations;

--- a/tp-react/src/utils/sessionUtils.ts
+++ b/tp-react/src/utils/sessionUtils.ts
@@ -1,0 +1,9 @@
+import {Session_Typing_Count} from '@/const/config.const';
+
+export function incrementSessionTypingCount(): number {
+    const count = parseInt(sessionStorage.getItem(Session_Typing_Count) || '0', 10);
+    const newCount = count + 1;
+    sessionStorage.setItem(Session_Typing_Count, String(newCount));
+    window.dispatchEvent(new CustomEvent('typing-count-update', {detail: newCount}));
+    return newCount;
+}


### PR DESCRIPTION
## 개요
i18n 시스템을 3개 언어(한/일/영)로 확장하고, 비로그인 사용자에게 로그인 유도 및 GDPR 동의 배너를 인라인으로 표시합니다.

## 변경 사항

### i18n 일본어 지원
- 언어 감지를 `navigator.language` 기반 ko/ja/en 3단계 분기로 변경
- `isKorean ? ko : en` 패턴을 `l(ko, ja, en)` 헬퍼 함수로 전환
- 전체 UI 번역 키(150+개) 및 업데이트 내역(v1.0.0~v1.4.0) 일본어 추가

### 로그인 유도
- 세션 타이핑 3회 완료 후 비로그인 사용자에게 입력 영역 하단에 로그인 유도 표시
- Google 로그인 버튼 포함, 세션 단위 닫기 지원

### GDPR 동의 배너 인라인화
- 기존 오버레이 팝업 → 입력 영역 하단 인라인 div로 전환
- 타이핑 3회 후 지연 노출, 동의 전까지 데이터 수집 안 함
- 로그인 유도와 겹침 표시: 동의 응답 후 로그인 유도가 바로 노출
- 문장 연습 / 단어 연습 모두 지원

### 통계 차트 팝업 위치 수정
- SVG viewBox 좌표 변환 → getBoundingClientRect() 기반으로 단순화
- 데이터 점 좌하단에 팝업 고정