### PR TITLE
feat: UI 리디자인 v1.4.0 — 네비게이션, i18n, 로그인 유도, GDPR 배너

### DIFF
--- a/tp-react/prototype.css
+++ b/tp-react/prototype.css
@@ -11,13 +11,13 @@ body {
     flex-direction: column;
     align-items: center;
     min-height: 100vh;
-    padding-top: 18vh;
+    padding-top: 20vh;
     background-color: #fafafa;
     color: #333;
 }
 
 body.dark {
-    background-color: #0f0f0f;
+    background-color: #1a1a1e;
     color: #e5e7eb;
 }
 
@@ -25,43 +25,137 @@ body.dark {
     display: none !important;
 }
 
-/* 좌측 상단 컨트롤 */
-.top-left-controls {
+/* 상단 네비게이션 바 */
+.top-nav {
     position: fixed;
-    top: 1rem;
-    left: 1rem;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4.5rem;
     display: flex;
     align-items: center;
-    gap: 1.5rem;
+    justify-content: space-between;
+    padding: 0 2rem;
+    background-color: #ffffff;
+    border-bottom: 1px solid #e5e7eb;
     z-index: 100;
 }
 
-/* 폰트 슬라이더 */
-.font-size-slider-container {
+body.dark .top-nav {
+    background-color: #222228;
+    border-bottom-color: #26262c;
+}
+
+.nav-left {
     display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+    align-items: center;
+    gap: 2rem;
 }
 
-.font-size-label {
-    font-size: 0.75rem;
-    color: #999;
+.nav-logo {
+    font-size: 1.75rem;
+    font-weight: 600;
+    color: #333;
+    margin: 0;
     cursor: pointer;
+    white-space: nowrap;
 }
 
-.font-size-label.dark {
+body.dark .nav-logo {
+    color: #e5e7eb;
+}
+
+.nav-links {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.nav-link {
+    position: relative;
+    padding: 0 0.75rem;
+    border: none;
+    background: none;
     color: #666;
-}
-
-.font-size-slider {
-    width: 100px;
-    height: 4px;
-    background: #e5e7eb;
+    font-size: 0.95rem;
     cursor: pointer;
+    border-radius: 0;
+    transition: color 0.15s;
+    height: 4.5rem;
+    display: flex;
+    align-items: center;
 }
 
-.font-size-slider.dark {
-    background: #3f3f46;
+.nav-link:hover {
+    color: #333;
+    background-color: #f5f5f5;
+}
+
+body.dark .nav-link {
+    color: #a1a1aa;
+}
+
+body.dark .nav-link:hover {
+    color: #e5e7eb;
+    background-color: #26262c;
+}
+
+.nav-link.active {
+    color: #6d28d9;
+    font-weight: 600;
+}
+
+.nav-link.active::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0.75rem;
+    right: 0.75rem;
+    height: 3px;
+    background: #6d28d9;
+    border-radius: 1px;
+}
+
+body.dark .nav-link.active {
+    color: #8b5cf6;
+}
+
+body.dark .nav-link.active::after {
+    background: #8b5cf6;
+}
+
+.nav-beta {
+    font-size: 0.55rem;
+    font-weight: 600;
+    color: #6d28d9;
+    border: 1px solid #6d28d9;
+    border-radius: 0.2rem;
+    padding: 0.05rem 0.25rem;
+    margin-left: 0.25rem;
+    vertical-align: super;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+}
+
+body.dark .nav-beta {
+    color: #8b5cf6;
+    border-color: #8b5cf6;
+}
+
+.nav-right {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.nav-divider {
+    width: 1px;
+    height: 1.25rem;
+    background: #e5e7eb;
+}
+
+body.dark .nav-divider {
+    background: #3e3e46;
 }
 
 /* 모드 토글 */
@@ -75,10 +169,11 @@ body.dark {
     font-size: 0.75rem;
     color: #999;
     cursor: pointer;
+    user-select: none;
 }
 
 .mode-toggle-label.dark {
-    color: #666;
+    color: #9ca3af;
 }
 
 .mode-toggle {
@@ -92,7 +187,7 @@ body.dark {
 }
 
 .mode-toggle.dark {
-    background: #3f3f46;
+    background: #3e3e46;
 }
 
 .mode-toggle.active {
@@ -120,14 +215,10 @@ body.dark {
 
 /* 공지 아이콘 */
 .notice-icon {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
     color: #999;
     cursor: pointer;
-    font-size: 1.25rem;
+    font-size: 1rem;
     transition: color 0.2s;
-    z-index: 100;
 }
 
 .notice-icon:hover {
@@ -142,32 +233,7 @@ body.dark {
     color: #999;
 }
 
-/* 헤더 */
-.head {
-    width: 80%;
-    max-width: 1000px;
-    min-width: 600px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 3rem;
-}
-
-.title-title {
-    font-size: 2rem;
-    font-weight: 600;
-    color: #333;
-}
-
-.title-title.dark {
-    color: #e5e7eb;
-}
-
-.head-right {
-    display: flex;
-    align-items: center;
-    gap: 1rem;
-}
+/* 헤더 (deprecated - top-nav로 대체됨) */
 
 .header-btn {
     padding: 0.5rem 1rem;
@@ -193,7 +259,7 @@ body.dark {
 }
 
 .header-btn.dark:hover {
-    background-color: #27272a;
+    background-color: #26262c;
     color: #e5e7eb;
 }
 
@@ -244,7 +310,7 @@ body.dark {
 }
 
 .profile-btn.dark:hover {
-    background-color: #27272a;
+    background-color: #26262c;
     color: #e5e7eb;
 }
 
@@ -262,8 +328,8 @@ body.dark {
 }
 
 .dropdown-menu.dark {
-    background-color: #1f1f1f;
-    border-color: #3f3f46;
+    background-color: #28282e;
+    border-color: #3e3e46;
 }
 
 .dropdown-item {
@@ -291,7 +357,7 @@ body.dark {
 }
 
 .dropdown-item.dark:hover {
-    background-color: #27272a;
+    background-color: #26262c;
     color: #e5e7eb;
 }
 
@@ -302,142 +368,256 @@ body.dark {
 }
 
 .dropdown-divider.dark {
-    background-color: #3f3f46;
+    background-color: #3e3e46;
 }
 
 /* 정보 영역 */
 .info-background {
     width: 80%;
-    max-width: 1000px;
+    max-width: 1200px;
     min-width: 600px;
-    padding: 1rem 0 0;
+    padding: 1.25rem 0;
     margin-bottom: 0.5rem;
+    position: relative;
 }
 
-.info-settings {
+.info-row {
     display: flex;
-    justify-content: flex-end;
-    padding: 0 1rem;
-    margin-bottom: 1.5rem;
+    justify-content: space-between;
+    align-items: center;
 }
 
-.result-period-container {
+.info-stats {
     display: flex;
     align-items: center;
-    gap: 0.5rem;
+    gap: 2.5rem;
 }
 
-.result-period-btn {
+.info-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+}
+
+.info-stat-label {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: #a1a1aa;
+}
+
+body.dark .info-stat-label {
+    color: #9ca3af;
+}
+
+.info-stat-value {
+    font-size: 2.25rem;
+    font-weight: 300;
+    color: #c4c4c4;
+    line-height: 1.1;
+}
+
+.info-stat-value.current {
+    color: #6d28d9;
+    font-weight: 400;
+}
+
+body.dark .info-stat-value {
+    color: #a1a1aa;
+}
+
+body.dark .info-stat-value.current {
+    color: #8b5cf6;
+}
+
+.info-stat-sep {
+    width: 1px;
+    height: 2.75rem;
+    background: #e5e7eb;
+    margin: 0 -0.5rem;
+}
+
+body.dark .info-stat-sep {
+    background: #3e3e46;
+}
+
+/* Info 우측 컨트롤 pill */
+.info-controls {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    background: #f4f4f5;
+    border-radius: 0.75rem;
+    min-height: 3.25rem;
+    overflow: hidden;
+    transition: max-width 0.25s ease, padding 0.25s ease, opacity 0.25s ease;
+}
+
+body.dark .info-controls {
+    background: #26262c;
+}
+
+.info-controls-inner {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+    padding: 1.125rem 0 1.125rem 1.5rem;
+    overflow: hidden;
+    transition: max-width 0.25s ease, padding 0.25s ease, opacity 0.25s ease;
+    max-width: 500px;
+    opacity: 1;
+}
+
+.info-controls.collapsed .info-controls-inner {
+    max-width: 0;
+    padding-left: 0;
+    opacity: 0;
+}
+
+.info-controls.narrow-mode {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    z-index: 10;
+}
+
+.info-controls-toggle {
     border: none;
     background: none;
-    color: #666;
+    color: #a1a1aa;
+    font-size: 0.75rem;
     cursor: pointer;
-    font-size: 0.9rem;
+    padding: 1.125rem 1rem;
+    transition: color 0.15s;
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
 }
 
-.result-period-btn.dark {
-    color: #999;
+.info-controls-toggle:hover {
+    color: #6d28d9;
 }
 
-.result-period-value {
-    font-size: 1.3rem;
+body.dark .info-controls-toggle {
+    color: #9ca3af;
+}
+
+body.dark .info-controls-toggle:hover {
+    color: #8b5cf6;
+}
+
+.info-tt-label {
+    font-size: 1.125rem;
+    font-weight: 400;
+    color: #9ca3af;
+    cursor: pointer;
+    user-select: none;
+    line-height: 1;
+}
+
+body.dark .info-tt-label {
+    color: #a1a1aa;
+}
+
+.info-slider {
+    width: 110px;
+    height: 4px;
+    cursor: pointer;
+    accent-color: #6d28d9;
+    -webkit-appearance: none;
+    appearance: none;
+    background: #d4d4d8;
+    border-radius: 2px;
+    outline: none;
+}
+
+body.dark .info-slider {
+    background: #54545e;
+}
+
+.info-slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: #6d28d9;
+    cursor: pointer;
+    border: 3px solid #ffffff;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+body.dark .info-slider::-webkit-slider-thumb {
+    background: #8b5cf6;
+    border-color: #26262c;
+}
+
+.info-control-sep {
+    width: 1px;
+    height: 1.5rem;
+    background: #d4d4d8;
+}
+
+body.dark .info-control-sep {
+    background: #3e3e46;
+}
+
+.info-control-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    color: #a1a1aa;
+    white-space: nowrap;
+    user-select: none;
+}
+
+body.dark .info-control-label {
+    color: #9ca3af;
+}
+
+.info-interval-control {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+}
+
+.info-interval-value {
+    font-size: 0.9375rem;
+    font-weight: 600;
     color: #333;
-    min-width: 2rem;
+    min-width: 1rem;
     text-align: center;
 }
 
-.result-period-value.dark {
+body.dark .info-interval-value {
     color: #e5e7eb;
 }
 
-.info-CPMs {
-    display: flex;
-    justify-content: space-between;
-    padding: 0 1rem;
-    margin-bottom: 1.5rem;
-    font-size: 1.1rem;
-}
-
-.CPM-text {
-    color: #666;
-}
-
-.CPM-text.dark {
-    color: #999;
-}
-
-.CPM-value {
-    margin-left: 2rem;
-    font-weight: 600;
-    color: #333;
-}
-
-.CPM-value.dark {
-    color: #ffffff;
-}
-
-.info-averages {
-    display: flex;
-    justify-content: space-around;
-    padding: 1.5rem 1rem;
-    border-top: 1px solid #e5e7eb;
-    border-bottom: 1px solid #e5e7eb;
-}
-
-.info-averages.dark {
-    border-top-color: #27272a;
-    border-bottom-color: #27272a;
-}
-
-.info-averages.collapsed {
-    display: none;
-}
-
-.average-label {
-    font-size: 1.1rem;
-    color: #666;
-}
-
-.average-label.dark {
-    color: #999;
-}
-
-.average-value {
-    margin-left: 1.5rem;
-    font-weight: 600;
-    color: #333;
-}
-
-.average-value.dark {
-    color: #e5e7eb;
-}
-
-.averages-toggle-container {
-    display: flex;
-    justify-content: center;
-    padding: 0.5rem 0 0 0;
-}
-
-.averages-toggle-btn {
+.info-period-btn {
     border: none;
     background: none;
-    color: #999;
+    color: #a1a1aa;
     cursor: pointer;
-    padding: 0.25rem 0.5rem;
-    font-size: 0.8rem;
-    transition: color 0.2s;
+    font-size: 0.5rem;
+    padding: 0.125rem;
+    line-height: 1;
+    transition: color 0.15s;
+    display: flex;
+    align-items: center;
 }
 
-.averages-toggle-btn:hover {
-    color: #666;
+.info-period-btn:hover {
+    color: #6d28d9;
 }
 
-.averages-toggle-btn.dark {
-    color: #666;
+body.dark .info-period-btn {
+    color: #9ca3af;
 }
 
-.averages-toggle-btn.dark:hover {
-    color: #999;
+body.dark .info-period-btn:hover {
+    color: #8b5cf6;
 }
 
 /* 문장 소스 선택 */
@@ -445,63 +625,113 @@ body.dark {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 0.5rem;
+    margin-bottom: 0;
+    border-bottom: 1px solid #e5e7eb;
+}
+
+body.dark .quote-top-row {
+    border-bottom-color: #26262c;
 }
 
 .quote-source-selector {
     display: flex;
-    gap: 0.5rem;
+    gap: 0;
 }
 
 .quote-source-btn {
-    padding: 0.25rem 0.5rem;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.375rem;
+    position: relative;
+    padding: 0.75rem 1rem;
+    border: none;
+    border-radius: 0;
     background-color: transparent;
     color: #999;
-    font-size: 0.8rem;
+    font-size: 0.95rem;
+    font-weight: 500;
     cursor: pointer;
-    transition: all 0.2s;
+    transition: color 0.2s;
     display: flex;
     align-items: center;
-    gap: 0.25rem;
+    gap: 0.375rem;
 }
 
 .quote-source-btn:hover {
-    border-color: #666;
     color: #666;
 }
 
 .quote-source-btn.active {
-    border-color: #666;
-    background-color: #666;
-    color: white;
+    color: #6d28d9;
+    font-weight: 600;
 }
 
-.quote-source-btn.dark {
-    border-color: #3f3f46;
-    color: #71717a;
+.quote-source-btn.active::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: #6d28d9;
 }
 
-.quote-source-btn.dark:hover {
-    border-color: #a1a1aa;
+body.dark .quote-source-btn {
+    color: #9ca3af;
+}
+
+body.dark .quote-source-btn:hover {
     color: #a1a1aa;
 }
 
-.quote-source-btn.dark.active {
-    border-color: #71717a;
-    background-color: #71717a;
-    color: white;
+body.dark .quote-source-btn.active {
+    color: #8b5cf6;
+}
+
+body.dark .quote-source-btn.active::after {
+    background: #8b5cf6;
 }
 
 .quote-top-row .author-container {
     margin-bottom: 0;
 }
 
+.quote-sub-row {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 0.5rem 0;
+}
+
+.upload-inline-btn {
+    padding: 0.4rem 0.75rem;
+    border: none;
+    background: transparent;
+    color: #999;
+    font-size: 0.85rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    transition: color 0.15s;
+    border-radius: 0.375rem;
+}
+
+.upload-inline-btn:hover {
+    color: #6d28d9;
+    background-color: #f5f5f5;
+}
+
+body.dark .upload-inline-btn {
+    color: #9ca3af;
+}
+
+body.dark .upload-inline-btn:hover {
+    color: #8b5cf6;
+    background-color: #26262c;
+}
+
 /* 타이핑 영역 */
 .quote-container {
     width: 80%;
-    max-width: 1000px;
+    max-width: 1200px;
     min-width: 600px;
     padding: 0 2rem 2rem;
 }
@@ -518,7 +748,7 @@ body.dark {
 }
 
 .author-text.dark {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 .sentence-input-wrapper {
@@ -629,7 +859,7 @@ body.dark {
 }
 
 .quote-container.default-mode .input.dark::placeholder {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 .spacer {
@@ -673,7 +903,7 @@ body.dark {
 }
 
 .update-popup.dark {
-    background-color: #1f1f1f;
+    background-color: #28282e;
     color: #e5e7eb;
 }
 
@@ -745,12 +975,12 @@ body.dark {
 }
 
 .update-popup-history-btn.dark {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #999;
 }
 
 .update-popup-history-btn.dark:hover {
-    background-color: #27272a;
+    background-color: #26262c;
     color: #e5e7eb;
 }
 
@@ -761,7 +991,7 @@ body.dark {
 }
 
 .update-history-item.dark {
-    border-bottom-color: #3f3f46;
+    border-bottom-color: #3e3e46;
 }
 
 .update-history-item:last-child {
@@ -838,7 +1068,7 @@ body.dark {
 }
 
 .update-popup.history-mode .update-popup-section-title {
-    font-size: 0.9rem;
+    font-size: 1rem;
     margin-bottom: 0.25rem;
 }
 
@@ -904,7 +1134,7 @@ body.dark {
 }
 
 .nickname-popup.dark {
-    background-color: #1f1f1f;
+    background-color: #28282e;
     color: #e5e7eb;
 }
 
@@ -916,7 +1146,7 @@ body.dark {
 }
 
 .nickname-popup-description {
-    font-size: 0.9rem;
+    font-size: 1rem;
     color: #666;
     margin-bottom: 1.5rem;
 }
@@ -931,7 +1161,7 @@ body.dark {
 
 .nickname-label {
     display: block;
-    font-size: 0.9rem;
+    font-size: 1rem;
     color: #333;
     margin-bottom: 0.5rem;
 }
@@ -955,8 +1185,8 @@ body.dark {
 }
 
 .nickname-input.dark {
-    background-color: #27272a;
-    border-color: #3f3f46;
+    background-color: #26262c;
+    border-color: #3e3e46;
     color: #e5e7eb;
 }
 
@@ -1025,7 +1255,7 @@ body.dark {
     border-radius: 1rem;
     padding: 2rem;
     width: 80%;
-    max-width: 1000px;
+    max-width: 1200px;
     min-width: 600px;
     max-height: 85vh;
     overflow-y: auto;
@@ -1033,7 +1263,7 @@ body.dark {
 }
 
 .upload-popup.dark {
-    background-color: #1f1f1f;
+    background-color: #28282e;
     color: #e5e7eb;
 }
 
@@ -1128,7 +1358,7 @@ body.dark {
 }
 
 .upload-type-tooltip.dark {
-    background-color: #3f3f46;
+    background-color: #3e3e46;
 }
 
 .upload-type-info:hover .upload-type-tooltip {
@@ -1154,8 +1384,8 @@ body.dark {
 }
 
 .upload-entry.dark {
-    border-color: #3f3f46;
-    background-color: #27272a;
+    border-color: #3e3e46;
+    background-color: #26262c;
 }
 
 .upload-entry.success {
@@ -1189,7 +1419,7 @@ body.dark {
     border: none;
     background: none;
     color: #999;
-    font-size: 0.9rem;
+    font-size: 1rem;
     cursor: pointer;
     padding: 0.25rem;
     display: flex;
@@ -1243,7 +1473,7 @@ body.dark {
 }
 
 .upload-entry-type-btn.dark {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #666;
 }
 
@@ -1289,7 +1519,7 @@ body.dark {
 }
 
 .upload-input.dark {
-    border-bottom-color: #3f3f46;
+    border-bottom-color: #3e3e46;
     color: #e5e7eb;
 }
 
@@ -1331,7 +1561,7 @@ body.dark {
     border-radius: 0.5rem;
     background-color: transparent;
     color: #999;
-    font-size: 0.9rem;
+    font-size: 1rem;
     cursor: pointer;
     transition: all 0.2s;
     display: flex;
@@ -1346,7 +1576,7 @@ body.dark {
 }
 
 .upload-add-btn.dark {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #666;
 }
 
@@ -1362,7 +1592,7 @@ body.dark {
 }
 
 .upload-add-btn.dark:disabled {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #555;
 }
 
@@ -1390,12 +1620,12 @@ body.dark {
 }
 
 .upload-cancel-btn.dark {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #999;
 }
 
 .upload-cancel-btn.dark:hover {
-    background-color: #27272a;
+    background-color: #26262c;
     color: #e5e7eb;
 }
 
@@ -1454,7 +1684,7 @@ body.dark {
 }
 
 .confirm-popup.dark {
-    background-color: #1f1f1f;
+    background-color: #28282e;
     color: #e5e7eb;
 }
 
@@ -1493,12 +1723,12 @@ body.dark {
 }
 
 .confirm-popup-cancel-btn.dark {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #999;
 }
 
 .confirm-popup-cancel-btn.dark:hover {
-    background-color: #27272a;
+    background-color: #26262c;
     color: #e5e7eb;
 }
 
@@ -1562,11 +1792,11 @@ body.dark {
 }
 
 .my-quotes-popup.dark {
-    background-color: #1f1f1f;
+    background-color: #28282e;
 }
 
 body.dark .my-quotes-popup {
-    background-color: #1f1f1f;
+    background-color: #28282e;
 }
 
 .my-quotes-header {
@@ -1601,7 +1831,7 @@ body.dark .my-quotes-popup {
 }
 
 .my-quotes-close-btn.dark {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 .my-quotes-close-btn.dark:hover {
@@ -1609,7 +1839,7 @@ body.dark .my-quotes-popup {
 }
 
 body.dark .my-quotes-close-btn {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 body.dark .my-quotes-close-btn:hover {
@@ -1626,11 +1856,11 @@ body.dark .my-quotes-close-btn:hover {
 }
 
 .my-quotes-filters.dark {
-    border-bottom-color: #27272a;
+    border-bottom-color: #26262c;
 }
 
 body.dark .my-quotes-filters {
-    border-bottom-color: #27272a;
+    border-bottom-color: #26262c;
 }
 
 .my-quotes-filter-group {
@@ -1661,8 +1891,8 @@ body.dark .my-quotes-filters {
 }
 
 .my-quotes-filter-btn.dark {
-    border-color: #3f3f46;
-    color: #71717a;
+    border-color: #3e3e46;
+    color: #9ca3af;
 }
 
 .my-quotes-filter-btn.dark:hover {
@@ -1695,8 +1925,8 @@ body.dark .my-quotes-filters {
 }
 
 .my-quote-card.dark {
-    border-color: #27272a;
-    background-color: #18181b;
+    border-color: #26262c;
+    background-color: #222228;
 }
 
 .my-quote-card-header {
@@ -1807,12 +2037,12 @@ body.dark .my-quotes-filters {
 }
 
 .my-quote-action-btn.dark {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #a1a1aa;
 }
 
 .my-quote-action-btn.dark:hover {
-    background-color: #27272a;
+    background-color: #26262c;
     color: #e5e7eb;
 }
 
@@ -1864,7 +2094,7 @@ body.dark .my-quotes-filters {
     gap: 0.5rem;
     padding: 1rem;
     color: #666;
-    font-size: 0.9rem;
+    font-size: 1rem;
 }
 
 .my-quotes-loading.dark {
@@ -1881,7 +2111,7 @@ body.dark .my-quotes-filters {
 }
 
 .my-quotes-spinner.dark {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     border-top-color: #8b5cf6;
 }
 
@@ -1893,7 +2123,7 @@ body.dark .my-quotes-filters {
 }
 
 .my-quotes-end.dark {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 .my-quotes-empty {
@@ -1906,7 +2136,7 @@ body.dark .my-quotes-filters {
 }
 
 .my-quotes-empty.dark {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 .my-quotes-empty i {
@@ -1945,7 +2175,7 @@ body.dark .my-quotes-filters {
 }
 
 .quote-edit-popup.dark {
-    background-color: #1f1f1f;
+    background-color: #28282e;
 }
 
 .quote-edit-title {
@@ -1996,7 +2226,7 @@ body.dark .my-quotes-filters {
 }
 
 .quote-edit-input.dark {
-    border-bottom-color: #3f3f46;
+    border-bottom-color: #3e3e46;
     color: #e5e7eb;
 }
 
@@ -2020,7 +2250,7 @@ body.dark .my-quotes-filters {
 }
 
 .quote-edit-char-count.dark {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 .quote-edit-char-count.warning {
@@ -2050,12 +2280,12 @@ body.dark .my-quotes-filters {
 }
 
 .quote-edit-cancel-btn.dark {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #a1a1aa;
 }
 
 .quote-edit-cancel-btn.dark:hover {
-    background-color: #27272a;
+    background-color: #26262c;
     color: #e5e7eb;
 }
 
@@ -2082,8 +2312,8 @@ body.dark .my-quotes-filters {
 }
 
 .quote-edit-save-btn.dark {
-    background-color: #3f3f46;
-    color: #71717a;
+    background-color: #3e3e46;
+    color: #9ca3af;
 }
 
 .quote-edit-save-btn.dark:enabled {
@@ -2099,8 +2329,8 @@ body.dark .my-quotes-filters {
    body.dark 기반 스타일 (내 문장, 문장 수정 팝업)
    =========================================== */
 body.dark .my-quotes-filter-btn {
-    border-color: #3f3f46;
-    color: #71717a;
+    border-color: #3e3e46;
+    color: #9ca3af;
 }
 
 body.dark .my-quotes-filter-btn:hover {
@@ -2115,8 +2345,8 @@ body.dark .my-quotes-filter-btn.active {
 }
 
 body.dark .my-quote-card {
-    border-color: #27272a;
-    background-color: #18181b;
+    border-color: #26262c;
+    background-color: #222228;
 }
 
 body.dark .my-quote-badge.type-public {
@@ -2153,12 +2383,12 @@ body.dark .my-quote-author {
 }
 
 body.dark .my-quote-action-btn {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #a1a1aa;
 }
 
 body.dark .my-quote-action-btn:hover {
-    background-color: #27272a;
+    background-color: #26262c;
     color: #e5e7eb;
 }
 
@@ -2187,16 +2417,16 @@ body.dark .my-quotes-loading {
 }
 
 body.dark .my-quotes-spinner {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     border-top-color: #8b5cf6;
 }
 
 body.dark .my-quotes-empty {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 body.dark .quote-edit-popup {
-    background-color: #1f1f1f;
+    background-color: #28282e;
 }
 
 body.dark .quote-edit-label {
@@ -2204,7 +2434,7 @@ body.dark .quote-edit-label {
 }
 
 body.dark .quote-edit-input {
-    border-bottom-color: #3f3f46;
+    border-bottom-color: #3e3e46;
     color: #e5e7eb;
 }
 
@@ -2213,22 +2443,22 @@ body.dark .quote-edit-input:focus {
 }
 
 body.dark .quote-edit-char-count {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 body.dark .quote-edit-cancel-btn {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #a1a1aa;
 }
 
 body.dark .quote-edit-cancel-btn:hover {
-    background-color: #27272a;
+    background-color: #26262c;
     color: #e5e7eb;
 }
 
 body.dark .quote-edit-save-btn {
-    background-color: #3f3f46;
-    color: #71717a;
+    background-color: #3e3e46;
+    color: #9ca3af;
 }
 
 body.dark .quote-edit-save-btn:enabled {
@@ -2241,7 +2471,7 @@ body.dark .quote-edit-save-btn:enabled:hover {
 }
 
 body.dark .confirm-popup {
-    background-color: #1f1f1f;
+    background-color: #28282e;
 }
 
 body.dark .confirm-popup-message {
@@ -2249,12 +2479,12 @@ body.dark .confirm-popup-message {
 }
 
 body.dark .confirm-popup-cancel-btn {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #999;
 }
 
 body.dark .confirm-popup-cancel-btn:hover {
-    background-color: #27272a;
+    background-color: #26262c;
     color: #e5e7eb;
 }
 
@@ -2287,7 +2517,7 @@ body.dark .confirm-popup-ok-btn:hover {
 }
 
 body.dark .quote-more-btn {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 body.dark .quote-more-btn:hover {
@@ -2308,8 +2538,8 @@ body.dark .quote-more-btn:hover {
 }
 
 body.dark .quote-more-menu {
-    background-color: #1f1f1f;
-    border-color: #3f3f46;
+    background-color: #28282e;
+    border-color: #3e3e46;
 }
 
 .quote-more-item {
@@ -2337,7 +2567,7 @@ body.dark .quote-more-item {
 }
 
 body.dark .quote-more-item:hover {
-    background-color: #27272a;
+    background-color: #26262c;
     color: #f87171;
 }
 
@@ -2365,7 +2595,7 @@ body.dark .quote-more-item:hover {
 }
 
 body.dark .report-popup {
-    background-color: #1f1f1f;
+    background-color: #28282e;
 }
 
 .report-popup-header {
@@ -2401,7 +2631,7 @@ body.dark .report-popup-title {
 }
 
 body.dark .report-popup-close-btn {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 body.dark .report-popup-close-btn:hover {
@@ -2417,7 +2647,7 @@ body.dark .report-popup-close-btn:hover {
 }
 
 body.dark .report-quote-preview {
-    background-color: #27272a;
+    background-color: #26262c;
 }
 
 .report-quote-label {
@@ -2428,7 +2658,7 @@ body.dark .report-quote-preview {
 }
 
 body.dark .report-quote-label {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 .report-quote-sentence {
@@ -2457,7 +2687,7 @@ body.dark .report-quote-author {
 }
 
 .report-section-label {
-    font-size: 0.9rem;
+    font-size: 1rem;
     font-weight: 500;
     color: #333;
     display: block;
@@ -2491,12 +2721,12 @@ body.dark .report-section-label {
 }
 
 body.dark .report-reason-option {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
 }
 
 body.dark .report-reason-option:hover {
-    border-color: #52525b;
-    background-color: #27272a;
+    border-color: #54545e;
+    background-color: #26262c;
 }
 
 .report-reason-option:has(input:checked) {
@@ -2525,7 +2755,7 @@ body.dark .report-reason-option:has(input:checked) {
 }
 
 body.dark .report-reason-radio {
-    border-color: #52525b;
+    border-color: #54545e;
 }
 
 .report-reason-option:has(input:checked) .report-reason-radio {
@@ -2596,8 +2826,8 @@ body.dark .report-reason-desc {
 }
 
 body.dark .report-detail-input {
-    background-color: #27272a;
-    border-color: #3f3f46;
+    background-color: #26262c;
+    border-color: #3e3e46;
     color: #e5e7eb;
 }
 
@@ -2610,7 +2840,7 @@ body.dark .report-detail-input:focus {
 }
 
 body.dark .report-detail-input::placeholder {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 .report-detail-count {
@@ -2622,7 +2852,7 @@ body.dark .report-detail-input::placeholder {
 }
 
 body.dark .report-detail-count {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 /* 신고 버튼 */
@@ -2649,12 +2879,12 @@ body.dark .report-detail-count {
 }
 
 body.dark .report-cancel-btn {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #a1a1aa;
 }
 
 body.dark .report-cancel-btn:hover {
-    background-color: #27272a;
+    background-color: #26262c;
     color: #e5e7eb;
 }
 
@@ -2712,7 +2942,7 @@ body.dark .report-submit-btn:disabled {
 }
 
 body.dark .my-reports-popup {
-    background-color: #1f1f1f;
+    background-color: #28282e;
 }
 
 .my-reports-header {
@@ -2724,7 +2954,7 @@ body.dark .my-reports-popup {
 }
 
 body.dark .my-reports-header {
-    border-bottom-color: #3f3f46;
+    border-bottom-color: #3e3e46;
 }
 
 .my-reports-title {
@@ -2753,7 +2983,7 @@ body.dark .my-reports-title {
 }
 
 body.dark .my-reports-close-btn {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 body.dark .my-reports-close-btn:hover {
@@ -2768,7 +2998,7 @@ body.dark .my-reports-close-btn:hover {
 }
 
 body.dark .my-reports-filters {
-    border-bottom-color: #3f3f46;
+    border-bottom-color: #3e3e46;
 }
 
 .my-reports-filter-btn {
@@ -2794,13 +3024,13 @@ body.dark .my-reports-filters {
 }
 
 body.dark .my-reports-filter-btn {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #a1a1aa;
 }
 
 body.dark .my-reports-filter-btn:hover {
-    border-color: #52525b;
-    background-color: #27272a;
+    border-color: #54545e;
+    background-color: #26262c;
 }
 
 body.dark .my-reports-filter-btn.active {
@@ -2826,8 +3056,8 @@ body.dark .my-reports-filter-btn.active {
 }
 
 body.dark .my-report-card {
-    background-color: #27272a;
-    border-color: #3f3f46;
+    background-color: #26262c;
+    border-color: #3e3e46;
 }
 
 .my-report-card-header {
@@ -2895,7 +3125,7 @@ body.dark .my-report-badge.status-processed {
 }
 
 body.dark .my-report-date {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 .my-report-quote {
@@ -2907,7 +3137,7 @@ body.dark .my-report-date {
 }
 
 body.dark .my-report-quote {
-    background-color: #1f1f1f;
+    background-color: #28282e;
     border-left-color: #8b5cf6;
 }
 
@@ -2917,11 +3147,11 @@ body.dark .my-report-quote {
 }
 
 body.dark .my-report-quote.deleted {
-    border-left-color: #52525b;
+    border-left-color: #54545e;
 }
 
 .my-report-sentence {
-    font-size: 0.9rem;
+    font-size: 1rem;
     color: #333;
     margin: 0 0 0.25rem 0;
     line-height: 1.5;
@@ -2947,7 +3177,7 @@ body.dark .my-report-author {
 }
 
 body.dark .my-report-deleted-text {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 .my-report-detail {
@@ -2984,7 +3214,7 @@ body.dark .my-report-detail {
 }
 
 body.dark .my-report-delete-btn {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #a1a1aa;
 }
 
@@ -3010,7 +3240,7 @@ body.dark .my-report-delete-btn:hover {
 }
 
 body.dark .my-reports-spinner {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     border-top-color: #8b5cf6;
 }
 
@@ -3039,7 +3269,7 @@ body.dark .my-reports-spinner {
 }
 
 body.dark .my-reports-empty {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 /* ===========================================
@@ -3047,23 +3277,23 @@ body.dark .my-reports-empty {
    =========================================== */
 .stats-page {
     position: fixed;
-    top: 0;
+    top: 4.5rem;
     left: 0;
     width: 100%;
-    height: 100%;
+    height: calc(100% - 4.5rem);
     background-color: #fafafa;
-    z-index: 200;
+    z-index: 50;
     overflow-y: auto;
     padding: 2rem 0;
 }
 
 body.dark .stats-page {
-    background-color: #0f0f0f;
+    background-color: #1a1a1e;
 }
 
 .stats-container {
     width: 80%;
-    max-width: 1000px;
+    max-width: 1200px;
     min-width: 600px;
     margin: 0 auto;
 }
@@ -3100,13 +3330,13 @@ body.dark .stats-page {
 }
 
 body.dark .stats-refresh-btn {
-    border-color: #3f3f46;
-    background: #18181b;
+    border-color: #3e3e46;
+    background: #222228;
     color: #a1a1aa;
 }
 
 body.dark .stats-refresh-btn:hover {
-    background-color: #27272a;
+    background-color: #26262c;
 }
 
 /* Summary Layout */
@@ -3128,8 +3358,8 @@ body.dark .stats-refresh-btn:hover {
 }
 
 body.dark .stats-main-card {
-    background: #18181b;
-    border-color: #3f3f46;
+    background: #222228;
+    border-color: #3e3e46;
 }
 
 .stats-main-label {
@@ -3221,7 +3451,7 @@ body.dark .stats-main-sub {
 }
 
 body.dark .stats-sub-card {
-    background: #27272a;
+    background: #26262c;
 }
 
 .stats-sub-label {
@@ -3230,7 +3460,7 @@ body.dark .stats-sub-card {
 }
 
 body.dark .stats-sub-label {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 .stats-sub-value {
@@ -3251,7 +3481,7 @@ body.dark .stats-sub-value {
 }
 
 body.dark .stats-sub-unit {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 /* Section */
@@ -3265,8 +3495,8 @@ body.dark .stats-sub-unit {
 }
 
 body.dark .stats-section {
-    background: #18181b;
-    border-color: #3f3f46;
+    background: #222228;
+    border-color: #3e3e46;
 }
 
 .stats-section-header {
@@ -3313,7 +3543,7 @@ body.dark .stats-section-title {
 }
 
 body.dark .stats-tab {
-    border-color: #3f3f46;
+    border-color: #3e3e46;
     color: #a1a1aa;
 }
 
@@ -3331,7 +3561,7 @@ body.dark .stats-tab.active {
 }
 
 body.dark .stats-tab-divider {
-    background: #3f3f46;
+    background: #3e3e46;
 }
 
 /* Chart */
@@ -3350,7 +3580,7 @@ body.dark .stats-tab-divider {
 }
 
 body.dark .stats-chart-grid {
-    stroke: #3f3f46;
+    stroke: #3e3e46;
 }
 
 .stats-chart-grid-label {
@@ -3394,7 +3624,7 @@ body.dark .stats-chart-line {
 
 body.dark .stats-chart-dot {
     fill: #8b5cf6;
-    stroke: #18181b;
+    stroke: #222228;
 }
 
 .stats-chart-point-label {
@@ -3420,8 +3650,8 @@ body.dark .stats-chart-point-label {
 }
 
 body.dark .stats-chart-tooltip-bg {
-    fill: #27272a;
-    stroke: #3f3f46;
+    fill: #26262c;
+    stroke: #3e3e46;
 }
 
 .stats-chart-date-label {
@@ -3509,7 +3739,7 @@ body.dark .stats-typo-char {
 }
 
 body.dark .stats-typo-bar-container {
-    background: #3f3f46;
+    background: #3e3e46;
 }
 
 .stats-typo-bar-fill {
@@ -3554,7 +3784,7 @@ body.dark .stats-typo-count {
 }
 
 body.dark .stats-typo-detail-item {
-    background: #1a1a1d;
+    background: #222228;
 }
 
 .stats-typo-detail-expected {
@@ -3631,8 +3861,8 @@ body.dark .stats-typo-detail-count {
 }
 
 body.dark .stats-daily-popup {
-    background: #18181b;
-    border-color: #3f3f46;
+    background: #222228;
+    border-color: #3e3e46;
     box-shadow: 0 4px 16px rgba(0, 0, 0, 0.3);
 }
 
@@ -3674,7 +3904,7 @@ body.dark .stats-daily-popup-title {
 }
 
 body.dark .stats-daily-popup-item {
-    background: #27272a;
+    background: #26262c;
 }
 
 .stats-daily-popup-label {
@@ -3683,7 +3913,7 @@ body.dark .stats-daily-popup-item {
 }
 
 body.dark .stats-daily-popup-label {
-    color: #71717a;
+    color: #9ca3af;
 }
 
 .stats-daily-popup-value {
@@ -3715,11 +3945,174 @@ body.dark .stats-daily-popup-value {
 }
 
 body.dark .stats-back-btn {
-    border-color: #3f3f46;
-    background: #18181b;
+    border-color: #3e3e46;
+    background: #222228;
     color: #a1a1aa;
 }
 
 body.dark .stats-back-btn:hover {
-    background-color: #27272a;
+    background-color: #26262c;
+}
+
+/* ===========================================
+   Updates Page
+   =========================================== */
+.updates-page {
+    position: fixed;
+    top: 4.5rem;
+    left: 0;
+    width: 100%;
+    height: calc(100% - 4.5rem);
+    background-color: #fafafa;
+    z-index: 50;
+    overflow-y: auto;
+    padding: 2rem 0;
+}
+
+body.dark .updates-page {
+    background-color: #1a1a1e;
+}
+
+.updates-container {
+    width: 80%;
+    max-width: 800px;
+    min-width: 600px;
+    margin: 0 auto;
+}
+
+.updates-header {
+    margin-bottom: 1.75rem;
+}
+
+.updates-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: #6d28d9;
+}
+
+.updates-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.update-card {
+    background: #fff;
+    border: 1px solid #e5e7eb;
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+}
+
+body.dark .update-card {
+    background: #222228;
+    border-color: #3e3e46;
+}
+
+.update-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.update-card-version {
+    font-weight: 600;
+    color: #6d28d9;
+    font-size: 1rem;
+}
+
+body.dark .update-card-version {
+    color: #8b5cf6;
+}
+
+.update-card-date {
+    font-size: 0.8rem;
+    color: #999;
+}
+
+body.dark .update-card-date {
+    color: #9ca3af;
+}
+
+.update-card-section {
+    margin-bottom: 0.75rem;
+}
+
+.update-card-section:last-child {
+    margin-bottom: 0;
+}
+
+.update-card-section-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: #333;
+    margin-bottom: 0.375rem;
+}
+
+body.dark .update-card-section-title {
+    color: #e5e7eb;
+}
+
+.update-card-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.update-card-list li {
+    position: relative;
+    padding-left: 1rem;
+    margin-bottom: 0.25rem;
+    font-size: 0.875rem;
+    color: #555;
+    line-height: 1.5;
+}
+
+body.dark .update-card-list li {
+    color: #a1a1aa;
+}
+
+.update-card-list li::before {
+    content: "•";
+    position: absolute;
+    left: 0;
+    color: #6d28d9;
+}
+
+body.dark .update-card-list li::before {
+    color: #8b5cf6;
+}
+
+.updates-footer {
+    margin-top: 1.75rem;
+    display: flex;
+    justify-content: center;
+}
+
+.updates-back-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1.5rem;
+    border-radius: 0.5rem;
+    border: 1px solid #e5e7eb;
+    background: #fff;
+    color: #666;
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: background-color 0.15s;
+}
+
+.updates-back-btn:hover {
+    background-color: #f4f4f5;
+}
+
+body.dark .updates-back-btn {
+    border-color: #3e3e46;
+    background: #222228;
+    color: #a1a1aa;
+}
+
+body.dark .updates-back-btn:hover {
+    background-color: #26262c;
 }

--- a/tp-react/prototype1.js
+++ b/tp-react/prototype1.js
@@ -41,8 +41,8 @@ if (savedFontSize) {
 }
 slider.addEventListener('input', e => updateFontSize(sliderToFontSize(parseFloat(e.target.value))));
 
-// Font Size 라벨 클릭 시 리셋
-document.getElementById('fontSizeLabel').addEventListener('click', () => {
+// Font Size 라벨(Tt) 클릭 시 리셋
+document.querySelector('.info-tt-label').addEventListener('click', () => {
     updateFontSize(1.5);
     slider.value = fontSizeToSlider(1.5);
 });
@@ -50,9 +50,10 @@ document.getElementById('fontSizeLabel').addEventListener('click', () => {
 // 다크모드
 function toggleTheme() {
     document.getElementById('body').classList.toggle('dark');
+    document.documentElement.classList.remove('dark-pending');
     document.getElementById('iconSun').classList.toggle('display-none');
     document.getElementById('iconMoon').classList.toggle('display-none');
-    document.querySelectorAll('.font-size-label, .font-size-slider, .mode-toggle-label, .mode-toggle, .notice-icon, .title-title, .header-btn, .profile-btn, .dropdown-menu, .dropdown-item, .dropdown-divider, .dark-mode-icon, .result-period-btn, .result-period-value, .CPM-text, .CPM-value, .info-averages, .average-label, .average-value, .averages-toggle-btn, .author-text, .character, .input-char-correct, .input, .contact, .upload-popup, .upload-popup-close-btn, .upload-type-hint, .upload-type-info, .upload-type-tooltip, .upload-entry, .upload-input, .upload-entry-delete-btn, .upload-entry-type-btn, .upload-entry-message.success, .upload-add-btn, .upload-cancel-btn, .upload-submit-btn, .confirm-popup, .confirm-popup-message, .confirm-popup-cancel-btn, .confirm-popup-ok-btn').forEach(el => el.classList.toggle('dark'));
+    document.querySelectorAll('.notice-icon, .nav-logo, .header-btn, .profile-btn, .dropdown-menu, .dropdown-item, .dropdown-divider, .dark-mode-icon, .author-text, .character, .input-char-correct, .input, .contact, .upload-popup, .upload-popup-close-btn, .upload-type-hint, .upload-type-info, .upload-type-tooltip, .upload-entry, .upload-input, .upload-entry-delete-btn, .upload-entry-type-btn, .upload-entry-message.success, .upload-add-btn, .upload-cancel-btn, .upload-submit-btn, .confirm-popup, .confirm-popup-message, .confirm-popup-cancel-btn, .confirm-popup-ok-btn').forEach(el => el.classList.toggle('dark'));
     localStorage.setItem('Typing-Practice-darkMode', isDark());
 }
 
@@ -67,30 +68,7 @@ textarea.addEventListener('input', function () {
     this.style.height = this.scrollHeight + 'px';
 });
 
-// 평균점수 토글
-let averagesVisible = localStorage.getItem('Typing-Practice-averagesVisible') !== 'false';
-const infoAverages = document.getElementById('infoAverages');
-const averagesToggleIcon = document.getElementById('averagesToggleIcon');
-
-function updateAveragesVisibility() {
-    if (averagesVisible) {
-        infoAverages.classList.remove('collapsed');
-        averagesToggleIcon.classList.remove('fa-chevron-down');
-        averagesToggleIcon.classList.add('fa-chevron-up');
-    } else {
-        infoAverages.classList.add('collapsed');
-        averagesToggleIcon.classList.remove('fa-chevron-up');
-        averagesToggleIcon.classList.add('fa-chevron-down');
-    }
-}
-
-updateAveragesVisibility();
-
-document.getElementById('averagesToggleBtn').addEventListener('click', () => {
-    averagesVisible = !averagesVisible;
-    localStorage.setItem('Typing-Practice-averagesVisible', averagesVisible);
-    updateAveragesVisibility();
-});
+// 평균점수 토글 (제거됨 - info 영역 통합)
 
 // 모드 토글 (Default / Compact)
 let isCompactMode = localStorage.getItem('Typing-Practice-compactMode') === 'true';
@@ -121,6 +99,63 @@ function toggleMode() {
 
 modeToggle.addEventListener('click', toggleMode);
 modeLabel.addEventListener('click', toggleMode);
+
+// Info 컨트롤 접기/펼치기
+const infoControls = document.getElementById('infoControls');
+const infoControlsToggle = document.getElementById('infoControlsToggle');
+const infoControlsToggleIcon = document.getElementById('infoControlsToggleIcon');
+let userControlsPref = localStorage.getItem('Typing-Practice-controlsCollapsed'); // 'true' | 'false' | null
+let isControlsCollapsed = false;
+let isNarrowMode = false;
+
+function applyControlsState(collapsed) {
+    isControlsCollapsed = collapsed;
+    if (collapsed) {
+        infoControls.classList.add('collapsed');
+        infoControlsToggleIcon.classList.remove('fa-chevron-right');
+        infoControlsToggleIcon.classList.add('fa-chevron-left');
+    } else {
+        infoControls.classList.remove('collapsed');
+        infoControlsToggleIcon.classList.remove('fa-chevron-left');
+        infoControlsToggleIcon.classList.add('fa-chevron-right');
+    }
+    if (isNarrowMode) {
+        infoControls.classList.add('narrow-mode');
+    } else {
+        infoControls.classList.remove('narrow-mode');
+    }
+}
+
+function resolveControlsState() {
+    isNarrowMode = window.innerWidth <= 1080;
+    if (isNarrowMode) {
+        applyControlsState(true);
+    } else if (userControlsPref !== null) {
+        applyControlsState(userControlsPref === 'true');
+    } else {
+        applyControlsState(false);
+    }
+}
+
+resolveControlsState();
+
+infoControlsToggle.addEventListener('click', () => {
+    const next = !isControlsCollapsed;
+    if (!isNarrowMode) {
+        userControlsPref = String(next);
+        localStorage.setItem('Typing-Practice-controlsCollapsed', userControlsPref);
+    }
+    applyControlsState(next);
+});
+
+// overlay 상태에서 외부 클릭 시 닫기
+document.addEventListener('click', (e) => {
+    if (isNarrowMode && !isControlsCollapsed && !infoControls.contains(e.target)) {
+        applyControlsState(true);
+    }
+});
+
+window.addEventListener('resize', resolveControlsState);
 
 // 업데이트 공지 데이터
 const updateHistory = [
@@ -161,139 +196,93 @@ const updateHistory = [
     }
 ];
 
-const CURRENT_VERSION = updateHistory[0].version;
-const updatePopupOverlay = document.getElementById('updatePopupOverlay');
-const updatePopup = document.getElementById('updatePopup');
-const updatePopupTitle = document.getElementById('updatePopupTitle');
-const updateContent = document.getElementById('updateContent');
-const updateHistoryBtn = document.getElementById('updateHistoryBtn');
-
-// 최신 업데이트 렌더링 (첫 진입 시)
-function renderLatestUpdate(update) {
-    const darkClass = isDark() ? ' dark' : '';
-
+// 업데이트 페이지
+function renderUpdateCard(update) {
     let html = `
-            <div class="update-popup-version${darkClass}">v${update.version}</div>
-            <div class="update-popup-date${darkClass}">${update.date}</div>
-        `;
+        <div class="update-card">
+            <div class="update-card-header">
+                <span class="update-card-version">v${update.version}</span>
+                <span class="update-card-date">${update.date}</span>
+            </div>`;
 
     if (update.features && update.features.length > 0) {
         html += `
-                <div class="update-popup-section">
-                    <div class="update-popup-section-title${darkClass}">✨ 새로운 기능</div>
-                    <ul class="update-popup-list">
-                        ${update.features.map(f => `<li class="${darkClass}">${f}</li>`).join('')}
-                    </ul>
-                </div>
-            `;
+            <div class="update-card-section">
+                <div class="update-card-section-title">새로운 기능</div>
+                <ul class="update-card-list">
+                    ${update.features.map(f => `<li>${f}</li>`).join('')}
+                </ul>
+            </div>`;
     }
 
     if (update.improvements && update.improvements.length > 0) {
         html += `
-                <div class="update-popup-section">
-                    <div class="update-popup-section-title${darkClass}">🔧 개선사항</div>
-                    <ul class="update-popup-list">
-                        ${update.improvements.map(i => `<li class="${darkClass}">${i}</li>`).join('')}
-                    </ul>
-                </div>
-            `;
-    }
-
-    return html;
-}
-
-// 히스토리 아이템 렌더링 (아이콘 클릭 시)
-function renderHistoryItem(update) {
-    const darkClass = isDark() ? ' dark' : '';
-
-    let html = `
-            <div class="update-history-item${darkClass}">
-                <div class="update-history-header">
-                    <span class="update-history-version">v${update.version}</span>
-                    <span class="update-history-date${darkClass}">${update.date}</span>
-                </div>
-        `;
-
-    if (update.features && update.features.length > 0) {
-        html += `
-                <div class="update-popup-section">
-                    <div class="update-popup-section-title${darkClass}">✨ 새로운 기능</div>
-                    <ul class="update-popup-list">
-                        ${update.features.map(f => `<li class="${darkClass}">${f}</li>`).join('')}
-                    </ul>
-                </div>
-            `;
-    }
-
-    if (update.improvements && update.improvements.length > 0) {
-        html += `
-                <div class="update-popup-section">
-                    <div class="update-popup-section-title${darkClass}">🔧 개선사항</div>
-                    <ul class="update-popup-list">
-                        ${update.improvements.map(i => `<li class="${darkClass}">${i}</li>`).join('')}
-                    </ul>
-                </div>
-            `;
+            <div class="update-card-section">
+                <div class="update-card-section-title">개선사항</div>
+                <ul class="update-card-list">
+                    ${update.improvements.map(i => `<li>${i}</li>`).join('')}
+                </ul>
+            </div>`;
     }
 
     html += '</div>';
     return html;
 }
 
-// 모든 업데이트 렌더링
-function renderAllUpdates() {
-    let html = '';
-    for (const update of updateHistory) {
-        html += renderHistoryItem(update);
-    }
-    return html;
+function openUpdatesPage() {
+    document.getElementById('updatesPage').classList.remove('display-none');
+    document.body.style.overflow = 'hidden';
+    document.querySelectorAll('.nav-link').forEach(function(l) { l.classList.remove('active'); });
+    document.getElementById('navUpdates').classList.add('active');
+
+    const content = document.getElementById('updatesContent');
+    content.innerHTML = updateHistory.map(u => renderUpdateCard(u)).join('');
 }
 
-// 첫 진입 시 최신 업데이트만 표시
-function openLatestUpdatePopup() {
-    updatePopupOverlay.classList.remove('display-none');
-    updatePopup.classList.remove('history-mode');
-    updatePopupTitle.textContent = '🎉 업데이트 안내';
-    updateContent.innerHTML = renderLatestUpdate(updateHistory[0]);
-    updateHistoryBtn.classList.remove('display-none');
-
-    if (isDark()) {
-        updatePopup.classList.add('dark');
-        updateHistoryBtn.classList.add('dark');
-    }
+function closeUpdatesPage() {
+    document.getElementById('updatesPage').classList.add('display-none');
+    document.body.style.overflow = '';
+    document.querySelectorAll('.nav-link').forEach(function(l) { l.classList.remove('active'); });
+    document.getElementById('navSentence').classList.add('active');
 }
 
-// 아이콘 클릭 시 모든 업데이트 표시
-function openAllUpdatesPopup() {
-    updatePopupOverlay.classList.remove('display-none');
-    updatePopup.classList.add('history-mode');
-    updatePopupTitle.textContent = '📋 업데이트 내역';
-    updateContent.innerHTML = renderAllUpdates();
-    updateHistoryBtn.classList.add('display-none');
+document.getElementById('navUpdates').addEventListener('click', openUpdatesPage);
+document.getElementById('updatesBackBtn').addEventListener('click', closeUpdatesPage);
 
-    if (isDark()) {
-        updatePopup.classList.add('dark');
-    }
-}
+// 첫 진입 시 업데이트 알림 팝업
+const CURRENT_VERSION = updateHistory[0].version;
 
-function closeUpdatePopup() {
-    updatePopupOverlay.classList.add('display-none');
-    localStorage.setItem('Typing-Practice-lastSeenVersion', CURRENT_VERSION);
-}
-
-// 새 버전이면 자동으로 팝업 표시
 function showUpdatePopupIfNew() {
     const lastSeenVersion = localStorage.getItem('Typing-Practice-lastSeenVersion');
     if (lastSeenVersion !== CURRENT_VERSION) {
-        openLatestUpdatePopup();
+        const latest = updateHistory[0];
+        let html = `
+            <div class="update-popup-version">v${latest.version}</div>
+            <div class="update-popup-date">${latest.date}</div>`;
+
+        if (latest.features && latest.features.length > 0) {
+            html += `<div class="update-popup-section">
+                <div class="update-popup-section-title">새로운 기능</div>
+                <ul class="update-popup-list">${latest.features.map(f => `<li>${f}</li>`).join('')}</ul>
+            </div>`;
+        }
+        if (latest.improvements && latest.improvements.length > 0) {
+            html += `<div class="update-popup-section">
+                <div class="update-popup-section-title">개선사항</div>
+                <ul class="update-popup-list">${latest.improvements.map(i => `<li>${i}</li>`).join('')}</ul>
+            </div>`;
+        }
+
+        document.getElementById('updatePopupContent').innerHTML = html;
+        document.getElementById('updatePopupOverlay').classList.remove('display-none');
     }
 }
 
-document.getElementById('updatePopupClose').addEventListener('click', closeUpdatePopup);
-document.getElementById('iconNotice').addEventListener('click', openAllUpdatesPopup);
-updateHistoryBtn.addEventListener('click', openAllUpdatesPopup);
+document.getElementById('updatePopupClose').addEventListener('click', () => {
+    document.getElementById('updatePopupOverlay').classList.add('display-none');
+    localStorage.setItem('Typing-Practice-lastSeenVersion', CURRENT_VERSION);
+});
 
-// 페이지 로드 시 팝업 표시
 showUpdatePopupIfNew();
 
 // ============ 로그인 관련 ============

--- a/tp-react/prototype2.js
+++ b/tp-react/prototype2.js
@@ -300,11 +300,6 @@ document.getElementById('mysentencesBtn').addEventListener('click', () => {
     openMyQuotesPopup();
 });
 
-document.getElementById('statsBtn').addEventListener('click', () => {
-    // 통계 기능은 prototype4-stats.js에서 처리
-    document.getElementById('dropdownMenu').classList.add('display-none');
-});
-
 document.getElementById('settingsBtn').addEventListener('click', () => {
     alert('설정 기능 (준비 중)');
     document.getElementById('dropdownMenu').classList.add('display-none');

--- a/tp-react/prototype4-stats.js
+++ b/tp-react/prototype4-stats.js
@@ -61,12 +61,18 @@ var statsSelectedTypo = null;
 function openStatsPage() {
     document.getElementById('statsPage').classList.remove('display-none');
     document.body.style.overflow = 'hidden';
+    // 네비게이션 활성 상태 업데이트
+    document.querySelectorAll('.nav-link').forEach(function(l) { l.classList.remove('active'); });
+    document.getElementById('navStats').classList.add('active');
     renderStats();
 }
 
 function closeStatsPage() {
     document.getElementById('statsPage').classList.add('display-none');
     document.body.style.overflow = '';
+    // 네비게이션 활성 상태 복원
+    document.querySelectorAll('.nav-link').forEach(function(l) { l.classList.remove('active'); });
+    document.getElementById('navSentence').classList.add('active');
 }
 
 function renderStats() {
@@ -252,8 +258,7 @@ function renderTypoDetail(expected) {
 }
 
 // Events
-document.getElementById('statsBtn').addEventListener('click', function () {
-    document.getElementById('dropdownMenu').classList.add('display-none');
+document.getElementById('navStats').addEventListener('click', function () {
     openStatsPage();
 });
 document.getElementById('statsBackBtn').addEventListener('click', closeStatsPage);

--- a/tp-react/src/App.jsx
+++ b/tp-react/src/App.jsx
@@ -15,6 +15,7 @@ import QuoteUpload from "./pages/QuoteUpload/QuoteUpload";
 import MyQuotes from "./pages/MyQuotes/MyQuotes";
 import MyReports from "./pages/MyReports/MyReports";
 import Stats from "./pages/Stats/Stats";
+import Updates from "./pages/Updates/Updates";
 import PrivacyPolicy from "./pages/PrivacyPolicy/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService/TermsOfService";
 import {Analytics} from "@vercel/analytics/react";
@@ -37,6 +38,7 @@ function App() {
                   <Route path="/quote/my" element={<MyQuotes />} />
                   <Route path="/quote/report" element={<MyReports />} />
                   <Route path="/stats" element={<Stats />} />
+                  <Route path="/updates" element={<Updates />} />
                   <Route path="/privacy" element={<PrivacyPolicy />} />
                   <Route path="/terms" element={<TermsOfService />} />
                   <Route path="*" element={<Navigate to="/" replace />} />

--- a/tp-react/src/App.jsx
+++ b/tp-react/src/App.jsx
@@ -19,7 +19,6 @@ import Updates from "./pages/Updates/Updates";
 import PrivacyPolicy from "./pages/PrivacyPolicy/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService/TermsOfService";
 import {Analytics} from "@vercel/analytics/react";
-import ConsentBanner from "./components/ConsentBanner/ConsentBanner";
 
 function App() {
   return (
@@ -44,7 +43,6 @@ function App() {
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
                 <Contact />
-                <ConsentBanner/>
                 <Analytics/>
               </AppDiv>
               </ScoreContextProvider>

--- a/tp-react/src/Context/QuoteContext.tsx
+++ b/tp-react/src/Context/QuoteContext.tsx
@@ -43,7 +43,7 @@ const QUOTE_SOURCE = {
     MY: 'my' as const,
 };
 
-const generateSeed = () => Math.round((Math.random() * 2 - 1) * 100) / 100;
+const generateSeed = () => Math.round((Math.random() * 2 - 1) * 1000) / 1000;
 
 const shuffleArray = <T, >(array: T[]): T[] => {
     const shuffled = [...array];

--- a/tp-react/src/components/AppDiv/AppDiv.css
+++ b/tp-react/src/components/AppDiv/AppDiv.css
@@ -24,11 +24,11 @@
     overflow-x: hidden;
     overflow-y: auto;
     margin: 0;
-    padding-top: 18vh;
+    padding-top: 20vh;
     background-color: var(--color-bg);
     color: var(--color-text);
 }
 
 .background.compact {
-    padding-top: 2rem;
+    padding-top: 6rem;
 }

--- a/tp-react/src/components/AppDiv/AppDiv.jsx
+++ b/tp-react/src/components/AppDiv/AppDiv.jsx
@@ -7,7 +7,7 @@ const AppDiv = ({ children }) => {
   const location = useLocation();
   
   // 상단 여백이 필요 없는 페이지
-  const isCompactPage = location.pathname.startsWith('/quote/') || location.pathname === '/stats' || location.pathname === '/privacy' || location.pathname === '/terms';
+  const isCompactPage = location.pathname.startsWith('/quote/') || location.pathname === '/stats' || location.pathname === '/updates' || location.pathname === '/privacy' || location.pathname === '/terms';
   
   return (
     <div className={`background ${isDark ? "dark" : ""} ${isCompactPage ? "compact" : ""}`}>

--- a/tp-react/src/components/ConsentBanner/ConsentBanner.css
+++ b/tp-react/src/components/ConsentBanner/ConsentBanner.css
@@ -1,119 +1,120 @@
-.consent-overlay {
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: rgba(0, 0, 0, 0.4);
-    backdrop-filter: blur(4px);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    z-index: 9999;
-}
-
-.consent-banner {
-    background: var(--color-popup-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 1rem;
-    padding: 2rem;
-    width: 90%;
-    max-width: 400px;
-}
-
-.consent-title {
-    font-size: 1.125rem;
-    font-weight: 600;
-    color: var(--color-text);
-    margin: 0 0 0.5rem 0;
-}
-
-.consent-desc {
-    font-size: 0.875rem;
-    line-height: 1.6;
-    color: var(--color-text-muted);
-    margin: 0 0 1.25rem 0;
-}
-
-.consent-details {
-    display: flex;
-    flex-direction: column;
-    gap: 0.875rem;
-    padding: 1rem;
-    margin-bottom: 1.25rem;
+.consent-inline {
+    margin-top: 2.5rem;
+    padding: 1rem 1.25rem;
     background: var(--color-bg-secondary);
     border-radius: 0.5rem;
 }
 
-.consent-detail-item {
+/* login-prompt-wrapper 안에서는 겹침 */
+.login-prompt-wrapper .consent-inline {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    z-index: 1;
+    margin-top: 0;
+}
+
+.consent-inline-main {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.consent-inline-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.consent-inline-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.consent-inline-desc {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+}
+
+.consent-inline-actions {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+}
+
+.consent-inline-btn {
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: all 0.15s;
+}
+
+.consent-inline-accept {
+    border: none;
+    background: var(--color-primary);
+    color: white;
+}
+
+.consent-inline-accept:hover {
+    background: var(--color-primary-dark);
+}
+
+.consent-inline-reject {
+    border: 1px solid var(--color-border);
+    background: var(--color-popup-bg);
+    color: var(--color-text-muted);
+}
+
+.consent-inline-reject:hover {
+    border-color: var(--color-text-placeholder);
+    color: var(--color-text);
+}
+
+.consent-inline-details {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem;
+    margin-top: 1rem;
+    padding: 0.875rem 0 0;
+}
+
+.consent-inline-detail-item {
     display: flex;
     flex-direction: column;
     gap: 0.125rem;
 }
 
-.consent-detail-label {
-    font-size: 0.8125rem;
+.consent-inline-detail-label {
+    font-size: 0.75rem;
     font-weight: 500;
     color: var(--color-primary);
 }
 
-.consent-detail-desc {
-    font-size: 0.75rem;
-    line-height: 1.5;
+.consent-inline-detail-desc {
+    font-size: 0.7rem;
+    line-height: 1.4;
     color: var(--color-text-muted);
 }
 
-.consent-actions {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.consent-btn {
-    width: 100%;
-    padding: 0.625rem;
-    border-radius: 0.5rem;
-    font-size: 0.9375rem;
-    font-weight: 500;
-    cursor: pointer;
-    transition: all 0.15s;
-}
-
-.consent-btn-accept {
-    border: none;
-    background: var(--color-primary);
-    color: var(--color-white);
-}
-
-.consent-btn-accept:hover {
-    background: var(--color-primary-dark);
-}
-
-.consent-btn-reject {
-    border: 1px solid var(--color-border);
-    background: transparent;
-    color: var(--color-text-muted);
-}
-
-.consent-btn-reject:hover {
-    background: var(--color-bg-secondary);
-    color: var(--color-text);
-}
-
-.consent-more-btn {
+.consent-inline-more {
     display: block;
     width: 100%;
-    margin-top: 0.75rem;
+    margin-top: 0.5rem;
     padding: 0;
     border: none;
     background: transparent;
     color: var(--color-text-placeholder);
-    font-size: 0.8125rem;
+    font-size: 0.75rem;
     cursor: pointer;
     text-align: center;
     transition: color 0.15s;
 }
 
-.consent-more-btn:hover {
+.consent-inline-more:hover {
     color: var(--color-text-muted);
 }

--- a/tp-react/src/components/ConsentBanner/ConsentBanner.jsx
+++ b/tp-react/src/components/ConsentBanner/ConsentBanner.jsx
@@ -1,16 +1,33 @@
-import {useState} from 'react';
-import {useTheme} from '../../Context/ThemeContext';
-import {Storage_Anonymous_Id, Storage_Consent} from '@/const/config.const.ts';
+import {useEffect, useState} from 'react';
+import {Storage_Anonymous_Id, Storage_Consent, Session_Typing_Count, CONSENT_BANNER_THRESHOLD} from '@/const/config.const.ts';
+import {t} from '@/utils/i18n.ts';
 import './ConsentBanner.css';
 
 export const hasConsent = () => localStorage.getItem(Storage_Consent);
 
-const isKorean = navigator.language.startsWith('ko');
-
 function ConsentBanner() {
-    const {isDark} = useTheme();
-    const [visible, setVisible] = useState(() => !hasConsent());
+    const [visible, setVisible] = useState(false);
     const [showDetails, setShowDetails] = useState(false);
+
+    useEffect(() => {
+        if (hasConsent()) return;
+
+        // 마운트 시 현재 카운트 확인
+        const currentCount = parseInt(sessionStorage.getItem(Session_Typing_Count) || '0', 10);
+        if (currentCount >= CONSENT_BANNER_THRESHOLD) {
+            setVisible(true);
+            return;
+        }
+
+        const handleTypingCount = (e) => {
+            if (e.detail >= CONSENT_BANNER_THRESHOLD && !hasConsent()) {
+                setVisible(true);
+            }
+        };
+
+        window.addEventListener('typing-count-update', handleTypingCount);
+        return () => window.removeEventListener('typing-count-update', handleTypingCount);
+    }, []);
 
     if (!visible) return null;
 
@@ -28,79 +45,44 @@ function ConsentBanner() {
     };
 
     return (
-        <div className="consent-overlay">
-            <div className={`consent-banner ${isDark ? 'dark' : ''}`}>
-                <p className="consent-title">
-                    {isKorean ? '더 나은 서비스를 위해' : 'Help us improve'}
-                </p>
-                <p className="consent-desc">
-                    {isKorean
-                        ? '서비스 개선을 위해 익명 사용 데이터를 수집합니다. 개인을 식별할 수 없습니다.'
-                        : 'We collect anonymous usage data to improve the service. It cannot identify you personally.'}
-                </p>
-
-                {showDetails && (
-                    <div className="consent-details">
-                        <div className="consent-detail-item">
-                            <span className="consent-detail-label">
-                                {isKorean ? '익명 식별자' : 'Anonymous ID'}
-                            </span>
-                            <span className="consent-detail-desc">
-                                {isKorean
-                                    ? '이름, 이메일 등 개인정보와 연결되지 않습니다.'
-                                    : 'Not linked to any personal information like name or email.'}
-                            </span>
-                        </div>
-                        <div className="consent-detail-item">
-                            <span className="consent-detail-label">
-                                {isKorean ? '기기 유형' : 'Device type'}
-                            </span>
-                            <span className="consent-detail-desc">
-                                {isKorean
-                                    ? '모바일 / 태블릿 / 데스크톱 중 어떤 환경인지 확인합니다.'
-                                    : 'Whether you\'re on mobile, tablet, or desktop.'}
-                            </span>
-                        </div>
-                        <div className="consent-detail-item">
-                            <span className="consent-detail-label">
-                                {isKorean ? '유입 경로' : 'Referrer'}
-                            </span>
-                            <span className="consent-detail-desc">
-                                {isKorean
-                                    ? '어떤 사이트에서 방문했는지 확인합니다.'
-                                    : 'Which site you came from.'}
-                            </span>
-                        </div>
-                        <div className="consent-detail-item">
-                            <span className="consent-detail-label">
-                                {isKorean ? '세션 정보' : 'Session info'}
-                            </span>
-                            <span className="consent-detail-desc">
-                                {isKorean
-                                    ? '한 번의 방문 동안만 유지되며, 탭을 닫으면 자동으로 삭제됩니다.'
-                                    : 'Only kept during your visit. Automatically deleted when you close the tab.'}
-                            </span>
-                        </div>
-                    </div>
-                )}
-
-                <div className="consent-actions">
-                    <button className="consent-btn consent-btn-accept" onClick={handleAccept}>
-                        {isKorean ? '동의' : 'Accept'}
+        <div className="consent-inline">
+            <div className="consent-inline-main">
+                <div className="consent-inline-text">
+                    <span className="consent-inline-title">{t('consentTitle')}</span>
+                    <span className="consent-inline-desc">{t('consentDesc')}</span>
+                </div>
+                <div className="consent-inline-actions">
+                    <button className="consent-inline-btn consent-inline-accept" onClick={handleAccept}>
+                        {t('consentAccept')}
                     </button>
-                    <button className="consent-btn consent-btn-reject" onClick={handleReject}>
-                        {isKorean ? '거절' : 'Reject'}
+                    <button className="consent-inline-btn consent-inline-reject" onClick={handleReject}>
+                        {t('consentReject')}
                     </button>
                 </div>
-                <button
-                    className="consent-more-btn"
-                    onClick={() => setShowDetails(!showDetails)}
-                >
-                    {showDetails
-                        ? (isKorean ? '접기' : 'Less')
-                        : (isKorean ? '자세히 보기' : 'More info')}
-                </button>
             </div>
+            {showDetails && (
+                <div className="consent-inline-details">
+                    <div className="consent-inline-detail-item">
+                        <span className="consent-inline-detail-label">{t('consentAnonymousId')}</span>
+                        <span className="consent-inline-detail-desc">{t('consentAnonymousIdDesc')}</span>
+                    </div>
+                    <div className="consent-inline-detail-item">
+                        <span className="consent-inline-detail-label">{t('consentDeviceType')}</span>
+                        <span className="consent-inline-detail-desc">{t('consentDeviceTypeDesc')}</span>
+                    </div>
+                    <div className="consent-inline-detail-item">
+                        <span className="consent-inline-detail-label">{t('consentReferrer')}</span>
+                        <span className="consent-inline-detail-desc">{t('consentReferrerDesc')}</span>
+                    </div>
+                    <div className="consent-inline-detail-item">
+                        <span className="consent-inline-detail-label">{t('consentSession')}</span>
+                        <span className="consent-inline-detail-desc">{t('consentSessionDesc')}</span>
+                    </div>
+                </div>
+            )}
+            <button className="consent-inline-more" onClick={() => setShowDetails(!showDetails)}>
+                {showDetails ? t('consentLess') : t('consentMore')}
+            </button>
         </div>
     );
 }

--- a/tp-react/src/components/Head/Head.css
+++ b/tp-react/src/components/Head/Head.css
@@ -1,53 +1,66 @@
 .head {
-    width: 80%;
-    max-width: 1100px;
-    min-width: 600px;
-
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    height: 4.5rem;
     display: flex;
     align-items: center;
     justify-content: space-between;
-    margin-bottom: 3rem;
+    padding: 0 2rem;
+    background-color: var(--color-popup-bg);
+    border-bottom: 1px solid var(--color-border);
+    z-index: 100;
 }
 
 .head-left {
     display: flex;
     align-items: center;
-    gap: 1.5rem;
+    gap: 2rem;
 }
 
-.mode-nav {
+.nav-links {
     display: flex;
     align-items: center;
     gap: 0.25rem;
 }
 
-.mode-nav-divider {
-    color: var(--color-text-placeholder);
-    font-size: 0.85rem;
-    user-select: none;
-}
-
-.mode-nav-btn {
-    padding: 0.3rem 0.6rem;
+.nav-link {
+    position: relative;
+    padding: 0 0.75rem;
     border: none;
-    background: transparent;
+    background: none;
     color: var(--color-text-muted);
-    font-size: 0.85rem;
+    font-size: 0.95rem;
     cursor: pointer;
-    border-radius: 0.25rem;
-    transition: all 0.2s;
+    border-radius: 0;
+    height: 4.5rem;
+    display: flex;
+    align-items: center;
 }
 
-.mode-nav-btn:hover {
+.nav-link:hover {
     color: var(--color-text);
+    font-weight: 500;
 }
 
-.mode-nav-btn.mode-nav-active {
+.nav-link.nav-active {
     color: var(--color-primary);
     font-weight: 600;
 }
 
-.mode-nav-beta {
+.nav-link.nav-active::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 0.75rem;
+    right: 0.75rem;
+    height: 3px;
+    background: var(--color-primary);
+    border-radius: 1px;
+}
+
+.nav-beta {
     font-size: 0.55rem;
     font-weight: 600;
     color: var(--color-primary);
@@ -65,23 +78,4 @@
     display: flex;
     align-items: center;
     gap: 1rem;
-}
-
-.header-btn {
-    padding: 0.5rem 1rem;
-    border: none;
-    background-color: transparent;
-    color: var(--color-text-muted);
-    border-radius: 0.375rem;
-    font-size: 0.9rem;
-    cursor: pointer;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-}
-
-.header-btn:hover {
-    background-color: var(--color-bg-secondary);
-    color: var(--color-text);
 }

--- a/tp-react/src/components/Head/Head.jsx
+++ b/tp-react/src/components/Head/Head.jsx
@@ -6,13 +6,10 @@ import LoginButton from "../LoginButton/LoginButton";
 import ProfileDropdown from "../ProfileDropdown/ProfileDropdown";
 import LoadingSpinner from "../LoadingSpinner/LoadingSpinner";
 import NicknamePopup from "../NicknamePopup/NicknamePopup";
-import LoginRequiredPopup from "../LoginRequiredPopup/LoginRequiredPopup";
 import {useAuth} from "../../Context/AuthContext";
-import {useTheme} from "../../Context/ThemeContext";
 import {useError} from "../../Context/ErrorContext";
 import {useGoogleLogin} from "@react-oauth/google";
 import {loginWithGoogle} from "@/utils/authApi.ts";
-import {FaPlus} from "react-icons/fa";
 import {t} from "@/utils/i18n.ts";
 import {Storage_Last_Mode} from "@/const/config.const.ts";
 import FeatureGuide from "../FeatureGuide/FeatureGuide";
@@ -28,11 +25,9 @@ const isUuidFormat = (str) => {
 const Head = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const {isDark} = useTheme();
     const {showError} = useError();
     const {user, accessToken, refreshToken, isLoading, setIsLoading, login, loginTrigger} = useAuth();
     const [showNicknamePopup, setShowNicknamePopup] = useState(false);
-    const [showLoginPopup, setShowLoginPopup] = useState(false);
     const prevLoginTriggerRef = useRef(loginTrigger);
 
     // user가 변경될 때마다 닉네임이 UUID 형식인지 체크
@@ -50,10 +45,8 @@ const Head = () => {
             try {
                 const response = await loginWithGoogle(codeResponse.code);
 
-                // response.data: { newMember, nickname, accessToken, refreshToken }
                 const userData = response.data;
 
-                // 신규/기존 회원 모두 바로 로그인 처리
                 login({
                     nickname: userData.nickname,
                     email: userData.email,
@@ -62,7 +55,6 @@ const Head = () => {
                     isNewMember: userData.newMember,
                 }, userData.accessToken, userData.refreshToken);
 
-                // UUID 형식 닉네임이면 팝업 표시 (useEffect에서도 처리하지만 즉시 표시를 위해)
                 if (isUuidFormat(userData.nickname)) {
                     setShowNicknamePopup(true);
                 }
@@ -93,7 +85,6 @@ const Head = () => {
     };
 
     const handleNicknameSubmit = (newNickname) => {
-        // 닉네임 업데이트 + isNewMember false 처리
         login({
             ...user,
             nickname: newNickname,
@@ -104,56 +95,54 @@ const Head = () => {
 
     return (
         <>
-            <div className="head">
+            <nav className="head">
                 <div className="head-left">
                     <Title/>
-                    <div className="mode-nav">
+                    <div className="nav-links">
                         <button
-                            className={`mode-nav-btn ${location.pathname === '/' ? 'mode-nav-active' : ''} ${isDark ? 'dark' : ''}`}
+                            className={`nav-link ${location.pathname === '/' ? 'nav-active' : ''}`}
                             onClick={() => { localStorage.setItem(Storage_Last_Mode, 'sentence'); navigate('/'); }}
                         >
                             {t('sentenceMode')}
                         </button>
-                        <span className="mode-nav-divider">|</span>
                         <button
-                            className={`mode-nav-btn ${location.pathname === '/word' ? 'mode-nav-active' : ''} ${isDark ? 'dark' : ''}`}
+                            className={`nav-link ${location.pathname === '/word' ? 'nav-active' : ''}`}
                             onClick={() => { localStorage.setItem(Storage_Last_Mode, 'word'); navigate('/word'); }}
                         >
-                            {t('wordMode')}<span className="mode-nav-beta">beta</span>
+                            {t('wordMode')}<span className="nav-beta">beta</span>
+                        </button>
+                        <button
+                            className={`nav-link ${location.pathname === '/stats' ? 'nav-active' : ''}`}
+                            onClick={() => {
+                                if (user) {
+                                    navigate('/stats');
+                                } else {
+                                    googleLogin();
+                                }
+                            }}
+                        >
+                            {t('records')}
+                        </button>
+                        <button
+                            className={`nav-link ${location.pathname === '/updates' ? 'nav-active' : ''}`}
+                            onClick={() => navigate('/updates')}
+                        >
+                            {t('updateHistory')}
                         </button>
                     </div>
                 </div>
                 <div className="head-right">
-                    <button
-                        className={`header-btn ${isDark ? 'dark' : ''}`}
-                        onClick={() => {
-                            if (user) {
-                                navigate('/quote/upload');
-                            } else {
-                                setShowLoginPopup(true);
-                            }
-                        }}
-                    >
-                        <FaPlus/>
-                        <span>{t('uploadSentence')}</span>
-                    </button>
                     {user ? <ProfileDropdown/> : <LoginButton onClick={handleLogin}/>}
                     <DarkModeButton/>
                     {!user && <FeatureGuide/>}
                 </div>
-            </div>
+            </nav>
 
             {isLoading && <LoadingSpinner/>}
             {showNicknamePopup && (
                 <NicknamePopup
                     initialNickname={user?.nickname}
                     onSubmit={handleNicknameSubmit}
-                />
-            )}
-            {showLoginPopup && (
-                <LoginRequiredPopup
-                    message={t('uploadLoginRequired')}
-                    onClose={() => setShowLoginPopup(false)}
                 />
             )}
         </>

--- a/tp-react/src/components/Head/themeButton/ThemeButton.css
+++ b/tp-react/src/components/Head/themeButton/ThemeButton.css
@@ -17,7 +17,7 @@
 }
 
 .theme-icon {
-    font-size: 1rem;
+    font-size: 1.25rem;
     background: none;
 }
 

--- a/tp-react/src/components/Head/title/Title.css
+++ b/tp-react/src/components/Head/title/Title.css
@@ -1,7 +1,8 @@
 .title {
-    font-size: 2rem;
+    font-size: 1.75rem;
     color: var(--color-text);
     font-weight: 600;
-    letter-spacing: -0.5px;
     cursor: pointer;
+    white-space: nowrap;
+    margin: 0;
 }

--- a/tp-react/src/components/LoginButton/LoginButton.css
+++ b/tp-react/src/components/LoginButton/LoginButton.css
@@ -7,7 +7,7 @@
     border-radius: 0.375rem;
     background-color: transparent;
     color: var(--color-text-muted);
-    font-size: 0.85rem;
+    font-size: 0.9rem;
     font-weight: 500;
     cursor: pointer;
     transition: all 0.15s;

--- a/tp-react/src/components/ProfileDropdown/ProfileDropdown.jsx
+++ b/tp-react/src/components/ProfileDropdown/ProfileDropdown.jsx
@@ -4,7 +4,7 @@ import {useTheme} from '../../Context/ThemeContext';
 import {useAuth} from '../../Context/AuthContext';
 import {logout as logoutApi} from '../../utils/authApi';
 import ProfilePopup from '../ProfilePopup/ProfilePopup';
-import {FaChartBar, FaChevronDown, FaCog, FaFileAlt, FaFlag, FaSignOutAlt, FaUser} from 'react-icons/fa';
+import {FaChevronDown, FaCog, FaFileAlt, FaFlag, FaSignOutAlt, FaUser} from 'react-icons/fa';
 import {t} from '@/utils/i18n.ts';
 import './ProfileDropdown.css';
 
@@ -51,9 +51,6 @@ const ProfileDropdown = () => {
             case 'my-reports':
                 navigate('/quote/report');
                 break;
-            case 'stats':
-                navigate('/stats');
-                break;
             case 'settings':
                 setShowProfilePopup(true);
                 break;
@@ -92,13 +89,6 @@ const ProfileDropdown = () => {
                         >
                             <FaFileAlt/>
                             <span>{t('mySentences')}</span>
-                        </button>
-                        <button
-                            className={`dropdown-item ${isDark ? 'dark' : ''}`}
-                            onClick={() => handleMenuClick('stats')}
-                        >
-                            <FaChartBar/>
-                            <span>{t('records')}</span>
                         </button>
                         <button
                             className={`dropdown-item ${isDark ? 'dark' : ''}`}

--- a/tp-react/src/const/config.const.ts
+++ b/tp-react/src/const/config.const.ts
@@ -9,6 +9,7 @@ export const Storage_Last_Seen_Version = "Typing-Practice-lastSeenVersion" as co
 export const Storage_Refresh_Token = "Typing-Practice-refreshToken" as const;
 export const Storage_Consent = "Typing-Practice-storageConsent" as const;
 export const Storage_Feature_Guide = "Typing-Practice-featureGuide" as const;
+export const Storage_Controls_Collapsed = "Typing-Practice-controlsCollapsed" as const;
 export const Storage_Anonymous_Id = "Typing-Practice-anonymousId" as const;
 export const Storage_Session_Id = "Typing-Practice-sessionId" as const;
 

--- a/tp-react/src/const/config.const.ts
+++ b/tp-react/src/const/config.const.ts
@@ -23,5 +23,11 @@ export const Storage_Word_Difficulty = "Typing-Practice-wordDifficulty" as const
 export const Storage_Word_Count = "Typing-Practice-wordCount" as const;
 export const Storage_Last_Mode = "Typing-Practice-lastMode" as const;
 
+// 로그인 유도
+export const Session_Typing_Count = "Typing-Practice-sessionTypingCount" as const;
+export const LOGIN_PROMPT_THRESHOLD = 3 as const;
+export const CONSENT_BANNER_THRESHOLD = 3 as const;
+export const Session_Login_Prompt_Dismissed = "Typing-Practice-loginPromptDismissed" as const;
+
 // Typing Record 관련 상수
 export const RESET_COUNT_THRESHOLD_RATIO = 0.3 as const;

--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -37,7 +37,7 @@ export const updateHistory: UpdateEntry[] = [
         features: [
             {ko: "단어 모드 추가 (beta)", en: "Word mode added (beta)"},
             {ko: "난이도 선택 (Random, Easy, Normal, Hard)", en: "Difficulty selection (Random, Easy, Normal, Hard)"},
-            {ko: "단어 수 선택 (10, 25, 50)", en: "Word count selection (10, 25, 50)"},
+            {ko: "단어 수 선택 (15, 25, 50)", en: "Word count selection (10, 25, 50)"},
             {ko: "문장/단어 모드 전환 기능 추가", en: "Sentence/Word mode switch"},
         ],
         improvements: [

--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -30,6 +30,26 @@ export function localize(item: LocalizedText): string {
 
 export const updateHistory: UpdateEntry[] = [
     {
+        version: "1.4.0",
+        date: "2026-04-06",
+        showPopup: true,
+        hidden: false,
+        features: [
+            {ko: "상단 네비게이션 바 디자인 변경", en: "Redesigned top navigation bar"},
+            {ko: "업데이트 내역 페이지 추가", en: "Added update history page"},
+            {ko: "타이핑 속도/정확도 표시 및 설정 영역 디자인 변경", en: "Redesigned typing stats and settings area"},
+            {
+                ko: "단어 연습에 실시간 WPM, 난이도, 단어수, 폰트 크기 설정 추가",
+                en: "Added real-time WPM, difficulty, word count, font size settings to word mode"
+            },
+            {ko: "문장 소스 선택 탭 디자인 변경", en: "Redesigned sentence source selector tabs"},
+        ],
+        improvements: [
+            {ko: "다크모드 배경 및 보라색(primary) 색상 개선", en: "Improved dark mode background and primary colors"},
+            {ko: "좁은 화면에서 컨트롤 영역 자동 접기/오버레이 지원", en: "Auto-collapse controls on narrow screens with overlay support"},
+        ]
+    },
+    {
         version: "1.3.0",
         date: "2026-04-06",
         showPopup: true,
@@ -37,7 +57,7 @@ export const updateHistory: UpdateEntry[] = [
         features: [
             {ko: "단어 모드 추가 (beta)", en: "Word mode added (beta)"},
             {ko: "난이도 선택 (Random, Easy, Normal, Hard)", en: "Difficulty selection (Random, Easy, Normal, Hard)"},
-            {ko: "단어 수 선택 (15, 25, 50)", en: "Word count selection (10, 25, 50)"},
+            {ko: "단어 수 선택 (15, 25, 50)", en: "Word count selection (15, 25, 50)"},
             {ko: "문장/단어 모드 전환 기능 추가", en: "Sentence/Word mode switch"},
         ],
         improvements: [

--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -1,5 +1,6 @@
 interface LocalizedText {
     ko: string;
+    ja: string;
     en: string;
 }
 
@@ -13,19 +14,24 @@ interface UpdateEntry {
     improvements?: LocalizedText[];
 }
 
-const isKorean = navigator.language.startsWith('ko');
+const lang = navigator.language.startsWith('ko') ? 'ko' : navigator.language.startsWith('ja') ? 'ja' : 'en';
 
 export function formatUpdateDate(isoDate: string): string {
     const [year, month, day] = isoDate.split('-').map(Number);
-    if (isKorean) {
+    if (lang === 'ko') {
         return `${year}년 ${month}월 ${day}일`;
+    }
+    if (lang === 'ja') {
+        return `${year}年${month}月${day}日`;
     }
     const months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
     return `${months[month - 1]} ${day}, ${year}`;
 }
 
 export function localize(item: LocalizedText): string {
-    return isKorean ? item.ko : item.en;
+    if (lang === 'ko') return item.ko;
+    if (lang === 'ja') return item.ja;
+    return item.en;
 }
 
 export const updateHistory: UpdateEntry[] = [
@@ -35,18 +41,15 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: true,
         hidden: false,
         features: [
-            {ko: "상단 네비게이션 바 디자인 변경", en: "Redesigned top navigation bar"},
-            {ko: "업데이트 내역 페이지 추가", en: "Added update history page"},
-            {ko: "타이핑 속도/정확도 표시 및 설정 영역 디자인 변경", en: "Redesigned typing stats and settings area"},
-            {
-                ko: "단어 연습에 실시간 WPM, 난이도, 단어수, 폰트 크기 설정 추가",
-                en: "Added real-time WPM, difficulty, word count, font size settings to word mode"
-            },
-            {ko: "문장 소스 선택 탭 디자인 변경", en: "Redesigned sentence source selector tabs"},
+            {ko: "상단 네비게이션 바 디자인 변경", ja: "上部ナビゲーションバーのデザイン変更", en: "Redesigned top navigation bar"},
+            {ko: "업데이트 내역 페이지 추가", ja: "アップデート履歴ページ追加", en: "Added update history page"},
+            {ko: "타이핑 속도/정확도 표시 및 설정 영역 디자인 변경", ja: "タイピング速度・正確度表示と設定エリアのデザイン変更", en: "Redesigned typing stats and settings area"},
+            {ko: "단어 연습에 실시간 WPM, 난이도, 단어수, 폰트 크기 설정 추가", ja: "単語練習にリアルタイムWPM・難易度・単語数・フォントサイズ設定を追加", en: "Added real-time WPM, difficulty, word count, font size settings to word mode"},
+            {ko: "문장 소스 선택 탭 디자인 변경", ja: "文章ソース選択タブのデザイン変更", en: "Redesigned sentence source selector tabs"},
         ],
         improvements: [
-            {ko: "다크모드 배경 및 보라색(primary) 색상 개선", en: "Improved dark mode background and primary colors"},
-            {ko: "좁은 화면에서 컨트롤 영역 자동 접기/오버레이 지원", en: "Auto-collapse controls on narrow screens with overlay support"},
+            {ko: "다크모드 배경 및 보라색(primary) 색상 개선", ja: "ダークモードの背景とプライマリカラーの改善", en: "Improved dark mode background and primary colors"},
+            {ko: "좁은 화면에서 컨트롤 영역 자동 접기/오버레이 지원", ja: "狭い画面でコントロールエリアの自動折りたたみ・オーバーレイ対応", en: "Auto-collapse controls on narrow screens with overlay support"},
         ]
     },
     {
@@ -55,13 +58,13 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: true,
         hidden: false,
         features: [
-            {ko: "단어 모드 추가 (beta)", en: "Word mode added (beta)"},
-            {ko: "난이도 선택 (Random, Easy, Normal, Hard)", en: "Difficulty selection (Random, Easy, Normal, Hard)"},
-            {ko: "단어 수 선택 (15, 25, 50)", en: "Word count selection (15, 25, 50)"},
-            {ko: "문장/단어 모드 전환 기능 추가", en: "Sentence/Word mode switch"},
+            {ko: "단어 모드 추가 (beta)", ja: "単語モード追加（beta）", en: "Word mode added (beta)"},
+            {ko: "난이도 선택 (Random, Easy, Normal, Hard)", ja: "難易度選択（Random, Easy, Normal, Hard）", en: "Difficulty selection (Random, Easy, Normal, Hard)"},
+            {ko: "단어 수 선택 (15, 25, 50)", ja: "単語数選択（15, 25, 50）", en: "Word count selection (15, 25, 50)"},
+            {ko: "문장/단어 모드 전환 기능 추가", ja: "文章・単語モード切り替え機能追加", en: "Sentence/Word mode switch"},
         ],
         improvements: [
-            {ko: "마지막 사용 모드 자동 기억", en: "Auto-remember last used mode"},
+            {ko: "마지막 사용 모드 자동 기억", ja: "最後に使用したモードを自動記憶", en: "Auto-remember last used mode"},
         ]
     },
     {
@@ -70,18 +73,9 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: false,
         hidden: true,
         notices: [
-            {
-                ko: "4월 2일 00:48 ~ 15:00 사이에 서버 문제로 타이핑 기록이 저장되지 않았습니다.",
-                en: "Due to a server issue, typing records were not saved between Apr 2, 00:48 – 15:00 KST."
-            },
-            {
-                ko: "해당 시간대의 기록은 복구가 불가능합니다.",
-                en: "Records from that period cannot be recovered."
-            },
-            {
-                ko: "불편을 드려 죄송합니다. 현재는 정상 동작 중입니다.",
-                en: "We apologize for the inconvenience. The service is now operating normally."
-            }
+            {ko: "4월 2일 00:48 ~ 15:00 사이에 서버 문제로 타이핑 기록이 저장되지 않았습니다.", ja: "4月2日 00:48〜15:00の間、サーバーの問題によりタイピング記録が保存されませんでした。", en: "Due to a server issue, typing records were not saved between Apr 2, 00:48 – 15:00 KST."},
+            {ko: "해당 시간대의 기록은 복구가 불가능합니다.", ja: "該当時間帯の記録は復旧できません。", en: "Records from that period cannot be recovered."},
+            {ko: "불편을 드려 죄송합니다. 현재는 정상 동작 중입니다.", ja: "ご不便をおかけして申し訳ございません。現在は正常に動作しています。", en: "We apologize for the inconvenience. The service is now operating normally."}
         ]
     },
     {
@@ -90,16 +84,16 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: true,
         hidden: false,
         features: [
-            {ko: "문장 업로드 기능 추가", en: "Upload your own sentences"},
-            {ko: "내 문장 관리 페이지 추가 (수정, 삭제, 공개전환)", en: "My sentences page (edit, delete, toggle visibility)"},
-            {ko: "전체 문장 / 내 문장 전환 기능 추가", en: "Switch between all sentences and my sentences"},
-            {ko: "문장 신고 기능 및 신고 내역 페이지 추가", en: "Report sentences and view report history"},
-            {ko: "타이핑 기록 페이지 추가 (종합 통계, 일별 추이, 오타 분석)", en: "Typing stats page (summary, daily trends, typo analysis)"},
-            {ko: "타이핑 연습 완료 시 기록 자동 저장", en: "Auto-save typing records on completion"},
+            {ko: "문장 업로드 기능 추가", ja: "文章アップロード機能追加", en: "Upload your own sentences"},
+            {ko: "내 문장 관리 페이지 추가 (수정, 삭제, 공개전환)", ja: "マイ文章管理ページ追加（編集・削除・公開切替）", en: "My sentences page (edit, delete, toggle visibility)"},
+            {ko: "전체 문장 / 내 문장 전환 기능 추가", ja: "すべての文章・マイ文章の切り替え機能追加", en: "Switch between all sentences and my sentences"},
+            {ko: "문장 신고 기능 및 신고 내역 페이지 추가", ja: "文章の報告機能と報告履歴ページ追加", en: "Report sentences and view report history"},
+            {ko: "타이핑 기록 페이지 추가 (종합 통계, 일별 추이, 오타 분석)", ja: "タイピング記録ページ追加（総合統計・日別推移・誤字分析）", en: "Typing stats page (summary, daily trends, typo analysis)"},
+            {ko: "타이핑 연습 완료 시 기록 자동 저장", ja: "タイピング練習完了時に記録を自動保存", en: "Auto-save typing records on completion"},
         ],
         improvements: [
-            {ko: "타이핑 채점 색상 표시 방식 개선", en: "Improved typing grading color display"},
-            {ko: "결과 표시 주기 선택 버그 수정", en: "Fixed result display interval selection bug"},
+            {ko: "타이핑 채점 색상 표시 방식 개선", ja: "タイピング採点の色表示方法を改善", en: "Improved typing grading color display"},
+            {ko: "결과 표시 주기 선택 버그 수정", ja: "結果表示間隔の選択バグを修正", en: "Fixed result display interval selection bug"},
         ]
     },
     {
@@ -108,7 +102,7 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: true,
         hidden: false,
         improvements: [
-            {ko: "일반 모드에서 입력 시 예문이 변경되지 않고 원본 유지되도록 개선", en: "Fixed sentence changing during input in normal mode"}
+            {ko: "일반 모드에서 입력 시 예문이 변경되지 않고 원본 유지되도록 개선", ja: "通常モードで入力中に例文が変わらず原文を維持するよう改善", en: "Fixed sentence changing during input in normal mode"}
         ]
     },
     {
@@ -117,10 +111,7 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: false,
         hidden: false,
         improvements: [
-            {
-                ko: "브라우저 높이가 낮을 때 예문과 Contact가 겹치는 문제 수정",
-                en: "Fixed sentence and contact section overlap on short browser windows"
-            }
+            {ko: "브라우저 높이가 낮을 때 예문과 Contact가 겹치는 문제 수정", ja: "ブラウザの高さが低い時に例文とContactが重なる問題を修正", en: "Fixed sentence and contact section overlap on short browser windows"}
         ]
     },
     {
@@ -129,14 +120,14 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: true,
         hidden: false,
         features: [
-            {ko: "평균점수 영역 접기/펼치기 기능 추가", en: "Collapsible average score section"},
-            {ko: "Default/Compact 모드 전환 기능 추가", en: "Default/Compact mode toggle"},
-            {ko: "업데이트 알림 팝업 추가", en: "Update notification popup"},
-            {ko: "업데이트 내역 보기 기능 추가 (우측 상단)", en: "Update history viewer (top right)"}
+            {ko: "평균점수 영역 접기/펼치기 기능 추가", ja: "平均スコアエリアの折りたたみ・展開機能追加", en: "Collapsible average score section"},
+            {ko: "Default/Compact 모드 전환 기능 추가", ja: "Default/Compactモード切り替え機能追加", en: "Default/Compact mode toggle"},
+            {ko: "업데이트 알림 팝업 추가", ja: "アップデート通知ポップアップ追加", en: "Update notification popup"},
+            {ko: "업데이트 내역 보기 기능 추가 (우측 상단)", ja: "アップデート履歴表示機能追加（右上）", en: "Update history viewer (top right)"}
         ],
         improvements: [
-            {ko: "문장 셔플 알고리즘 개선", en: "Improved sentence shuffle algorithm"},
-            {ko: "예문 101개 추가 (총 1,138개)", en: "Added 101 sentences (1,138 total)"}
+            {ko: "문장 셔플 알고리즘 개선", ja: "文章シャッフルアルゴリズム改善", en: "Improved sentence shuffle algorithm"},
+            {ko: "예문 101개 추가 (총 1,138개)", ja: "例文101個追加（合計1,138個）", en: "Added 101 sentences (1,138 total)"}
         ]
     },
     {
@@ -145,12 +136,12 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: true,
         hidden: false,
         features: [
-            {ko: "새로운 디자인 적용", en: "New design"},
-            {ko: "폰트 크기 조절 기능 추가", en: "Font size adjustment"},
-            {ko: "예문과 입력 영역 통합", en: "Unified sentence and input area"}
+            {ko: "새로운 디자인 적용", ja: "新しいデザインを適用", en: "New design"},
+            {ko: "폰트 크기 조절 기능 추가", ja: "フォントサイズ調整機能追加", en: "Font size adjustment"},
+            {ko: "예문과 입력 영역 통합", ja: "例文と入力エリアを統合", en: "Unified sentence and input area"}
         ],
         improvements: [
-            {ko: "타이핑 중인 글자까지 실시간 채점", en: "Real-time grading while typing"}
+            {ko: "타이핑 중인 글자까지 실시간 채점", ja: "タイピング中の文字までリアルタイム採点", en: "Real-time grading while typing"}
         ]
     }
 ];

--- a/tp-react/src/index.css
+++ b/tp-react/src/index.css
@@ -70,26 +70,26 @@
 /* Dark Mode */
 .dark {
     /* Primary (Purple) */
-    --color-primary: #6d28d9;
-    --color-primary-dark: #5b21b6;
-    --color-primary-light: #8b5cf6;
+    --color-primary: #8b5cf6;
+    --color-primary-dark: #7c3aed;
+    --color-primary-light: #a78bfa;
     --color-primary-bg: rgba(139, 92, 246, 0.15);
     --color-primary-bg-dark: rgba(139, 92, 246, 0.1);
 
     /* Text */
     --color-text: #e5e7eb;
     --color-text-muted: #a1a1aa;
-    --color-text-placeholder: #71717a;
+    --color-text-placeholder: #9ca3af;
 
     /* Background */
-    --color-bg: #0f0f0f;
-    --color-bg-secondary: #18181b;
-    --color-bg-tertiary: #27272a;
-    --color-popup-bg: #1f1f1f;
+    --color-bg: #1a1a1e;
+    --color-bg-secondary: #222228;
+    --color-bg-tertiary: #26262c;
+    --color-popup-bg: #28282e;
 
     /* Border & Toggle */
-    --color-border: #3f3f46;
-    --color-toggle-bg: #3f3f46;
+    --color-border: #3e3e46;
+    --color-toggle-bg: #3e3e46;
 
     /* Semantic */
     --color-error: #f87171;
@@ -222,8 +222,8 @@ code {
 
 /* Error Popup - Dark Mode */
 .error-popup-overlay.dark .error-popup {
-    background-color: #0f0f0f;
-    border-color: #27272a;
+    background-color: #1a1a1e;
+    border-color: #3e3e46;
 }
 
 .error-popup-overlay.dark .error-popup-icon {

--- a/tp-react/src/pages/Home/Home.jsx
+++ b/tp-react/src/pages/Home/Home.jsx
@@ -1,7 +1,5 @@
 import {useEffect} from 'react';
 import {useNavigate} from 'react-router-dom';
-import FontSizeSlider from './components/FontSizeSlider/FontSizeSlider';
-import ModeToggle from './components/ModeToggle/ModeToggle';
 import UpdatePopup from './components/UpdatePopup/UpdatePopup';
 import AverageScorePopUp from './components/AverageScorePopUp/AverageScorePopUp';
 import Info from './components/Info/Info';
@@ -24,10 +22,6 @@ function Home() {
 
     return (
         <SettingContextProvider>
-            <div className="top-left-controls">
-                <FontSizeSlider/>
-                <ModeToggle/>
-            </div>
             <UpdatePopup/>
             <AverageScorePopUp/>
             <Info/>

--- a/tp-react/src/pages/Home/components/FontSizeSlider/FontSizeSlider.css
+++ b/tp-react/src/pages/Home/components/FontSizeSlider/FontSizeSlider.css
@@ -1,46 +1,47 @@
 .font-size-slider-container {
     display: flex;
-    flex-direction: column;
+    align-items: center;
     gap: 0.5rem;
 }
 
-.font-size-label {
-    font-size: 0.75rem;
+.info-tt-label {
+    font-size: 1.125rem;
+    font-weight: 400;
     color: var(--color-text-placeholder);
     cursor: pointer;
-    transition: color 0.2s;
     user-select: none;
+    line-height: 1;
 }
 
-.font-size-label:hover {
-    color: var(--color-text-muted);
-}
-
-.font-size-slider {
-    width: 100px;
+.info-slider {
+    width: 110px;
     height: 4px;
     -webkit-appearance: none;
     appearance: none;
-    background: var(--color-toggle-bg);
+    background: var(--color-bg-tertiary);
     outline: none;
     border-radius: 2px;
+    cursor: pointer;
 }
 
-.font-size-slider::-webkit-slider-thumb {
+.info-slider::-webkit-slider-thumb {
     -webkit-appearance: none;
     appearance: none;
-    width: 16px;
-    height: 16px;
-    background: var(--color-primary);
-    cursor: pointer;
-    border-radius: 50%;
-}
-
-.font-size-slider::-moz-range-thumb {
-    width: 16px;
-    height: 16px;
+    width: 14px;
+    height: 14px;
     background: var(--color-primary);
     cursor: pointer;
     border-radius: 50%;
     border: none;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
+}
+
+.info-slider::-moz-range-thumb {
+    width: 14px;
+    height: 14px;
+    background: var(--color-primary);
+    cursor: pointer;
+    border-radius: 50%;
+    border: none;
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.2);
 }

--- a/tp-react/src/pages/Home/components/FontSizeSlider/FontSizeSlider.jsx
+++ b/tp-react/src/pages/Home/components/FontSizeSlider/FontSizeSlider.jsx
@@ -46,13 +46,13 @@ const FontSizeSlider = () => {
 
     return (
         <div className="font-size-slider-container">
-            <label
-                className="font-size-label"
+            <span
+                className="info-tt-label"
                 onClick={handleReset}
                 title="Click to reset"
             >
-                Font Size
-            </label>
+                Tt
+            </span>
             <input
                 type="range"
                 min="0"
@@ -60,7 +60,7 @@ const FontSizeSlider = () => {
                 step="1"
                 value={fontSizeToSlider(fontSize)}
                 onChange={handleChange}
-                className="font-size-slider"
+                className="info-slider"
             />
         </div>
     );

--- a/tp-react/src/pages/Home/components/Info/Info.jsx
+++ b/tp-react/src/pages/Home/components/Info/Info.jsx
@@ -1,58 +1,111 @@
-import {useState} from "react";
+import {useState, useEffect, useRef} from "react";
 import "./Info.css";
 import ResultPeriod from "./ResultPeriod/ResultPeriod";
-import CurrentLastCpm from "./Cpms/CurrentLastCpm";
-import HighestCpm from "./Cpms/HighestCpm";
-import AverageScore from "./AverageScores/AverageScore";
-//import {Storage_Averages_Visible} from "../../const/config.const";
-import {FaChevronDown, FaChevronUp} from "react-icons/fa6";
-import {useTheme} from "@/Context/ThemeContext.tsx";
+import FontSizeSlider from "../FontSizeSlider/FontSizeSlider";
+import ModeToggle from "../ModeToggle/ModeToggle";
+import {FaChevronLeft, FaChevronRight} from "react-icons/fa6";
 import {useScore} from "@/Context/ScoreContext.tsx";
-import {Storage_Averages_Visible} from "@/const/config.const.ts";
+import {useSetting} from "@/Context/SettingContext.tsx";
+import {Storage_Controls_Collapsed, Storage_Display_Cpm} from "@/const/config.const.ts";
 
 const Info = () => {
-    const {isDark} = useTheme();
-    const {totalScore} = useScore();
+    const {currentCpm, lastCpm, totalScore} = useScore();
+    const {displayCurrentCpm, setDisplayCurrentCpm} = useSetting();
 
-    const [averagesVisible, setAveragesVisible] = useState(() => {
-        return localStorage.getItem(Storage_Averages_Visible) !== "false";
-    });
+    const [isCollapsed, setIsCollapsed] = useState(false);
+    const [isNarrowMode, setIsNarrowMode] = useState(false);
+    const userPrefRef = useRef(localStorage.getItem(Storage_Controls_Collapsed));
+    const infoRowRef = useRef(null);
 
-    const toggleAverages = () => {
-        const newValue = !averagesVisible;
-        setAveragesVisible(newValue);
-        localStorage.setItem(Storage_Averages_Visible, newValue);
+    const cpmValue = displayCurrentCpm ? currentCpm : lastCpm;
+    const cpmLabel = displayCurrentCpm ? "CURRENT CPM" : "LAST CPM";
+    const accValue = totalScore.cnt === 0 ? "-" : Math.round(totalScore.accs / totalScore.cnt);
+    const cntValue = totalScore.cnt === 0 ? "-" : totalScore.cnt;
+
+    const handleCpmToggle = () => {
+        const next = !displayCurrentCpm;
+        setDisplayCurrentCpm(next);
+        localStorage.setItem(Storage_Display_Cpm, String(next));
     };
 
-    const getAveragesClassName = () => {
-        let className = "info-averages";
-        if (isDark) className += " dark";
-        if (!averagesVisible) className += " collapsed";
-        return className;
+    const controlsRef = useRef(null);
+
+    useEffect(() => {
+        const resolveState = () => {
+            const narrow = window.innerWidth <= 1080;
+            if (narrow) {
+                setIsCollapsed(true);
+                setIsNarrowMode(true);
+            } else if (userPrefRef.current !== null) {
+                setIsCollapsed(userPrefRef.current === "true");
+                setIsNarrowMode(false);
+            } else {
+                setIsCollapsed(false);
+                setIsNarrowMode(false);
+            }
+        };
+        resolveState();
+        window.addEventListener("resize", resolveState);
+        return () => window.removeEventListener("resize", resolveState);
+    }, []);
+
+    // narrow 모드에서 외부 클릭 시 닫기
+    useEffect(() => {
+        const handleClickOutside = (e) => {
+            if (isNarrowMode && !isCollapsed && controlsRef.current && !controlsRef.current.contains(e.target)) {
+                setIsCollapsed(true);
+            }
+        };
+        document.addEventListener("click", handleClickOutside);
+        return () => document.removeEventListener("click", handleClickOutside);
+    }, [isNarrowMode, isCollapsed]);
+
+    const handleToggle = (e) => {
+        e.stopPropagation();
+        const next = !isCollapsed;
+        if (!isNarrowMode) {
+            userPrefRef.current = String(next);
+            localStorage.setItem(Storage_Controls_Collapsed, String(next));
+        }
+        setIsCollapsed(next);
     };
+
+    const controlsClass = `info-controls${isCollapsed ? " collapsed" : ""}${isNarrowMode ? " narrow-mode" : ""}`;
 
     return (
-        <div className={isDark ? "info-background info-dark" : "info-background"}>
-            <div className={isDark ? "info-settings dark" : "info-settings"}>
-                <ResultPeriod/>
-            </div>
-            <div className={isDark ? "info-CPMs dark" : "info-CPMs"}>
-                <CurrentLastCpm/>
-                <HighestCpm/>
-            </div>
-            <div className={getAveragesClassName()}>
-                {Object.keys(totalScore).map(
-                    (value, index) =>
-                        value !== "highestCpm" && <AverageScore type={value} key={index}/>,
-                )}
-            </div>
-            <div className="averages-toggle-container">
-                <button
-                    className={isDark ? "averages-toggle-btn dark" : "averages-toggle-btn"}
-                    onClick={toggleAverages}
-                >
-                    {averagesVisible ? <FaChevronUp/> : <FaChevronDown/>}
-                </button>
+        <div className="info-background">
+            <div className="info-row" ref={infoRowRef}>
+                <div className="info-stats">
+                    <div className="info-stat info-stat-clickable" onClick={handleCpmToggle} title="Click to toggle Current/Last CPM">
+                        <span className="info-stat-label">{cpmLabel}</span>
+                        <span className="info-stat-value current">{cpmValue}</span>
+                    </div>
+                    <div className="info-stat">
+                        <span className="info-stat-label">HIGHEST CPM</span>
+                        <span className="info-stat-value">{totalScore.highestCpm}</span>
+                    </div>
+                    <div className="info-stat-sep"/>
+                    <div className="info-stat">
+                        <span className="info-stat-label">ACC</span>
+                        <span className="info-stat-value">{accValue}</span>
+                    </div>
+                    <div className="info-stat">
+                        <span className="info-stat-label">CNT</span>
+                        <span className="info-stat-value">{cntValue}</span>
+                    </div>
+                </div>
+                <div className={controlsClass} ref={controlsRef}>
+                    <div className="info-controls-inner">
+                        <FontSizeSlider/>
+                        <div className="info-control-sep"/>
+                        <ResultPeriod/>
+                        <div className="info-control-sep"/>
+                        <ModeToggle/>
+                    </div>
+                    <button className="info-controls-toggle" onClick={handleToggle}>
+                        {isCollapsed ? <FaChevronLeft/> : <FaChevronRight/>}
+                    </button>
+                </div>
             </div>
         </div>
     );

--- a/tp-react/src/pages/Home/components/Info/ResultPeriod/ResultPeriod.css
+++ b/tp-react/src/pages/Home/components/Info/ResultPeriod/ResultPeriod.css
@@ -1,31 +1,29 @@
 .result-period-container{
     display: flex;
-    justify-content: space-between;
     align-items: center;
-    gap: 0.15rem;
+    gap: 0.375rem;
 }
+
 .result-period-button {
     border: none;
     background: none;
     display: flex;
-    justify-content: center;
     align-items: center;
-    color: var(--color-text-muted);
-    padding: 0.25rem;
+    color: var(--color-text-placeholder);
+    padding: 0.125rem;
     cursor: pointer;
-    transition: color 0.2s;
+    font-size: 0.5rem;
+    transition: color 0.15s;
 }
 
 .result-period-button:hover {
-    color: var(--color-text);
+    color: var(--color-primary);
 }
 
 .result-period-text {
-    padding-left: 0.5rem;
-    padding-right: 0.5rem;
     color: var(--color-text);
-    font-size: 1.3rem;
-    min-width: 4rem;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    min-width: 2ch;
     text-align: center;
-    display: inline-block;
 }

--- a/tp-react/src/pages/Home/components/ModeToggle/ModeToggle.css
+++ b/tp-react/src/pages/Home/components/ModeToggle/ModeToggle.css
@@ -6,8 +6,10 @@
 
 .mode-toggle-label {
     font-size: 0.75rem;
+    font-weight: 500;
     color: var(--color-text-placeholder);
     cursor: pointer;
+    user-select: none;
 }
 
 .mode-toggle {

--- a/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
+++ b/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
@@ -15,6 +15,7 @@ import {
     KEY_ESC,
 } from "@/const/key.const.js";
 import {RESET_COUNT_THRESHOLD_RATIO} from "@/const/config.const.ts";
+import {incrementSessionTypingCount} from "@/utils/sessionUtils.ts";
 import {koreanSeparator} from "@/utils/koreanSeparator.ts";
 import {createFlatTypoEntry, isLanguageSwitchMistake} from "@/utils/typoUtils.ts";
 import {saveTypingRecord} from "@/utils/typingRecordApi.ts";
@@ -278,6 +279,9 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
         // typos, resetCount 초기화
         typosRef.current = [];
         resetCountRef.current = 0;
+
+        // 세션 타이핑 카운트 증가 (동의 배너, 로그인 유도에 사용)
+        incrementSessionTypingCount();
     };
 
     const onInputChange = (e) => {

--- a/tp-react/src/pages/Home/components/Quote/Quote.css
+++ b/tp-react/src/pages/Home/components/Quote/Quote.css
@@ -1,6 +1,6 @@
 .quote-container {
     width: 80%;
-    max-width: 1100px;
+    max-width: 1200px;
     min-width: 600px;
     display: flex;
     flex-direction: column;
@@ -18,7 +18,34 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 0.75rem;
+    border-bottom: 1px solid var(--color-border);
+    margin-bottom: 1rem;
+}
+
+.quote-sub-row {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    padding: 0.75rem 0;
+}
+
+.upload-inline-btn {
+    padding: 0.4rem 0.75rem;
+    border: none;
+    background: transparent;
+    color: var(--color-text-placeholder);
+    font-size: 0.95rem;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    transition: color 0.15s;
+    border-radius: 0.375rem;
+}
+
+.upload-inline-btn:hover {
+    color: var(--color-primary);
+    background-color: var(--color-bg-secondary);
 }
 
 .author-container {

--- a/tp-react/src/pages/Home/components/Quote/Quote.css
+++ b/tp-react/src/pages/Home/components/Quote/Quote.css
@@ -65,3 +65,77 @@
     position: relative;
     min-height: auto;
 }
+
+/* 로그인 유도 */
+.login-prompt-wrapper {
+    position: relative;
+    margin-top: 4.5rem;
+}
+
+.login-prompt {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 1rem 1.25rem;
+    background: var(--color-bg-secondary);
+    border-radius: 0.5rem;
+}
+
+.login-prompt-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+
+.login-prompt-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.login-prompt-desc {
+    font-size: 0.8rem;
+    color: var(--color-text-muted);
+}
+
+.login-prompt-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    background: var(--color-popup-bg);
+    color: var(--color-text);
+    font-size: 0.8125rem;
+    font-weight: 500;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: border-color 0.15s;
+}
+
+.login-prompt-btn:hover {
+    border-color: var(--color-primary);
+}
+
+.login-prompt-actions {
+    display: flex;
+    align-items: center;
+    gap: 1.25rem;
+    flex-shrink: 0;
+}
+
+.login-prompt-close {
+    padding: 0;
+    border: none;
+    background: transparent;
+    color: var(--color-text-placeholder);
+    font-size: 0.875rem;
+    cursor: pointer;
+    line-height: 1;
+    transition: color 0.15s;
+}
+
+.login-prompt-close:hover {
+    color: var(--color-text-muted);
+}

--- a/tp-react/src/pages/Home/components/Quote/Quote.jsx
+++ b/tp-react/src/pages/Home/components/Quote/Quote.jsx
@@ -2,6 +2,7 @@ import "./Quote.css";
 import {useEffect, useState} from "react";
 import {useNavigate} from "react-router-dom";
 import {FaPlus} from "react-icons/fa";
+import {FaXmark} from "react-icons/fa6";
 import Sentence from "./Sentence/Sentence";
 import Author from "./Author/Author";
 import Input from "./Input/Input";
@@ -10,19 +11,38 @@ import QuoteSourceSelector from "./QuoteSourceSelector/QuoteSourceSelector";
 import QuoteMoreMenu from "./QuoteMoreMenu/QuoteMoreMenu";
 import QuoteLoading from "./QuoteLoading/QuoteLoading";
 import QuoteEmpty from "./QuoteEmpty/QuoteEmpty";
+import GoogleLogo from "@/components/GoogleLogo/GoogleLogo.jsx";
+import ConsentBanner from "@/components/ConsentBanner/ConsentBanner.jsx";
 import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useQuote} from "@/Context/QuoteContext.tsx";
 import {useSetting} from "@/Context/SettingContext.tsx";
 import {useAuth} from "@/Context/AuthContext.tsx";
+import {Session_Typing_Count, LOGIN_PROMPT_THRESHOLD, Session_Login_Prompt_Dismissed} from "@/const/config.const.ts";
 import {t} from "@/utils/i18n.ts";
 
 const Quote = () => {
     const navigate = useNavigate();
     const {isDark} = useTheme();
     const {user, triggerLogin} = useAuth();
-    const {author, sentence, isLoading, isEmpty} = useQuote();
+    const {author, sentence, isLoading, isEmpty, quotesIndex} = useQuote();
     const {isCompactMode} = useSetting();
     const [inputValue, setInputValue] = useState("");
+    const [showLoginPrompt, setShowLoginPrompt] = useState(false);
+
+    // 비로그인 시 타이핑 완료 횟수 체크
+    useEffect(() => {
+        if (user || sessionStorage.getItem(Session_Login_Prompt_Dismissed)) {
+            setShowLoginPrompt(false);
+            return;
+        }
+        const count = parseInt(sessionStorage.getItem(Session_Typing_Count) || '0', 10);
+        setShowLoginPrompt(count >= LOGIN_PROMPT_THRESHOLD);
+    }, [user, quotesIndex]);
+
+    const dismissLoginPrompt = () => {
+        sessionStorage.setItem(Session_Login_Prompt_Dismissed, 'true');
+        setShowLoginPrompt(false);
+    };
 
     useEffect(() => {
         setInputValue("");
@@ -73,6 +93,25 @@ const Quote = () => {
                         <Input onInputChange={setInputValue}/>
                     </div>
                 )}
+                {showLoginPrompt && (
+                    <div className="login-prompt-wrapper">
+                        <div className="login-prompt">
+                            <div className="login-prompt-text">
+                                <span className="login-prompt-title">{t('loginPromptTitle')}</span>
+                                <span className="login-prompt-desc">{t('loginPromptDesc')}</span>
+                            </div>
+                            <div className="login-prompt-actions">
+                                <button className="login-prompt-btn" onClick={triggerLogin}>
+                                    <GoogleLogo/>
+                                    <span>{t('googleLogin')}</span>
+                                </button>
+                                <button className="login-prompt-close" onClick={dismissLoginPrompt}><FaXmark/></button>
+                            </div>
+                        </div>
+                        <ConsentBanner/>
+                    </div>
+                )}
+                {!showLoginPrompt && <ConsentBanner/>}
             </div>
         </div>
     );

--- a/tp-react/src/pages/Home/components/Quote/Quote.jsx
+++ b/tp-react/src/pages/Home/components/Quote/Quote.jsx
@@ -1,5 +1,7 @@
 import "./Quote.css";
 import {useEffect, useState} from "react";
+import {useNavigate} from "react-router-dom";
+import {FaPlus} from "react-icons/fa";
 import Sentence from "./Sentence/Sentence";
 import Author from "./Author/Author";
 import Input from "./Input/Input";
@@ -11,14 +13,17 @@ import QuoteEmpty from "./QuoteEmpty/QuoteEmpty";
 import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useQuote} from "@/Context/QuoteContext.tsx";
 import {useSetting} from "@/Context/SettingContext.tsx";
+import {useAuth} from "@/Context/AuthContext.tsx";
+import {t} from "@/utils/i18n.ts";
 
 const Quote = () => {
+    const navigate = useNavigate();
     const {isDark} = useTheme();
+    const {user, triggerLogin} = useAuth();
     const {author, sentence, isLoading, isEmpty} = useQuote();
     const {isCompactMode} = useSetting();
     const [inputValue, setInputValue] = useState("");
 
-    // 문장이 변경되면 inputValue 초기화
     useEffect(() => {
         setInputValue("");
     }, [sentence]);
@@ -30,6 +35,14 @@ const Quote = () => {
         return className;
     };
 
+    const handleUploadClick = () => {
+        if (user) {
+            navigate('/quote/upload');
+        } else {
+            triggerLogin();
+        }
+    };
+
     const showLoading = isLoading && !sentence;
     const showEmpty = isEmpty && !isLoading;
     const showContent = !isEmpty && sentence;
@@ -37,9 +50,14 @@ const Quote = () => {
     return (
         <div className={getQuoteContainerClassName()}>
             <div className="quote-container-upper">
-                {/* 문장 소스 선택 + 저자 */}
                 <div className="quote-top-row">
                     <QuoteSourceSelector/>
+                    <button className="upload-inline-btn" onClick={handleUploadClick}>
+                        <FaPlus/>
+                        <span>{t('uploadSentence')}</span>
+                    </button>
+                </div>
+                <div className="quote-sub-row">
                     <div className={`author-container ${isDark ? "author-dark" : ""}`}>
                         <Author author={author}/>
                         <QuoteMoreMenu/>

--- a/tp-react/src/pages/Home/components/Quote/QuoteMoreMenu/QuoteMoreMenu.jsx
+++ b/tp-react/src/pages/Home/components/Quote/QuoteMoreMenu/QuoteMoreMenu.jsx
@@ -6,15 +6,13 @@ import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useAuth} from "@/Context/AuthContext.tsx";
 import {useQuote} from "@/Context/QuoteContext.tsx";
 import {t} from "@/utils/i18n.ts";
-import LoginRequiredPopup from "@/components/LoginRequiredPopup/LoginRequiredPopup.jsx";
 
 const QuoteMoreMenu = () => {
     const {isDark} = useTheme();
-    const {user} = useAuth();
+    const {user, triggerLogin} = useAuth();
     const {currentQuote} = useQuote();
 
     const [isMenuOpen, setIsMenuOpen] = useState(false);
-    const [showLoginPopup, setShowLoginPopup] = useState(false);
     const [showReportPopup, setShowReportPopup] = useState(false);
 
     const menuRef = useRef(null);
@@ -45,7 +43,7 @@ const QuoteMoreMenu = () => {
         setIsMenuOpen(false);
 
         if (!user) {
-            setShowLoginPopup(true);
+            triggerLogin();
             return;
         }
 
@@ -80,13 +78,6 @@ const QuoteMoreMenu = () => {
                     </div>
                 )}
             </div>
-
-            {showLoginPopup && (
-                <LoginRequiredPopup
-                    message={t('reportLoginRequired')}
-                    onClose={() => setShowLoginPopup(false)}
-                />
-            )}
 
             {showReportPopup && (
                 <ReportPopup

--- a/tp-react/src/pages/Home/components/Quote/QuoteSourceSelector/QuoteSourceSelector.css
+++ b/tp-react/src/pages/Home/components/Quote/QuoteSourceSelector/QuoteSourceSelector.css
@@ -1,46 +1,36 @@
 .quote-source-selector {
     display: flex;
-    gap: 0.5rem;
+    gap: 0;
 }
 
 .quote-source-btn {
-    padding: 0.25rem 0.5rem;
-    border: 1px solid #e5e7eb;
-    border-radius: 0.375rem;
+    position: relative;
+    padding: 0.75rem 1rem;
+    border: none;
+    border-radius: 0;
     background-color: transparent;
-    color: #999;
-    font-size: 0.8rem;
+    color: var(--color-text-placeholder);
+    font-size: 0.95rem;
+    font-weight: 500;
     cursor: pointer;
-    transition: all 0.2s;
-    display: flex;
-    align-items: center;
-    gap: 0.25rem;
+    transition: color 0.2s;
 }
 
 .quote-source-btn:hover {
-    border-color: #666;
-    color: #666;
+    color: var(--color-text-muted);
 }
 
 .quote-source-btn.active {
-    border-color: #666;
-    background-color: #666;
-    color: white;
+    color: var(--color-primary);
+    font-weight: 600;
 }
 
-/* 다크 모드 */
-.quote-source-btn.dark {
-    border-color: #3f3f46;
-    color: #71717a;
-}
-
-.quote-source-btn.dark:hover {
-    border-color: #a1a1aa;
-    color: #a1a1aa;
-}
-
-.quote-source-btn.dark.active {
-    border-color: #71717a;
-    background-color: #71717a;
-    color: white;
+.quote-source-btn.active::after {
+    content: '';
+    position: absolute;
+    bottom: -1px;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: var(--color-primary);
 }

--- a/tp-react/src/pages/Home/components/Quote/QuoteSourceSelector/QuoteSourceSelector.jsx
+++ b/tp-react/src/pages/Home/components/Quote/QuoteSourceSelector/QuoteSourceSelector.jsx
@@ -1,15 +1,11 @@
-import {useState} from 'react';
-import {FaGlobe, FaUser} from 'react-icons/fa';
 import './QuoteSourceSelector.css';
-import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useQuote} from "@/Context/QuoteContext.tsx";
+import {useAuth} from "@/Context/AuthContext.tsx";
 import {t} from "@/utils/i18n.ts";
-import LoginRequiredPopup from "@/components/LoginRequiredPopup/LoginRequiredPopup.jsx";
 
 const QuoteSourceSelector = () => {
-    const {isDark} = useTheme();
     const {quoteSource, changeQuoteSource} = useQuote();
-    const [showLoginPopup, setShowLoginPopup] = useState(false);
+    const {triggerLogin} = useAuth();
 
     const handleAllClick = () => {
         changeQuoteSource('all');
@@ -18,36 +14,25 @@ const QuoteSourceSelector = () => {
     const handleMyClick = () => {
         const success = changeQuoteSource('my');
         if (!success) {
-            setShowLoginPopup(true);
+            triggerLogin();
         }
     };
 
     return (
-        <>
-            <div className="quote-source-selector">
-                <button
-                    className={`quote-source-btn ${quoteSource === 'all' ? 'active' : ''} ${isDark ? 'dark' : ''}`}
-                    onClick={handleAllClick}
-                >
-                    <FaGlobe/>
-                    <span>{t('allSentences')}</span>
-                </button>
-                <button
-                    className={`quote-source-btn ${quoteSource === 'my' ? 'active' : ''} ${isDark ? 'dark' : ''}`}
-                    onClick={handleMyClick}
-                >
-                    <FaUser/>
-                    <span>{t('mySentencesOnly')}</span>
-                </button>
-            </div>
-
-            {showLoginPopup && (
-                <LoginRequiredPopup
-                    message={t('mySentencesLoginRequired')}
-                    onClose={() => setShowLoginPopup(false)}
-                />
-            )}
-        </>
+        <div className="quote-source-selector">
+            <button
+                className={`quote-source-btn ${quoteSource === 'all' ? 'active' : ''}`}
+                onClick={handleAllClick}
+            >
+                {t('allSentences')}
+            </button>
+            <button
+                className={`quote-source-btn ${quoteSource === 'my' ? 'active' : ''}`}
+                onClick={handleMyClick}
+            >
+                {t('mySentencesOnly')}
+            </button>
+        </div>
     );
 };
 

--- a/tp-react/src/pages/Home/components/ReportPopup/ReportPopup.jsx
+++ b/tp-react/src/pages/Home/components/ReportPopup/ReportPopup.jsx
@@ -41,8 +41,10 @@ const ReportPopup = ({quote, onClose, onSuccess}) => {
             onClose();
         } catch (error) {
             console.error('신고 실패:', error);
-            const message = error.response?.data?.detail || t('reportFailed');
-            showError(message);
+            if (error?.response?.status !== 401) {
+                const message = error.response?.data?.detail || t('reportFailed');
+                showError(message);
+            }
         } finally {
             setIsSubmitting(false);
         }

--- a/tp-react/src/pages/Home/components/UpdatePopup/UpdatePopup.jsx
+++ b/tp-react/src/pages/Home/components/UpdatePopup/UpdatePopup.jsx
@@ -1,23 +1,20 @@
 import {useEffect, useState} from "react";
-import {CiBullhorn} from "react-icons/ci";
-import UpdateHistoryList from "./UpdateHistoryList/UpdateHistoryList";
+import {useNavigate} from "react-router-dom";
 import LatestUpdate, {getLatestPopupUpdate} from "./LatestUpdate/LatestUpdate";
 import "./UpdatePopup.css";
 import {Storage_Last_Seen_Version} from "@/const/config.const.ts";
 import {t} from "@/utils/i18n.ts";
 
 const UpdatePopup = () => {
+    const navigate = useNavigate();
     const [isOpen, setIsOpen] = useState(false);
-    const [isHistoryMode, setIsHistoryMode] = useState(false);
 
     useEffect(() => {
         const lastSeenVersion = localStorage.getItem(Storage_Last_Seen_Version);
         const latestPopupUpdate = getLatestPopupUpdate();
 
-        // showPopup: true인 업데이트가 있고, 아직 해당 버전을 본 적 없으면 팝업 표시
         if (latestPopupUpdate && lastSeenVersion !== latestPopupUpdate.version) {
             setIsOpen(true);
-            setIsHistoryMode(false);
         }
     }, []);
 
@@ -33,66 +30,33 @@ const UpdatePopup = () => {
         }
     };
 
-    const handleIconClick = () => {
-        setIsOpen(true);
-        setIsHistoryMode(true);
+    const handleViewHistory = () => {
+        setIsOpen(false);
+        navigate('/updates');
     };
 
-    const handleHistoryClick = () => {
-        setIsHistoryMode(true);
-    };
+    if (!isOpen) return null;
 
     return (
-        <>
-            {/* 공지 아이콘 */}
-            <CiBullhorn
-                className="notice-icon"
-                title={t('updateNotice')}
-                onClick={handleIconClick}
-            />
-
-            {/* 팝업 */}
-            {isOpen && (
-                <div className="update-popup-overlay" onClick={handleClose}>
-                    <div className={`update-popup ${isHistoryMode ? "history-mode" : ""}`}
-                         onClick={e => e.stopPropagation()}>
-                        <div className="update-popup-header">
-                            <span className="update-popup-title">
-                                {isHistoryMode ? t('updateHistory') : t('updateNotice')}
-                            </span>
-                        </div>
-
-                        <div className="update-content">
-                            {isHistoryMode ? (
-                                <UpdateHistoryList/>
-                            ) : (
-                                <LatestUpdate/>
-                            )}
-                        </div>
-
-                        <button className="update-popup-close" onClick={handleClose}>
-                            {t('updateClose')}
-                        </button>
-                        {!isHistoryMode && (
-                            <>
-                                <button
-                                    className="update-popup-history-btn"
-                                    onClick={handleHistoryClick}
-                                >
-                                    {t('updateViewHistory')}
-                                </button>
-                                <button
-                                    className="update-popup-dont-show-btn"
-                                    onClick={handleDontShowAgain}
-                                >
-                                    {t('updateDontShow')}
-                                </button>
-                            </>
-                        )}
-                    </div>
+        <div className="update-popup-overlay" onClick={handleClose}>
+            <div className="update-popup" onClick={e => e.stopPropagation()}>
+                <div className="update-popup-header">
+                    <span className="update-popup-title">{t('updateNotice')}</span>
                 </div>
-            )}
-        </>
+                <div className="update-content">
+                    <LatestUpdate/>
+                </div>
+                <button className="update-popup-close" onClick={handleClose}>
+                    {t('updateClose')}
+                </button>
+                <button className="update-popup-history-btn" onClick={handleViewHistory}>
+                    {t('updateViewHistory')}
+                </button>
+                <button className="update-popup-dont-show-btn" onClick={handleDontShowAgain}>
+                    {t('updateDontShow')}
+                </button>
+            </div>
+        </div>
     );
 };
 

--- a/tp-react/src/pages/MyQuotes/MyQuotes.jsx
+++ b/tp-react/src/pages/MyQuotes/MyQuotes.jsx
@@ -132,7 +132,9 @@ function MyQuotes() {
             setEditingQuote(null);
         } catch (error) {
             console.error('문장 수정 실패:', error);
-            showError(extractQuoteErrorMessage(error, t('similarMy'), t('editSentenceFailed')));
+            if (error?.response?.status !== 401) {
+                showError(extractQuoteErrorMessage(error, t('similarMy'), t('editSentenceFailed')));
+            }
         }
     };
 
@@ -151,8 +153,10 @@ function MyQuotes() {
             }
         } catch (error) {
             console.error('문장 삭제 실패:', error);
-            const message = error.response?.data?.detail || t('deleteSentenceFailed');
-            showError(message);
+            if (error?.response?.status !== 401) {
+                const message = error.response?.data?.detail || t('deleteSentenceFailed');
+                showError(message);
+            }
             setDeletingQuoteId(null);
         }
     };
@@ -169,7 +173,9 @@ function MyQuotes() {
             ));
         } catch (error) {
             console.error('공개 전환 실패:', error);
-            showError(extractQuoteErrorMessage(error, t('similarPublic'), t('makePublicFailed')));
+            if (error?.response?.status !== 401) {
+                showError(extractQuoteErrorMessage(error, t('similarPublic'), t('makePublicFailed')));
+            }
         }
     };
 
@@ -185,8 +191,10 @@ function MyQuotes() {
             ));
         } catch (error) {
             console.error('공개 취소 실패:', error);
-            const message = error.response?.data?.detail || t('cancelPublicFailed');
-            showError(message);
+            if (error?.response?.status !== 401) {
+                const message = error.response?.data?.detail || t('cancelPublicFailed');
+                showError(message);
+            }
         }
     };
 

--- a/tp-react/src/pages/MyReports/MyReports.jsx
+++ b/tp-react/src/pages/MyReports/MyReports.jsx
@@ -128,8 +128,10 @@ function MyReports() {
             }
         } catch (error) {
             console.error('신고 삭제 실패:', error);
-            const message = error.response?.data?.detail || t('deleteReportFailed');
-            showError(message);
+            if (error?.response?.status !== 401) {
+                const message = error.response?.data?.detail || t('deleteReportFailed');
+                showError(message);
+            }
             setDeletingReportId(null);
         }
     };

--- a/tp-react/src/pages/Stats/Stats.jsx
+++ b/tp-react/src/pages/Stats/Stats.jsx
@@ -53,7 +53,9 @@ function Stats() {
             setTypoStats(typoRes.data.data.content || []);
         } catch (error) {
             console.error('통계 로드 실패:', error);
-            showError(t('statsLoadFailed'));
+            if (error?.response?.status !== 401) {
+                showError(t('statsLoadFailed'));
+            }
         } finally {
             setIsLoading(false);
         }
@@ -76,7 +78,7 @@ function Stats() {
         } catch (error) {
             if (error.response?.status === 429) {
                 showError(t('refreshCooldown'));
-            } else {
+            } else if (error?.response?.status !== 401) {
                 showError(t('refreshFailed'));
             }
         }

--- a/tp-react/src/pages/Stats/components/DailyChart.css
+++ b/tp-react/src/pages/Stats/components/DailyChart.css
@@ -53,6 +53,7 @@
 }
 
 .daily-chart-area {
+    position: relative;
     height: 11.25rem;
 }
 

--- a/tp-react/src/pages/Stats/components/DailyChart.jsx
+++ b/tp-react/src/pages/Stats/components/DailyChart.jsx
@@ -56,24 +56,18 @@ function DailyChart({dailyStats, dailyRange, onRangeChange}) {
 
     const labelInterval = data.length > 14 ? Math.ceil(data.length / 6) : 1;
 
-    const handleMouseEnter = useCallback((i) => {
+    const handleMouseEnter = useCallback((e, i) => {
         setHoverIndex(i);
         setPopupData(data[i]);
-        if (svgRef.current && chartRef.current) {
-            const svg = svgRef.current;
-            const section = chartRef.current.closest('.daily-chart-section');
-            if (!svg || !section) return;
-            const svgRect = svg.getBoundingClientRect();
-            const sectionRect = section.getBoundingClientRect();
-            const vb = svg.viewBox.baseVal;
-            const sx = svgRect.width / vb.width;
-            const sy = svgRect.height / vb.height;
+        if (chartRef.current) {
+            const circle = e.target.getBoundingClientRect();
+            const area = chartRef.current.getBoundingClientRect();
             setPopupPos({
-                x: svgRect.left - sectionRect.left + points[i].x * sx,
-                y: svgRect.top - sectionRect.top + points[i].y * sy + 16,
+                x: circle.left - area.left + circle.width / 2 + 8,
+                y: circle.top - area.top + circle.height / 2 + 20,
             });
         }
-    }, [data, points]);
+    }, [data]);
 
     const handleMouseLeave = useCallback(() => {
         setHoverIndex(null);
@@ -119,7 +113,7 @@ function DailyChart({dailyStats, dailyRange, onRangeChange}) {
                                         <text x={p.x} y={p.y - 16} className="daily-chart-tooltip-text">{displayVal}</text>
                                     </g>
                                     <circle cx={p.x} cy={p.y} r={16} style={{fill: 'transparent', cursor: 'pointer'}}
-                                        onMouseEnter={() => handleMouseEnter(i)} onMouseLeave={handleMouseLeave}/>
+                                        onMouseEnter={(e) => handleMouseEnter(e, i)} onMouseLeave={handleMouseLeave}/>
                                     {showLabel && (
                                         <text x={p.x} y={PAD.top + CHART_H + 16} className="daily-chart-date-label" textAnchor={textAnchor}>
                                             {formatDateLabel(data[i].date)}

--- a/tp-react/src/pages/Updates/Updates.css
+++ b/tp-react/src/pages/Updates/Updates.css
@@ -1,0 +1,109 @@
+.updates-container {
+    width: 80%;
+    max-width: 800px;
+    min-width: 600px;
+    margin: 0 auto;
+}
+
+.updates-header {
+    margin-bottom: 1.75rem;
+}
+
+.updates-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--color-primary);
+}
+
+.updates-list {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    padding-bottom: 3rem;
+}
+
+.update-card {
+    background: var(--color-popup-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    padding: 1.5rem;
+}
+
+.update-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.update-card-version {
+    font-weight: 600;
+    color: var(--color-primary);
+    font-size: 1rem;
+}
+
+.update-card-date {
+    font-size: 0.8rem;
+    color: var(--color-text-placeholder);
+}
+
+.update-card-section {
+    margin-bottom: 0.75rem;
+}
+
+.update-card-section:last-child {
+    margin-bottom: 0;
+}
+
+.update-card-section-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: 0.375rem;
+}
+
+.update-card-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.update-card-list li {
+    position: relative;
+    padding-left: 1rem;
+    margin-bottom: 0.25rem;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    line-height: 1.5;
+}
+
+.update-card-list li::before {
+    content: "•";
+    position: absolute;
+    left: 0;
+    color: var(--color-primary);
+}
+
+.updates-footer {
+    margin-top: 1.75rem;
+    display: flex;
+    justify-content: center;
+}
+
+.updates-back-btn {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.625rem 1.5rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--color-border);
+    background: var(--color-popup-bg);
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: background-color 0.15s;
+}
+
+.updates-back-btn:hover {
+    background-color: var(--color-bg-secondary);
+}

--- a/tp-react/src/pages/Updates/Updates.jsx
+++ b/tp-react/src/pages/Updates/Updates.jsx
@@ -1,0 +1,43 @@
+import {formatUpdateDate, localize, updateHistory} from '@/data/updateHistory.ts';
+import {t} from '@/utils/i18n.ts';
+import './Updates.css';
+
+function Updates() {
+    const visibleUpdates = updateHistory.filter(u => !u.hidden);
+
+    return (
+        <div className="updates-container">
+            <div className="updates-header">
+                <h1 className="updates-title">{t('updateHistory')}</h1>
+            </div>
+            <div className="updates-list">
+                {visibleUpdates.map((update) => (
+                    <div className="update-card" key={update.version}>
+                        <div className="update-card-header">
+                            <span className="update-card-version">v{update.version}</span>
+                            <span className="update-card-date">{formatUpdateDate(update.date)}</span>
+                        </div>
+                        {update.features && update.features.length > 0 && (
+                            <div className="update-card-section">
+                                <div className="update-card-section-title">{t('updateFeatures')}</div>
+                                <ul className="update-card-list">
+                                    {update.features.map((item, i) => <li key={i}>{localize(item)}</li>)}
+                                </ul>
+                            </div>
+                        )}
+                        {update.improvements && update.improvements.length > 0 && (
+                            <div className="update-card-section">
+                                <div className="update-card-section-title">{t('updateImprovements')}</div>
+                                <ul className="update-card-list">
+                                    {update.improvements.map((item, i) => <li key={i}>{localize(item)}</li>)}
+                                </ul>
+                            </div>
+                        )}
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+}
+
+export default Updates;

--- a/tp-react/src/pages/WordMode/WordMode.css
+++ b/tp-react/src/pages/WordMode/WordMode.css
@@ -1,6 +1,6 @@
 .word-mode-container {
     width: 80%;
-    max-width: 1100px;
+    max-width: 1200px;
     min-width: 600px;
     display: flex;
     flex-direction: column;

--- a/tp-react/src/pages/WordMode/WordMode.jsx
+++ b/tp-react/src/pages/WordMode/WordMode.jsx
@@ -1,8 +1,8 @@
 import {useEffect} from "react";
 import {WordContextProvider, useWord} from "./context/WordContext";
+import WordInfo from "./components/WordInfo/WordInfo";
 import WordTyping from "./components/WordTyping/WordTyping";
 import WordResult from "./components/WordResult/WordResult";
-import FontSizeSlider from "../Home/components/FontSizeSlider/FontSizeSlider";
 import UpdatePopup from "../Home/components/UpdatePopup/UpdatePopup";
 import {SettingContextProvider} from "@/Context/SettingContext.tsx";
 import {Storage_Last_Mode} from "@/const/config.const.ts";
@@ -13,10 +13,13 @@ const WordModeContent = () => {
     const {phase} = state;
 
     return (
-        <div className="word-mode-container">
-            {phase !== 'result' && <WordTyping/>}
-            {phase === 'result' && <WordResult/>}
-        </div>
+        <>
+            <WordInfo/>
+            <div className="word-mode-container">
+                {phase !== 'result' && <WordTyping/>}
+                {phase === 'result' && <WordResult/>}
+            </div>
+        </>
     );
 };
 
@@ -27,9 +30,6 @@ const WordMode = () => {
 
     return (
         <SettingContextProvider>
-            <div className="top-left-controls">
-                <FontSizeSlider/>
-            </div>
             <UpdatePopup/>
             <WordContextProvider>
                 <WordModeContent/>

--- a/tp-react/src/pages/WordMode/components/WordInfo/WordInfo.css
+++ b/tp-react/src/pages/WordMode/components/WordInfo/WordInfo.css
@@ -1,38 +1,31 @@
-
-.info-background {
+.word-info-background {
     width: 80%;
     max-width: 1200px;
     min-width: 600px;
     padding: 1.25rem 0;
-    margin-bottom: 0.5rem;
+    margin-bottom: 2rem;
     position: relative;
 }
 
-.info-row {
+.word-info-row {
     display: flex;
     justify-content: space-between;
     align-items: center;
 }
 
-.info-stats {
+.word-info-stats {
     display: flex;
     align-items: center;
     gap: 2.5rem;
 }
 
-.info-stat {
+.word-info-stat {
     display: flex;
     flex-direction: column;
     gap: 0.15rem;
 }
 
-.info-stat-clickable {
-    cursor: pointer;
-    user-select: none;
-    min-width: 6rem;
-}
-
-.info-stat-label {
+.word-info-stat-label {
     font-size: 0.6875rem;
     font-weight: 600;
     letter-spacing: 0.1em;
@@ -40,35 +33,35 @@
     color: var(--color-text-placeholder);
 }
 
-.info-stat-value {
+.word-info-stat-value {
     font-size: 2.25rem;
     font-weight: 300;
     color: #c4c4c4;
     line-height: 1.1;
+    min-width: 3ch;
 }
 
-.info-stat-value.current {
+.word-info-stat-value.highlight {
     color: var(--color-primary);
     font-weight: 400;
 }
 
-.dark .info-stat-value {
+.dark .word-info-stat-value {
     color: var(--color-text-muted);
 }
 
-.dark .info-stat-value.current {
+.dark .word-info-stat-value.highlight {
     color: var(--color-primary-light);
 }
 
-.info-stat-sep {
+.word-info-stat-sep {
     width: 1px;
     height: 2.75rem;
     background: var(--color-border);
     margin: 0 -0.5rem;
 }
 
-/* 우측 컨트롤 pill */
-.info-controls {
+.word-info-controls {
     display: flex;
     align-items: center;
     background: var(--color-bg-secondary);
@@ -76,24 +69,24 @@
     overflow: hidden;
 }
 
-.info-controls-inner {
+.word-info-controls-inner {
     display: flex;
     align-items: center;
     gap: 1rem;
     padding: 1.125rem 0 1.125rem 1.5rem;
     overflow: hidden;
     transition: max-width 0.25s ease, padding 0.25s ease, opacity 0.25s ease;
-    max-width: 500px;
+    max-width: 700px;
     opacity: 1;
 }
 
-.info-controls.collapsed .info-controls-inner {
+.word-info-controls.collapsed .word-info-controls-inner {
     max-width: 0;
     padding-left: 0;
     opacity: 0;
 }
 
-.info-controls.narrow-mode {
+.word-info-controls.narrow-mode {
     position: absolute;
     right: 0;
     top: 50%;
@@ -101,7 +94,7 @@
     z-index: 10;
 }
 
-.info-controls-toggle {
+.word-info-controls-toggle {
     border: none;
     background: none;
     color: var(--color-text-placeholder);
@@ -114,13 +107,51 @@
     flex-shrink: 0;
 }
 
-.info-controls-toggle:hover {
+.word-info-controls-toggle:hover {
     color: var(--color-primary);
 }
 
-.info-control-sep {
+.word-info-control-sep {
     width: 1px;
     height: 1.5rem;
     background: var(--color-bg-tertiary);
     flex-shrink: 0;
+}
+
+.word-info-chip-group {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+}
+
+.word-info-chip-label {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    color: var(--color-text-placeholder);
+    margin-right: 0.25rem;
+    white-space: nowrap;
+}
+
+.word-info-chip {
+    padding: 0.2rem 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    background: transparent;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    font-size: 0.7rem;
+    transition: all 0.15s;
+    white-space: nowrap;
+}
+
+.word-info-chip:hover {
+    border-color: var(--color-primary);
+    color: var(--color-text);
+}
+
+.word-info-chip.active {
+    background-color: var(--color-primary);
+    border-color: var(--color-primary);
+    color: #fff;
 }

--- a/tp-react/src/pages/WordMode/components/WordInfo/WordInfo.jsx
+++ b/tp-react/src/pages/WordMode/components/WordInfo/WordInfo.jsx
@@ -1,0 +1,132 @@
+import {useEffect, useRef, useState} from "react";
+import {FaChevronLeft, FaChevronRight} from "react-icons/fa6";
+import {useWord} from "../../context/WordContext";
+import {DIFFICULTIES, fetchWords, WORD_COUNTS} from "@/utils/wordService";
+import {t} from "@/utils/i18n.ts";
+import {Storage_Controls_Collapsed} from "@/const/config.const.ts";
+import FontSizeSlider from "@/pages/Home/components/FontSizeSlider/FontSizeSlider";
+import "./WordInfo.css";
+
+const difficultyLabels = {
+    RANDOM: () => t('random'),
+    EASY: () => t('easy'),
+    NORMAL: () => t('normal'),
+    HARD: () => t('hard')
+};
+
+const WordInfo = () => {
+    const {state, dispatch, startTimeRef} = useWord();
+    const {difficulty, wordCount, currentWordIndex, words, phase, wordGrades} = state;
+    const [elapsed, setElapsed] = useState(0);
+    const timerRef = useRef(null);
+    const [isCollapsed, setIsCollapsed] = useState(false);
+    const [isNarrowMode, setIsNarrowMode] = useState(false);
+    const userPrefRef = useRef(localStorage.getItem(Storage_Controls_Collapsed));
+    const controlsRef = useRef(null);
+
+    useEffect(() => {
+        if (phase !== 'typing') {
+            clearInterval(timerRef.current);
+            return;
+        }
+        timerRef.current = setInterval(() => {
+            if (startTimeRef.current) setElapsed((Date.now() - startTimeRef.current) / 1000);
+        }, 200);
+        return () => clearInterval(timerRef.current);
+    }, [phase]); // startTimeRef is a stable ref
+
+    useEffect(() => {
+        if (phase === 'typing') setElapsed(0);
+    }, [phase]);
+
+    const correctCount = wordGrades.filter(g => g === 'correct').length;
+    const currentWpm = elapsed > 0 ? Math.round(correctCount / (elapsed / 60)) : 0;
+
+    useEffect(() => {
+        const resolveState = () => {
+            const narrow = window.innerWidth <= 1080;
+            if (narrow) {
+                setIsCollapsed(true);
+                setIsNarrowMode(true);
+            } else if (userPrefRef.current !== null) {
+                setIsCollapsed(userPrefRef.current === "true");
+                setIsNarrowMode(false);
+            } else {
+                setIsCollapsed(false);
+                setIsNarrowMode(false);
+            }
+        };
+        resolveState();
+        window.addEventListener("resize", resolveState);
+        return () => window.removeEventListener("resize", resolveState);
+    }, []);
+
+    useEffect(() => {
+        const h = (e) => {
+            if (isNarrowMode && !isCollapsed && controlsRef.current && !controlsRef.current.contains(e.target)) setIsCollapsed(true);
+        };
+        document.addEventListener("click", h);
+        return () => document.removeEventListener("click", h);
+    }, [isNarrowMode, isCollapsed]);
+
+    const handleToggle = (e) => {
+        e.stopPropagation();
+        const next = !isCollapsed;
+        if (!isNarrowMode) {
+            userPrefRef.current = String(next);
+            localStorage.setItem(Storage_Controls_Collapsed, String(next));
+        }
+        setIsCollapsed(next);
+    };
+
+    const loadWords = async (diff, count) => {
+        const w = await fetchWords(diff, count);
+        startTimeRef.current = null;
+        dispatch({type: 'START_TYPING', words: w});
+    };
+    const handleDifficultyChange = (d) => {
+        dispatch({type: 'SET_DIFFICULTY', difficulty: d});
+        loadWords(d, wordCount);
+    };
+    const handleWordCountChange = (c) => {
+        dispatch({type: 'SET_WORD_COUNT', wordCount: c});
+        loadWords(difficulty, c);
+    };
+
+    const controlsClass = `word-info-controls${isCollapsed ? " collapsed" : ""}${isNarrowMode ? " narrow-mode" : ""}`;
+
+    return (
+        <div className="word-info-background">
+            <div className="word-info-row">
+                <div className="word-info-stats">
+                    <div className="word-info-stat"><span className="word-info-stat-label">WPM</span><span
+                        className="word-info-stat-value highlight">{currentWpm}</span></div>
+                    <div className="word-info-stat"><span className="word-info-stat-label">PROGRESS</span><span
+                        className="word-info-stat-value">{currentWordIndex}/{words.length}</span></div>
+                </div>
+                <div className={controlsClass} ref={controlsRef}>
+                    <div className="word-info-controls-inner">
+                        <FontSizeSlider/>
+                        <div className="word-info-control-sep"/>
+                        <div className="word-info-chip-group">
+                            {DIFFICULTIES.map((d) => (
+                                <button key={d} className={`word-info-chip ${difficulty === d ? 'active' : ''}`}
+                                        onClick={() => handleDifficultyChange(d)}
+                                        tabIndex={-1}>{difficultyLabels[d]()}</button>))}
+                        </div>
+                        <div className="word-info-control-sep"/>
+                        <div className="word-info-chip-group">
+                            {WORD_COUNTS.map((c) => (
+                                <button key={c} className={`word-info-chip ${wordCount === c ? 'active' : ''}`}
+                                        onClick={() => handleWordCountChange(c)} tabIndex={-1}>{c}</button>))}
+                        </div>
+                    </div>
+                    <button className="word-info-controls-toggle" onClick={handleToggle}>{isCollapsed ?
+                        <FaChevronLeft/> : <FaChevronRight/>}</button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default WordInfo;

--- a/tp-react/src/pages/WordMode/components/WordTyping/WordInput.jsx
+++ b/tp-react/src/pages/WordMode/components/WordTyping/WordInput.jsx
@@ -2,6 +2,7 @@ import {useEffect, useRef, useState, useCallback, forwardRef, useImperativeHandl
 import {useWord} from "../../context/WordContext";
 import {koreanSeparator} from "@/utils/koreanSeparator.ts";
 import {areJamoEqual} from "@/pages/Home/components/Quote/Input/InputUtils";
+import {incrementSessionTypingCount} from "@/utils/sessionUtils.ts";
 import "./WordInput.css";
 
 const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocusChange}, ref) => {
@@ -70,7 +71,7 @@ const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocus
     }, []);
 
     // 전체 입력에 대한 글자 채점 (InputDisplay용)
-    const computeFullGrades = useCallback((input, confirmedCount) => {
+    const computeFullGrades = useCallback((input) => {
         const segments = input.split(' ');
         const allGrades = [];
 
@@ -105,6 +106,9 @@ const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocus
             timeMs: 0,
             elapsedMs,
         });
+
+        // 세션 타이핑 카운트 증가
+        incrementSessionTypingCount();
     }, [dispatch, gradeWord, words, startTimeRef]);
 
     const handleInput = (e) => {
@@ -162,7 +166,7 @@ const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocus
         }
 
         // 현재 단어 채점 + 전체 채점
-        const fullGrades = computeFullGrades(newValue, newConfirmedCount);
+        const fullGrades = computeFullGrades(newValue);
         onCurrentGradesChange?.(fullGrades);
         onFullInputChange?.(newValue);
     };

--- a/tp-react/src/pages/WordMode/components/WordTyping/WordTyping.css
+++ b/tp-react/src/pages/WordMode/components/WordTyping/WordTyping.css
@@ -42,6 +42,8 @@
 .word-typing-area {
     position: relative;
     line-height: 1.8;
+    user-select: none;
+    -webkit-user-select: none;
 }
 
 /* 하단 retry */

--- a/tp-react/src/pages/WordMode/components/WordTyping/WordTyping.jsx
+++ b/tp-react/src/pages/WordMode/components/WordTyping/WordTyping.jsx
@@ -1,21 +1,13 @@
 import {useState, useCallback, useRef, useEffect} from "react";
 import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useWord} from "../../context/WordContext";
-import {fetchWords, DIFFICULTIES, WORD_COUNTS} from "@/utils/wordService";
+import {fetchWords} from "@/utils/wordService";
 import {t} from "@/utils/i18n.ts";
 import {VscDebugRestart} from "react-icons/vsc";
 import WordSentence from "./WordSentence";
 import WordInputDisplay from "./WordInputDisplay";
 import WordInput from "./WordInput";
-import WordProgress from "../WordProgress/WordProgress";
 import "./WordTyping.css";
-
-const difficultyLabels = {
-    RANDOM: () => t('random'),
-    EASY: () => t('easy'),
-    NORMAL: () => t('normal'),
-    HARD: () => t('hard'),
-};
 
 const WordTyping = () => {
     const {isDark} = useTheme();
@@ -27,7 +19,6 @@ const WordTyping = () => {
     const [isFocused, setIsFocused] = useState(true);
     const inputRef = useRef(null);
 
-    // 최초 로드 시 단어 가져오기
     useEffect(() => {
         if (words.length === 0 && phase === 'typing') {
             loadWords(difficulty, wordCount);
@@ -40,18 +31,7 @@ const WordTyping = () => {
         dispatch({type: 'START_TYPING', words: newWords});
         setFullInput("");
         setFullGrades([]);
-        // 약간의 딜레이 후 포커스
         setTimeout(() => inputRef.current?.focus(), 50);
-    };
-
-    const handleDifficultyChange = (d) => {
-        dispatch({type: 'SET_DIFFICULTY', difficulty: d});
-        loadWords(d, wordCount);
-    };
-
-    const handleWordCountChange = (c) => {
-        dispatch({type: 'SET_WORD_COUNT', wordCount: c});
-        loadWords(difficulty, c);
     };
 
     const handleRetry = () => {
@@ -73,37 +53,6 @@ const WordTyping = () => {
 
     return (
         <div className={`word-typing-container ${isDark ? 'word-typing-dark' : ''}`}>
-            {/* 설정: 난이도 + 단어 수 */}
-            <div className="word-typing-settings">
-                <div className="word-typing-setting-group">
-                    {DIFFICULTIES.map((d) => (
-                        <button
-                            key={d}
-                            className={`word-typing-chip ${difficulty === d ? 'active' : ''}`}
-                            onClick={() => handleDifficultyChange(d)}
-                            tabIndex={-1}
-                        >
-                            {difficultyLabels[d]()}
-                        </button>
-                    ))}
-                </div>
-                <div className="word-typing-setting-group">
-                    {WORD_COUNTS.map((c) => (
-                        <button
-                            key={c}
-                            className={`word-typing-chip ${wordCount === c ? 'active' : ''}`}
-                            onClick={() => handleWordCountChange(c)}
-                            tabIndex={-1}
-                        >
-                            {c}
-                        </button>
-                    ))}
-                </div>
-            </div>
-
-            {/* 진행 표시 */}
-            <WordProgress/>
-
             {/* 타이핑 영역 */}
             {words.length > 0 && (
                 <div className="word-typing-area" onClick={handleAreaClick}>

--- a/tp-react/src/pages/WordMode/components/WordTyping/WordTyping.jsx
+++ b/tp-react/src/pages/WordMode/components/WordTyping/WordTyping.jsx
@@ -7,6 +7,7 @@ import {VscDebugRestart} from "react-icons/vsc";
 import WordSentence from "./WordSentence";
 import WordInputDisplay from "./WordInputDisplay";
 import WordInput from "./WordInput";
+import ConsentBanner from "@/components/ConsentBanner/ConsentBanner.jsx";
 import "./WordTyping.css";
 
 const WordTyping = () => {
@@ -79,6 +80,8 @@ const WordTyping = () => {
                 </button>
                 <span className="word-typing-bottom-hint">{t('retryHint')}</span>
             </div>
+
+            <ConsentBanner/>
         </div>
     );
 };

--- a/tp-react/src/utils/authApi.ts
+++ b/tp-react/src/utils/authApi.ts
@@ -26,7 +26,10 @@ interface MemberInfo {
 
 // Google OAuth 로그인
 export const loginWithGoogle = async (code: string): Promise<ApiResponse<LoginResponse>> => {
-    const response = await apiClient.post<ApiResponse<LoginResponse>>('/auth/google', {code});
+    const response = await apiClient.post<ApiResponse<LoginResponse>>('/auth/google', {
+        code,
+        redirectUri: import.meta.env.VITE_REDIRECT_URI
+    });
     return response.data;
 };
 

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -203,6 +203,50 @@ const translations = {
     ),
     featureGuideConfirm: l('확인', 'OK', 'Got it'),
 
+    // 로그인 유도
+    loginPromptTitle: l('타이핑 기록을 저장해보세요', 'タイピング記録を保存しましょう', 'Save your typing records'),
+    loginPromptDesc: l(
+        '로그인하면 타이핑 속도, 정확도, 오타 분석을 확인할 수 있어요.',
+        'ログインすると、タイピング速度・正確度・誤字分析を確認できます。',
+        'Sign in to track your typing speed, accuracy, and typo analysis.'
+    ),
+
+    // 동의 배너
+    consentTitle: l('더 나은 서비스를 위해', 'より良いサービスのために', 'Help us improve'),
+    consentDesc: l(
+        '서비스 개선을 위해 익명 사용 데이터를 수집합니다. 개인을 식별할 수 없습니다.',
+        'サービス改善のため匿名の使用データを収集します。個人を特定することはできません。',
+        'We collect anonymous usage data to improve the service. It cannot identify you personally.'
+    ),
+    consentAnonymousId: l('익명 식별자', '匿名識別子', 'Anonymous ID'),
+    consentAnonymousIdDesc: l(
+        '이름, 이메일 등 개인정보와 연결되지 않습니다.',
+        '名前やメールなどの個人情報とは関連付けられません。',
+        'Not linked to any personal information like name or email.'
+    ),
+    consentDeviceType: l('기기 유형', 'デバイスタイプ', 'Device type'),
+    consentDeviceTypeDesc: l(
+        '모바일 / 태블릿 / 데스크톱 중 어떤 환경인지 확인합니다.',
+        'モバイル/タブレット/デスクトップのどの環境かを確認します。',
+        'Whether you\'re on mobile, tablet, or desktop.'
+    ),
+    consentReferrer: l('유입 경로', '流入経路', 'Referrer'),
+    consentReferrerDesc: l(
+        '어떤 사이트에서 방문했는지 확인합니다.',
+        'どのサイトからアクセスしたかを確認します。',
+        'Which site you came from.'
+    ),
+    consentSession: l('세션 정보', 'セッション情報', 'Session info'),
+    consentSessionDesc: l(
+        '한 번의 방문 동안만 유지되며, 탭을 닫으면 자동으로 삭제됩니다.',
+        '1回の訪問中のみ保持され、タブを閉じると自動的に削除されます。',
+        'Only kept during your visit. Automatically deleted when you close the tab.'
+    ),
+    consentAccept: l('동의', '同意', 'Accept'),
+    consentReject: l('거절', '拒否', 'Reject'),
+    consentMore: l('자세히 보기', '詳しく見る', 'More info'),
+    consentLess: l('접기', '閉じる', 'Less'),
+
     // 결과 팝업
     popupLoginPrompt: l('이 기록을 저장할까요?', 'この記録を保存しますか？', 'Save this record?'),
     popupCumulativeAvg: l('Overall avg', 'Overall avg', 'Overall avg'),

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -1,210 +1,216 @@
-const isKorean = navigator.language.startsWith('ko');
+type Lang = 'ko' | 'ja' | 'en';
+const lang: Lang = navigator.language.startsWith('ko') ? 'ko' : navigator.language.startsWith('ja') ? 'ja' : 'en';
+const l = (ko: string, ja: string, en: string) => lang === 'ko' ? ko : lang === 'ja' ? ja : en;
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 const translations = {
     // 공통
-    confirm: isKorean ? '확인' : 'OK',
-    cancel: isKorean ? '취소' : 'Cancel',
-    back: isKorean ? '돌아가기' : 'Back',
-    delete: isKorean ? '삭제' : 'Delete',
-    save: isKorean ? '저장' : 'Save',
-    saving: isKorean ? '저장 중...' : 'Saving...',
-    saveChanges: isKorean ? '저장하기' : 'Save',
-    close: isKorean ? '닫기' : 'Close',
-    loading: isKorean ? '로딩 중...' : 'Loading...',
-    edit: isKorean ? '수정' : 'Edit',
+    confirm: l('확인', '確認', 'OK'),
+    cancel: l('취소', 'キャンセル', 'Cancel'),
+    back: l('돌아가기', '戻る', 'Back'),
+    delete: l('삭제', '削除', 'Delete'),
+    save: l('저장', '保存', 'Save'),
+    saving: l('저장 중...', '保存中...', 'Saving...'),
+    saveChanges: l('저장하기', '保存する', 'Save'),
+    close: l('닫기', '閉じる', 'Close'),
+    loading: l('로딩 중...', '読み込み中...', 'Loading...'),
+    edit: l('수정', '編集', 'Edit'),
 
     // 로그인/인증
-    googleLogin: isKorean ? '구글 로그인' : 'Sign in with Google',
-    loginRequired: isKorean ? '로그인이 필요합니다.' : 'Login required.',
-    logout: isKorean ? '로그아웃' : 'Logout',
-    backToHome: isKorean ? '홈으로 돌아가기' : 'Back to Home',
+    googleLogin: l('구글 로그인', 'Googleでログイン', 'Sign in with Google'),
+    loginRequired: l('로그인이 필요합니다.', 'ログインが必要です。', 'Login required.'),
+    logout: l('로그아웃', 'ログアウト', 'Logout'),
+    backToHome: l('홈으로 돌아가기', 'ホームに戻る', 'Back to Home'),
 
     // 닉네임
-    welcome: isKorean ? '환영합니다!' : 'Welcome!',
-    setNickname: isKorean ? '닉네임을 설정해주세요. (2-10자)' : 'Please set your nickname. (2-10 characters)',
-    nicknamePlaceholder: isKorean ? '닉네임 입력' : 'Enter nickname',
-    nicknameLength: isKorean ? '닉네임은 2-10자여야 합니다.' : 'Nickname must be 2-10 characters.',
-    nicknameDuplicate: isKorean ? '이미 사용 중인 닉네임입니다.' : 'This nickname is already taken.',
-    nicknameCheckFailed: isKorean ? '중복 확인에 실패했습니다.' : 'Failed to check nickname.',
-    nicknameCheckFirst: isKorean ? '닉네임 중복 확인을 먼저 해주세요.' : 'Please check nickname availability first.',
-    nicknameAvailable: isKorean ? '사용 가능한 닉네임입니다.' : 'Nickname is available.',
-    nicknameHelper: isKorean ? '한글, 영문, 숫자 사용 가능' : 'Korean, English, numbers allowed',
-    checkDuplicate: isKorean ? '중복확인' : 'Check',
-    checking: isKorean ? '확인 중...' : 'Checking...',
-    nicknameSetFailed: isKorean ? '닉네임 설정에 실패했습니다.' : 'Failed to set nickname.',
-    nicknameEditFailed: isKorean ? '닉네임 수정에 실패했습니다.' : 'Failed to update nickname.',
-    start: isKorean ? '시작하기' : 'Start',
-    setting: isKorean ? '설정 중...' : 'Setting...',
-    setNicknameBtn: isKorean ? '닉네임 설정' : 'Set Nickname',
+    welcome: l('환영합니다!', 'ようこそ！', 'Welcome!'),
+    setNickname: l('닉네임을 설정해주세요. (2-10자)', 'ニックネームを設定してください（2〜10文字）', 'Please set your nickname. (2-10 characters)'),
+    nicknamePlaceholder: l('닉네임 입력', 'ニックネーム入力', 'Enter nickname'),
+    nicknameLength: l('닉네임은 2-10자여야 합니다.', 'ニックネームは2〜10文字です。', 'Nickname must be 2-10 characters.'),
+    nicknameDuplicate: l('이미 사용 중인 닉네임입니다.', 'このニックネームは既に使用されています。', 'This nickname is already taken.'),
+    nicknameCheckFailed: l('중복 확인에 실패했습니다.', '確認に失敗しました。', 'Failed to check nickname.'),
+    nicknameCheckFirst: l('닉네임 중복 확인을 먼저 해주세요.', '先にニックネームの重複確認をしてください。', 'Please check nickname availability first.'),
+    nicknameAvailable: l('사용 가능한 닉네임입니다.', '使用可能なニックネームです。', 'Nickname is available.'),
+    nicknameHelper: l('한글, 영문, 숫자 사용 가능', '韓国語、英語、数字が使用可能', 'Korean, English, numbers allowed'),
+    checkDuplicate: l('중복확인', '確認', 'Check'),
+    checking: l('확인 중...', '確認中...', 'Checking...'),
+    nicknameSetFailed: l('닉네임 설정에 실패했습니다.', 'ニックネームの設定に失敗しました。', 'Failed to set nickname.'),
+    nicknameEditFailed: l('닉네임 수정에 실패했습니다.', 'ニックネームの変更に失敗しました。', 'Failed to update nickname.'),
+    start: l('시작하기', '始める', 'Start'),
+    setting: l('설정 중...', '設定中...', 'Setting...'),
+    setNicknameBtn: l('닉네임 설정', 'ニックネーム設定', 'Set Nickname'),
 
     // 프로필
-    profile: isKorean ? '프로필' : 'Profile',
-    profileLoadFailed: isKorean ? '프로필을 불러오는데 실패했습니다.' : 'Failed to load profile.',
-    email: isKorean ? '이메일' : 'Email',
-    nickname: isKorean ? '닉네임' : 'Nickname',
-    joinDate: isKorean ? '가입일' : 'Joined',
-    user: isKorean ? '사용자' : 'User',
+    profile: l('프로필', 'プロフィール', 'Profile'),
+    profileLoadFailed: l('프로필을 불러오는데 실패했습니다.', 'プロフィールの読み込みに失敗しました。', 'Failed to load profile.'),
+    email: l('이메일', 'メール', 'Email'),
+    nickname: l('닉네임', 'ニックネーム', 'Nickname'),
+    joinDate: l('가입일', '登録日', 'Joined'),
+    user: l('사용자', 'ユーザー', 'User'),
 
     // 프로필 드롭다운
-    mySentences: isKorean ? '내 문장' : 'My Sentences',
-    records: isKorean ? '기록' : 'Records',
-    reportHistory: isKorean ? '신고 내역' : 'Report History',
+    mySentences: l('내 문장', 'マイ文章', 'My Sentences'),
+    records: l('기록', '記録', 'Records'),
+    reportHistory: l('신고 내역', '報告履歴', 'Report History'),
 
     // 헤더
-    uploadSentence: isKorean ? '문장 업로드' : 'Upload',
-    uploadLoginRequired: isKorean ? '문장을 업로드하려면 로그인이 필요합니다.' : 'Login required to upload sentences.',
-    loginFailed: isKorean ? '로그인에 실패했습니다. 다시 시도해주세요.' : 'Login failed. Please try again.',
-    googleLoginFailed: isKorean ? '구글 로그인에 실패했습니다.' : 'Google login failed.',
+    uploadSentence: l('문장 업로드', '文章アップロード', 'Upload'),
+    uploadLoginRequired: l('문장을 업로드하려면 로그인이 필요합니다.', '文章をアップロードするにはログインが必要です。', 'Login required to upload sentences.'),
+    loginFailed: l('로그인에 실패했습니다. 다시 시도해주세요.', 'ログインに失敗しました。もう一度お試しください。', 'Login failed. Please try again.'),
+    googleLoginFailed: l('구글 로그인에 실패했습니다.', 'Googleログインに失敗しました。', 'Google login failed.'),
 
     // 타이핑 입력
-    inputPlaceholder: isKorean ? '위 문장을 입력하세요.' : 'Type the sentence above.',
-    pasteBlocked: isKorean ? '붙여넣기가 금지되어 있습니다!' : 'Pasting is not allowed!',
+    inputPlaceholder: l('타이핑을 시작하세요.', 'タイピングを始めましょう。', 'Start typing.'),
+    pasteBlocked: l('붙여넣기가 금지되어 있습니다!', '貼り付けは禁止されています！', 'Pasting is not allowed!'),
 
     // 문장 소스
-    allSentences: isKorean ? '전체 문장' : 'All',
-    mySentencesOnly: isKorean ? '내 문장만' : 'Mine',
-    mySentencesLoginRequired: isKorean ? '내 문장을 사용하려면 로그인이 필요합니다.' : 'Login required to use your sentences.',
+    allSentences: l('전체 문장', 'すべての文章', 'All'),
+    mySentencesOnly: l('내 문장만', 'マイ文章のみ', 'Mine'),
+    mySentencesLoginRequired: l('내 문장을 사용하려면 로그인이 필요합니다.', 'マイ文章を使用するにはログインが必要です。', 'Login required to use your sentences.'),
 
     // 문장 로딩/비어있음
-    loadingSentences: isKorean ? '문장을 불러오는 중...' : 'Loading sentences...',
-    noSentences: isKorean ? '등록된 문장이 없습니다.' : 'No sentences found.',
-    sentenceLoadFailed: isKorean ? '문장을 불러오는데 실패했습니다.' : 'Failed to load sentences.',
+    loadingSentences: l('문장을 불러오는 중...', '文章を読み込み中...', 'Loading sentences...'),
+    noSentences: l('등록된 문장이 없습니다.', '登録された文章がありません。', 'No sentences found.'),
+    sentenceLoadFailed: l('문장을 불러오는데 실패했습니다.', '文章の読み込みに失敗しました。', 'Failed to load sentences.'),
 
     // 신고
-    report: isKorean ? '신고' : 'Report',
-    reportSentence: isKorean ? '문장 신고' : 'Report Sentence',
-    reportTarget: isKorean ? '신고 대상' : 'Target',
-    reportReason: isKorean ? '신고 사유' : 'Reason',
-    reportDetail: isKorean ? '상세 설명' : 'Details',
-    reportDetailPlaceholder: isKorean ? '신고 사유를 자세히 설명해주세요.' : 'Please describe the reason in detail.',
-    optional: isKorean ? '선택' : 'optional',
-    reportModify: isKorean ? '수정 요청' : 'Request Edit',
-    reportModifyDesc: isKorean ? '오타, 맞춤법 오류 등' : 'Typos, grammar errors, etc.',
-    reportDelete: isKorean ? '삭제 요청' : 'Request Delete',
-    reportDeleteDesc: isKorean ? '부적절한 내용, 저작권 위반 등' : 'Inappropriate content, copyright, etc.',
-    reporting: isKorean ? '신고 중...' : 'Reporting...',
-    reportFailed: isKorean ? '신고 접수에 실패했습니다.' : 'Failed to submit report.',
-    reportLoginRequired: isKorean ? '문장을 신고하려면 로그인이 필요합니다.' : 'Login required to report.',
-    cancelReport: isKorean ? '신고 취소' : 'Cancel Report',
+    report: l('신고', '報告', 'Report'),
+    reportSentence: l('문장 신고', '文章を報告', 'Report Sentence'),
+    reportTarget: l('신고 대상', '対象', 'Target'),
+    reportReason: l('신고 사유', '理由', 'Reason'),
+    reportDetail: l('상세 설명', '詳細', 'Details'),
+    reportDetailPlaceholder: l('신고 사유를 자세히 설명해주세요.', '報告理由を詳しく説明してください。', 'Please describe the reason in detail.'),
+    optional: l('선택', '任意', 'optional'),
+    reportModify: l('수정 요청', '修正リクエスト', 'Request Edit'),
+    reportModifyDesc: l('오타, 맞춤법 오류 등', '誤字、スペルミスなど', 'Typos, grammar errors, etc.'),
+    reportDelete: l('삭제 요청', '削除リクエスト', 'Request Delete'),
+    reportDeleteDesc: l('부적절한 내용, 저작권 위반 등', '不適切な内容、著作権侵害など', 'Inappropriate content, copyright, etc.'),
+    reporting: l('신고 중...', '報告中...', 'Reporting...'),
+    reportFailed: l('신고 접수에 실패했습니다.', '報告の送信に失敗しました。', 'Failed to submit report.'),
+    reportLoginRequired: l('문장을 신고하려면 로그인이 필요합니다.', '報告するにはログインが必要です。', 'Login required to report.'),
+    cancelReport: l('신고 취소', '報告取消', 'Cancel Report'),
 
     // 내 문장 페이지
-    mySentencesTitle: isKorean ? '내 문장' : 'My Sentences',
-    noMySentences: isKorean ? '등록한 문장이 없습니다.' : 'No sentences registered.',
-    deleteSentenceConfirm: isKorean ? '이 문장을 삭제하시겠습니까?' : 'Delete this sentence?',
-    editSentence: isKorean ? '문장 수정' : 'Edit Sentence',
-    sentence: isKorean ? '문장' : 'Sentence',
-    authorOptional: isKorean ? '저자 (선택)' : 'Author (optional)',
-    makePublic: isKorean ? '공개전환' : 'Make Public',
-    cancelPublic: isKorean ? '공개취소' : 'Cancel Public',
+    mySentencesTitle: l('내 문장', 'マイ文章', 'My Sentences'),
+    noMySentences: l('등록한 문장이 없습니다.', '登録した文章がありません。', 'No sentences registered.'),
+    deleteSentenceConfirm: l('이 문장을 삭제하시겠습니까?', 'この文章を削除しますか？', 'Delete this sentence?'),
+    editSentence: l('문장 수정', '文章を編集', 'Edit Sentence'),
+    sentence: l('문장', '文章', 'Sentence'),
+    authorOptional: l('저자 (선택)', '著者（任意）', 'Author (optional)'),
+    makePublic: l('공개전환', '公開する', 'Make Public'),
+    cancelPublic: l('공개취소', '公開取消', 'Cancel Public'),
 
     // 필터
-    all: isKorean ? '전체' : 'All',
-    public: isKorean ? '공개' : 'Public',
-    private: isKorean ? '비공개' : 'Private',
-    pending: isKorean ? '대기중' : 'Pending',
-    active: isKorean ? '활성' : 'Active',
-    processed: isKorean ? '처리완료' : 'Processed',
+    all: l('전체', 'すべて', 'All'),
+    public: l('공개', '公開', 'Public'),
+    private: l('비공개', '非公開', 'Private'),
+    pending: l('대기중', '保留中', 'Pending'),
+    active: l('활성', 'アクティブ', 'Active'),
+    processed: l('처리완료', '処理済み', 'Processed'),
 
     // 신고 내역 페이지
-    reportHistoryTitle: isKorean ? '신고 내역' : 'Report History',
-    noReports: isKorean ? '신고 내역이 없습니다.' : 'No reports found.',
-    deleteReportConfirm: isKorean ? '이 신고를 취소하시겠습니까?' : 'Cancel this report?',
-    reportContent: isKorean ? '신고 내용' : 'Report Details',
-    deleted: isKorean ? '삭제됨' : 'Deleted',
+    reportHistoryTitle: l('신고 내역', '報告履歴', 'Report History'),
+    noReports: l('신고 내역이 없습니다.', '報告履歴がありません。', 'No reports found.'),
+    deleteReportConfirm: l('이 신고를 취소하시겠습니까?', 'この報告を取り消しますか？', 'Cancel this report?'),
+    reportContent: l('신고 내용', '報告内容', 'Report Details'),
+    deleted: l('삭제됨', '削除済み', 'Deleted'),
 
     // 업로드 페이지
-    uploadTitle: isKorean ? '문장 업로드' : 'Upload Sentences',
-    uploadTypeHint: isKorean ? '각 문장마다 공개/비공개를 선택할 수 있습니다.' : 'You can set each sentence as public or private.',
-    uploadTooltipPublic: isKorean ? '관리자 승인 후 모든 사용자에게 노출됩니다.' : 'Visible to all users after admin approval.',
-    uploadTooltipPrivate: isKorean ? '본인만 사용할 수 있습니다.' : 'Only visible to you.',
-    sentencePlaceholder: (min: number, max: number) => isKorean ? `문장을 입력하세요 (${min}-${max}자)` : `Enter a sentence (${min}-${max} characters)`,
-    authorPlaceholder: isKorean ? '저자 (선택)' : 'Author (optional)',
-    addSentence: (cur: number, max: number) => isKorean ? `문장 추가 (${cur}/${max})` : `Add sentence (${cur}/${max})`,
-    maxEntries: (max: number) => isKorean ? `최대 ${max}개` : `Max ${max}`,
-    upload: isKorean ? '업로드' : 'Upload',
-    uploading: isKorean ? '업로드 중...' : 'Uploading...',
-    minSentenceLength: (min: number) => isKorean ? `문장은 ${min}자 이상이어야 합니다.` : `Sentence must be at least ${min} characters.`,
-    maxSentenceLength: (max: number) => isKorean ? `문장은 ${max}자 이하여야 합니다.` : `Sentence must be at most ${max} characters.`,
-    maxAuthorLength: (max: number) => isKorean ? `저자는 ${max}자 이하여야 합니다.` : `Author must be at most ${max} characters.`,
-    enterAtLeastOne: isKorean ? '최소 1개의 문장을 입력해주세요.' : 'Please enter at least one sentence.',
-    uploadConfirmBoth: (pub: number, priv: number) => isKorean ? `공개 ${pub}개, 비공개 ${priv}개의 문장을 업로드합니다.` : `Upload ${pub} public and ${priv} private sentences.`,
-    uploadConfirmPublic: (n: number) => isKorean ? `${n}개의 문장을 공개로 업로드합니다.` : `Upload ${n} public sentences.`,
-    uploadConfirmPrivate: (n: number) => isKorean ? `${n}개의 문장을 비공개로 업로드합니다.` : `Upload ${n} private sentences.`,
-    uploadSuccess: (n: number) => isKorean ? `${n}개의 문장 업로드에 성공했습니다.` : `${n} sentences uploaded successfully.`,
-    uploadFailed: isKorean ? '업로드에 실패했습니다.' : 'Upload failed.',
-    similarPublic: isKorean ? '공개 문장 내에 유사한 문장이 존재합니다.' : 'A similar public sentence already exists.',
-    similarMy: isKorean ? '내 문장 내에 유사한 문장이 존재합니다.' : 'A similar sentence already exists in your sentences.',
-    editSentenceFailed: isKorean ? '문장 수정에 실패했습니다.' : 'Failed to edit sentence.',
-    deleteSentenceFailed: isKorean ? '문장 삭제에 실패했습니다.' : 'Failed to delete sentence.',
-    makePublicFailed: isKorean ? '공개 전환에 실패했습니다.' : 'Failed to make public.',
-    cancelPublicFailed: isKorean ? '공개 취소에 실패했습니다.' : 'Failed to cancel public.',
-    deleteReportFailed: isKorean ? '신고 삭제에 실패했습니다.' : 'Failed to delete report.',
+    uploadTitle: l('문장 업로드', '文章アップロード', 'Upload Sentences'),
+    uploadTypeHint: l('각 문장마다 공개/비공개를 선택할 수 있습니다.', '各文章ごとに公開/非公開を選択できます。', 'You can set each sentence as public or private.'),
+    uploadTooltipPublic: l('관리자 승인 후 모든 사용자에게 노출됩니다.', '管理者の承認後、すべてのユーザーに公開されます。', 'Visible to all users after admin approval.'),
+    uploadTooltipPrivate: l('본인만 사용할 수 있습니다.', '自分だけが使用できます。', 'Only visible to you.'),
+    sentencePlaceholder: (min: number, max: number) => l(`문장을 입력하세요 (${min}-${max}자)`, `文章を入力してください（${min}〜${max}文字）`, `Enter a sentence (${min}-${max} characters)`),
+    authorPlaceholder: l('저자 (선택)', '著者（任意）', 'Author (optional)'),
+    addSentence: (cur: number, max: number) => l(`문장 추가 (${cur}/${max})`, `文章追加（${cur}/${max}）`, `Add sentence (${cur}/${max})`),
+    maxEntries: (max: number) => l(`최대 ${max}개`, `最大${max}件`, `Max ${max}`),
+    upload: l('업로드', 'アップロード', 'Upload'),
+    uploading: l('업로드 중...', 'アップロード中...', 'Uploading...'),
+    minSentenceLength: (min: number) => l(`문장은 ${min}자 이상이어야 합니다.`, `文章は${min}文字以上必要です。`, `Sentence must be at least ${min} characters.`),
+    maxSentenceLength: (max: number) => l(`문장은 ${max}자 이하여야 합니다.`, `文章は${max}文字以下にしてください。`, `Sentence must be at most ${max} characters.`),
+    maxAuthorLength: (max: number) => l(`저자는 ${max}자 이하여야 합니다.`, `著者は${max}文字以下にしてください。`, `Author must be at most ${max} characters.`),
+    enterAtLeastOne: l('최소 1개의 문장을 입력해주세요.', '少なくとも1つの文章を入力してください。', 'Please enter at least one sentence.'),
+    uploadConfirmBoth: (pub: number, priv: number) => l(`공개 ${pub}개, 비공개 ${priv}개의 문장을 업로드합니다.`, `公開${pub}件、非公開${priv}件の文章をアップロードします。`, `Upload ${pub} public and ${priv} private sentences.`),
+    uploadConfirmPublic: (n: number) => l(`${n}개의 문장을 공개로 업로드합니다.`, `${n}件の文章を公開でアップロードします。`, `Upload ${n} public sentences.`),
+    uploadConfirmPrivate: (n: number) => l(`${n}개의 문장을 비공개로 업로드합니다.`, `${n}件の文章を非公開でアップロードします。`, `Upload ${n} private sentences.`),
+    uploadSuccess: (n: number) => l(`${n}개의 문장 업로드에 성공했습니다.`, `${n}件の文章をアップロードしました。`, `${n} sentences uploaded successfully.`),
+    uploadFailed: l('업로드에 실패했습니다.', 'アップロードに失敗しました。', 'Upload failed.'),
+    similarPublic: l('공개 문장 내에 유사한 문장이 존재합니다.', '公開文章に類似する文章が既に存在します。', 'A similar public sentence already exists.'),
+    similarMy: l('내 문장 내에 유사한 문장이 존재합니다.', 'マイ文章に類似する文章が既に存在します。', 'A similar sentence already exists in your sentences.'),
+    editSentenceFailed: l('문장 수정에 실패했습니다.', '文章の編集に失敗しました。', 'Failed to edit sentence.'),
+    deleteSentenceFailed: l('문장 삭제에 실패했습니다.', '文章の削除に失敗しました。', 'Failed to delete sentence.'),
+    makePublicFailed: l('공개 전환에 실패했습니다.', '公開への切り替えに失敗しました。', 'Failed to make public.'),
+    cancelPublicFailed: l('공개 취소에 실패했습니다.', '公開の取り消しに失敗しました。', 'Failed to cancel public.'),
+    deleteReportFailed: l('신고 삭제에 실패했습니다.', '報告の削除に失敗しました。', 'Failed to delete report.'),
 
     // 기록 페이지
-    myTypingRecords: isKorean ? '내 타이핑 기록' : 'My Typing Records',
-    statsLoadFailed: isKorean ? '기록을 불러오는데 실패했습니다.' : 'Failed to load records.',
-    refreshCooldown: isKorean ? '새로고침은 1분에 한 번만 가능합니다.' : 'Refresh is available once per minute.',
-    refreshFailed: isKorean ? '새로고침에 실패했습니다.' : 'Refresh failed.',
+    myTypingRecords: l('내 타이핑 기록', 'マイタイピング記録', 'My Typing Records'),
+    statsLoadFailed: l('기록을 불러오는데 실패했습니다.', '記録の読み込みに失敗しました。', 'Failed to load records.'),
+    refreshCooldown: l('새로고침은 1분에 한 번만 가능합니다.', '更新は1分に1回のみ可能です。', 'Refresh is available once per minute.'),
+    refreshFailed: l('새로고침에 실패했습니다.', '更新に失敗しました。', 'Refresh failed.'),
 
     // 종합 통계
-    recent7DayAvg: isKorean ? '최근 7일 평균' : '7-Day Average',
-    best: isKorean ? '최고' : 'Best',
-    accuracy: isKorean ? '정확도' : 'Accuracy',
-    practiceTime: isKorean ? '연습 시간' : 'Practice Time',
-    practiceCount: isKorean ? '연습 횟수' : 'Practices',
-    totalAverage: isKorean ? '전체 평균' : 'Overall Avg',
-    avgReset: isKorean ? '평균 초기화' : 'Avg Resets',
-    times: isKorean ? '회' : '',
+    recent7DayAvg: l('최근 7일 평균', '直近7日間の平均', '7-Day Average'),
+    best: l('최고', '最高', 'Best'),
+    accuracy: l('정확도', '正確度', 'Accuracy'),
+    practiceTime: l('연습 시간', '練習時間', 'Practice Time'),
+    practiceCount: l('연습 횟수', '練習回数', 'Practices'),
+    totalAverage: l('전체 평균', '全体平均', 'Overall Avg'),
+    avgReset: l('평균 초기화', '平均リセット', 'Avg Resets'),
+    times: l('회', '回', ''),
     formatTime: (min: number) => {
-        if (!min || min <= 0) return isKorean ? '0분' : '0m';
+        if (!min || min <= 0) return l('0분', '0分', '0m');
         const h = Math.floor(min / 60);
         const m = Math.round(min % 60);
-        if (isKorean) return h > 0 ? `${h}시간 ${m}분` : `${m}분`;
+        if (lang === 'ko') return h > 0 ? `${h}시간 ${m}분` : `${m}분`;
+        if (lang === 'ja') return h > 0 ? `${h}時間${m}分` : `${m}分`;
         return h > 0 ? `${h}h ${m}m` : `${m}m`;
     },
 
     // 에러 컨텍스트
-    errorConfirm: isKorean ? '확인' : 'OK',
+    errorConfirm: l('확인', '確認', 'OK'),
 
     // 일별 추이 차트
-    dailyTrend: isKorean ? '일별 추이' : 'Daily Trend',
-    accuracyTab: isKorean ? '정확도' : 'Accuracy',
-    days: (n: number) => isKorean ? `${n}일` : `${n}d`,
-    noData: isKorean ? '데이터가 없습니다.' : 'No data available.',
+    dailyTrend: l('일별 추이', '日別推移', 'Daily Trend'),
+    accuracyTab: l('정확도', '正確度', 'Accuracy'),
+    days: (n: number) => l(`${n}일`, `${n}日`, `${n}d`),
+    noData: l('데이터가 없습니다.', 'データがありません。', 'No data available.'),
     formatPopupTitle: (dateStr: string) => {
         const parts = dateStr.split('-');
-        if (isKorean) return parts[0] + '년 ' + parseInt(parts[1]) + '월 ' + parseInt(parts[2]) + '일';
+        if (lang === 'ko') return parts[0] + '년 ' + parseInt(parts[1]) + '월 ' + parseInt(parts[2]) + '일';
+        if (lang === 'ja') return parts[0] + '年' + parseInt(parts[1]) + '月' + parseInt(parts[2]) + '日';
         return MONTH_NAMES[parseInt(parts[1]) - 1] + ' ' + parseInt(parts[2]) + ', ' + parts[0];
     },
-    attempts: isKorean ? '연습 횟수' : 'Attempts',
-    avgSpeed: isKorean ? '평균 타자 속도' : 'Avg Speed',
-    bestSpeed: isKorean ? '최고 타자 속도' : 'Best Speed',
-    avgAccuracy: isKorean ? '평균 정확도' : 'Avg Accuracy',
-    avgResetCount: isKorean ? '평균 초기화 횟수' : 'Avg Resets',
-    countUnit: isKorean ? '회' : '',
+    attempts: l('연습 횟수', '練習回数', 'Attempts'),
+    avgSpeed: l('평균 타자 속도', '平均タイピング速度', 'Avg Speed'),
+    bestSpeed: l('최고 타자 속도', '最高タイピング速度', 'Best Speed'),
+    avgAccuracy: l('평균 정확도', '平均正確度', 'Avg Accuracy'),
+    avgResetCount: l('평균 초기화 횟수', '平均リセット回数', 'Avg Resets'),
+    countUnit: l('회', '回', ''),
 
     // 오타 통계
-    typoTop10: isKorean ? '자주 틀리는 글자 TOP 10' : 'Most Missed Characters TOP 10',
-    noTypoData: isKorean ? '오타 데이터가 없습니다.' : 'No typo data available.',
-    typoDetailTitle: isKorean ? '오타 상세' : 'Typo Details',
-    noDetailData: isKorean ? '상세 데이터가 없습니다.' : 'No detail data available.',
+    typoTop10: l('자주 틀리는 글자 TOP 10', 'よく間違える文字 TOP 10', 'Most Missed Characters TOP 10'),
+    noTypoData: l('오타 데이터가 없습니다.', '誤字データがありません。', 'No typo data available.'),
+    typoDetailTitle: l('오타 상세', '誤字の詳細', 'Typo Details'),
+    noDetailData: l('상세 데이터가 없습니다.', '詳細データがありません。', 'No detail data available.'),
 
     // 기능 가이드
-    featureGuideTitle: isKorean ? '이런 기능이 있어요!' : 'Check out these features!',
-    featureGuideDesc: isKorean
-        ? '로그인하면 원하는 문장을 직접 업로드하고, 타이핑 기록과 오타 분석을 확인할 수 있어요.'
-        : 'Sign in to upload your own sentences and track your typing speed, accuracy, and typo patterns.',
-    featureGuideConfirm: isKorean ? '확인' : 'Got it',
+    featureGuideTitle: l('이런 기능이 있어요!', 'こんな機能があります！', 'Check out these features!'),
+    featureGuideDesc: l(
+        '로그인하면 원하는 문장을 직접 업로드하고, 타이핑 기록과 오타 분석을 확인할 수 있어요.',
+        'ログインすると、好きな文章をアップロードしたり、タイピング記録や誤字分析を確認できます。',
+        'Sign in to upload your own sentences and track your typing speed, accuracy, and typo patterns.'
+    ),
+    featureGuideConfirm: l('확인', 'OK', 'Got it'),
 
     // 결과 팝업
-    popupLoginPrompt: isKorean ? '이 기록을 저장할까요?' : 'Save this record?',
-    popupCumulativeAvg: isKorean ? 'Overall avg' : 'Overall avg',
-    popupViewStats: isKorean ? '자세한 통계 보기 →' : 'View detailed stats →',
+    popupLoginPrompt: l('이 기록을 저장할까요?', 'この記録を保存しますか？', 'Save this record?'),
+    popupCumulativeAvg: l('Overall avg', 'Overall avg', 'Overall avg'),
+    popupViewStats: l('자세한 통계 보기 →', '詳しい統計を見る →', 'View detailed stats →'),
 
-    // 모드 전환 (영어 고정)
-    sentenceMode: isKorean ? '문장 연습' : 'Sentence',
-    wordMode: isKorean ? '단어 연습' : 'Word',
+    // 모드 전환
+    sentenceMode: l('문장 연습', '文章練習', 'Sentence'),
+    wordMode: l('단어 연습', '単語練習', 'Word'),
 
     // 단어 모드 설정 (영어 고정)
     difficulty: 'Difficulty',
@@ -232,14 +238,14 @@ const translations = {
     },
 
     // 업데이트 팝업
-    updateNotice: isKorean ? '업데이트 안내' : 'Update',
-    updateHistory: isKorean ? '업데이트 내역' : 'Update History',
-    updateClose: isKorean ? '확인' : 'OK',
-    updateViewHistory: isKorean ? '지난 업데이트 보기' : 'View past updates',
-    updateDontShow: isKorean ? '다시 보지 않기' : 'Don\'t show again',
-    updateNotices: isKorean ? '공지 사항' : 'Notices',
-    updateFeatures: isKorean ? '새로운 기능' : 'New features',
-    updateImprovements: isKorean ? '개선사항' : 'Improvements',
+    updateNotice: l('업데이트 안내', 'アップデート情報', 'Update'),
+    updateHistory: l('업데이트', 'アップデート', 'Updates'),
+    updateClose: l('확인', '確認', 'OK'),
+    updateViewHistory: l('지난 업데이트 보기', '過去のアップデートを見る', 'View past updates'),
+    updateDontShow: l('다시 보지 않기', '次から表示しない', 'Don\'t show again'),
+    updateNotices: l('공지 사항', 'お知らせ', 'Notices'),
+    updateFeatures: l('새로운 기능', '新機能', 'New features'),
+    updateImprovements: l('개선사항', '改善点', 'Improvements'),
 } as const;
 
 type TranslationKey = keyof typeof translations;

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -203,8 +203,8 @@ const translations = {
     popupViewStats: isKorean ? '자세한 통계 보기 →' : 'View detailed stats →',
 
     // 모드 전환 (영어 고정)
-    sentenceMode: 'Sentence',
-    wordMode: 'Word',
+    sentenceMode: isKorean ? '문장 연습' : 'Sentence',
+    wordMode: isKorean ? '단어 연습' : 'Word',
 
     // 단어 모드 설정 (영어 고정)
     difficulty: 'Difficulty',

--- a/tp-react/src/utils/sessionUtils.ts
+++ b/tp-react/src/utils/sessionUtils.ts
@@ -1,0 +1,9 @@
+import {Session_Typing_Count} from '@/const/config.const';
+
+export function incrementSessionTypingCount(): number {
+    const count = parseInt(sessionStorage.getItem(Session_Typing_Count) || '0', 10);
+    const newCount = count + 1;
+    sessionStorage.setItem(Session_Typing_Count, String(newCount));
+    window.dispatchEvent(new CustomEvent('typing-count-update', {detail: newCount}));
+    return newCount;
+}

--- a/tp-react/typing-practice-prototype.html
+++ b/tp-react/typing-practice-prototype.html
@@ -5,35 +5,31 @@
     <title>Typing Practice</title>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
     <link rel="stylesheet" href="prototype.css">
+    <script>
+        if (localStorage.getItem('Typing-Practice-darkMode') === 'true') {
+            document.documentElement.classList.add('dark-pending');
+        }
+    </script>
+    <style>
+        .dark-pending body, .dark-pending #body { background-color: #1a1a1e; }
+        .dark-pending .info-controls { background: #26262c; }
+        .dark-pending .top-nav { background-color: #222228; border-bottom-color: #3e3e46; }
+    </style>
 
 </head>
 <body id="body">
-<!-- 좌측 상단 컨트롤 -->
-<div class="top-left-controls">
-    <div class="font-size-slider-container">
-        <label class="font-size-label" id="fontSizeLabel" for="fontSizeSlider">Font Size</label>
-        <input type="range" class="font-size-slider" id="fontSizeSlider" min="0" max="100" value="50"/>
-    </div>
-    <div class="mode-toggle-container">
-        <span class="mode-toggle-label" id="modeLabel">Compact</span>
-        <div class="mode-toggle" id="modeToggle">
-            <div class="mode-toggle-knob"></div>
+<!-- 상단 네비게이션 바 -->
+<nav class="top-nav" id="topNav">
+    <div class="nav-left">
+        <h1 class="nav-logo" id="titleTitle">Typing Practice</h1>
+        <div class="nav-links">
+            <button class="nav-link active" id="navSentence">문장 연습</button>
+            <button class="nav-link" id="navWord">단어 연습<span class="nav-beta">beta</span></button>
+            <button class="nav-link" id="navStats">통계</button>
+            <button class="nav-link" id="navUpdates">업데이트</button>
         </div>
     </div>
-</div>
-
-<!-- 우측 상단 공지 아이콘 -->
-<i class="fa-solid fa-bullhorn notice-icon" id="iconNotice" title="업데이트 안내"></i>
-
-<!-- 헤더 -->
-<div class="head">
-    <h1 class="title-title" id="titleTitle">Typing Practice</h1>
-    <div class="head-right">
-        <button class="header-btn" id="uploadBtn">
-            <i class="fa-solid fa-upload"></i>
-            <span>문장 업로드</span>
-        </button>
-
+    <div class="nav-right">
         <!-- 로그인 전 -->
         <button class="header-btn" id="loginBtn">
             <i class="fa-solid fa-user"></i>
@@ -52,17 +48,13 @@
                     <i class="fa-solid fa-file-lines"></i>
                     <span>내 문장</span>
                 </button>
-                <button class="dropdown-item" id="statsBtn">
-                    <i class="fa-solid fa-chart-line"></i>
-                    <span>통계</span>
+                <button class="dropdown-item" id="myReportsBtn">
+                    <i class="fa-solid fa-flag"></i>
+                    <span>신고 내역</span>
                 </button>
                 <button class="dropdown-item" id="settingsBtn">
                     <i class="fa-solid fa-gear"></i>
                     <span>설정</span>
-                </button>
-                <button class="dropdown-item" id="myReportsBtn">
-                    <i class="fa-solid fa-flag"></i>
-                    <span>신고 내역</span>
                 </button>
                 <div class="dropdown-divider"></div>
                 <button class="dropdown-item" id="logoutBtn">
@@ -75,51 +67,50 @@
         <i class="fa-regular fa-sun fa-xl dark-mode-icon" id="iconSun"></i>
         <i class="fa-regular fa-moon fa-xl dark-mode-icon display-none" id="iconMoon"></i>
     </div>
-</div>
+</nav>
 
 <!-- 정보 영역 -->
 <div class="info-background">
-    <div class="info-settings">
-        <div class="result-period-container">
-            <button class="result-period-btn" id="resultPeriodDown">
-                <i class="fa-solid fa-chevron-down"></i>
+    <div class="info-row">
+        <div class="info-stats">
+            <div class="info-stat">
+                <span class="info-stat-label">CURRENT CPM</span>
+                <span class="info-stat-value current">324</span>
+            </div>
+            <div class="info-stat">
+                <span class="info-stat-label">HIGHEST CPM</span>
+                <span class="info-stat-value">512</span>
+            </div>
+            <div class="info-stat-sep"></div>
+            <div class="info-stat">
+                <span class="info-stat-label">ACC</span>
+                <span class="info-stat-value">96</span>
+            </div>
+            <div class="info-stat">
+                <span class="info-stat-label">CNT</span>
+                <span class="info-stat-value">7</span>
+            </div>
+        </div>
+        <div class="info-controls" id="infoControls">
+            <div class="info-controls-inner" id="infoControlsInner">
+                <span class="info-tt-label">Tt</span>
+                <input type="range" class="info-slider" id="fontSizeSlider" min="0" max="100" value="50"/>
+                <div class="info-control-sep"></div>
+                <div class="info-interval-control">
+                    <button class="info-period-btn" id="resultPeriodDown"><i class="fa-solid fa-chevron-down"></i></button>
+                    <span class="info-interval-value" id="resultPeriodValue">5</span>
+                    <button class="info-period-btn" id="resultPeriodUp"><i class="fa-solid fa-chevron-up"></i></button>
+                </div>
+                <div class="info-control-sep"></div>
+                <span class="info-control-label" id="modeLabel">Compact</span>
+                <div class="mode-toggle" id="modeToggle">
+                    <div class="mode-toggle-knob"></div>
+                </div>
+            </div>
+            <button class="info-controls-toggle" id="infoControlsToggle">
+                <i class="fa-solid fa-chevron-right" id="infoControlsToggleIcon"></i>
             </button>
-            <span class="result-period-value" id="resultPeriodValue">5</span>
-            <button class="result-period-btn" id="resultPeriodUp">
-                <i class="fa-solid fa-chevron-up"></i>
-            </button>
         </div>
-    </div>
-
-    <div class="info-CPMs">
-        <div>
-            <span class="CPM-text">Current CPM</span>
-            <span class="CPM-value">8</span>
-        </div>
-        <div>
-            <span class="CPM-text">Highest CPM</span>
-            <span class="CPM-value">706</span>
-        </div>
-    </div>
-
-    <div class="info-averages" id="infoAverages">
-        <div>
-            <span class="average-label">CPM</span>
-            <span class="average-value">706</span>
-        </div>
-        <div>
-            <span class="average-label">ACC</span>
-            <span class="average-value">100</span>
-        </div>
-        <div>
-            <span class="average-label">CNT</span>
-            <span class="average-value">1</span>
-        </div>
-    </div>
-    <div class="averages-toggle-container">
-        <button class="averages-toggle-btn" id="averagesToggleBtn">
-            <i class="fa-solid fa-chevron-up" id="averagesToggleIcon"></i>
-        </button>
     </div>
 </div>
 
@@ -129,14 +120,18 @@
         <!-- 문장 소스 선택 -->
         <div class="quote-source-selector">
             <button class="quote-source-btn active" id="quoteSourceAll">
-                <i class="fa-solid fa-globe"></i>
                 <span>전체 문장</span>
             </button>
             <button class="quote-source-btn" id="quoteSourceMy">
-                <i class="fa-solid fa-user"></i>
                 <span>내 문장만</span>
             </button>
         </div>
+        <button class="upload-inline-btn" id="uploadBtn">
+            <i class="fa-solid fa-plus"></i>
+            <span>업로드</span>
+        </button>
+    </div>
+    <div class="quote-sub-row">
         <div class="author-container">
             <span class="author-text">웰러비</span>
             <!-- 더보기 메뉴 -->
@@ -178,15 +173,32 @@
 <div class="spacer"></div>
 <a class="contact" href="#">Contact</a>
 
-<!-- 업데이트 공지 팝업 -->
+<!-- 업데이트 알림 팝업 (첫 진입 시) -->
 <div class="update-popup-overlay display-none" id="updatePopupOverlay">
     <div class="update-popup" id="updatePopup">
         <div class="update-popup-header">
-            <span class="update-popup-title" id="updatePopupTitle">🎉 업데이트 안내</span>
+            <span class="update-popup-title">업데이트 안내</span>
         </div>
-        <div id="updateContent"></div>
+        <div id="updatePopupContent"></div>
         <button class="update-popup-close" id="updatePopupClose">확인</button>
-        <button class="update-popup-history-btn display-none" id="updateHistoryBtn">지난 업데이트 보기</button>
+    </div>
+</div>
+
+<!-- 업데이트 페이지 -->
+<div class="updates-page display-none" id="updatesPage">
+    <div class="updates-container">
+        <div class="updates-header">
+            <h1 class="updates-title">업데이트 내역</h1>
+        </div>
+        <div class="updates-list" id="updatesContent">
+            <!-- JS로 렌더링 -->
+        </div>
+        <div class="updates-footer">
+            <button class="updates-back-btn" id="updatesBackBtn">
+                <i class="fa-solid fa-arrow-left"></i>
+                <span>돌아가기</span>
+            </button>
+        </div>
     </div>
 </div>
 


### PR DESCRIPTION
## 개요
상단 네비게이션과 주요 UI 영역을 재설계하고, i18n 일본어 지원을 추가하며, 비로그인 사용자 전환율 개선을 위한 로그인 유도 및 GDPR 동의 배너를 인라인으로 도입합니다.

## 변경 사항

### UI 리디자인
- 상단 고정 네비게이션 바 (문장 연습 / 단어 연습 / 기록 / 업데이트)
- Info 영역: CPM/ACC/CNT 수평 통합, 우측 pill (Tt 슬라이더, ResultPeriod, ModeToggle), 접기/펼치기
- WordInfo: 실시간 WPM, PROGRESS, Tt/난이도/단어수 pill
- Quote: 탭 스타일 소스 선택, 저자 분리, 업로드 버튼 이동
- Updates 페이지: /updates 라우트, 카드 형태
- 다크모드 색상 통일 (배경, primary, placeholder, 테두리)

### i18n 일본어 지원
- 언어 감지를 ko/ja/en 3단계 분기로 변경, `l(ko, ja, en)` 헬퍼 함수 도입
- 전체 UI 번역 키 및 업데이트 내역(v1.0.0~v1.4.0) 일본어 추가

### 로그인 유도
- 세션 타이핑 3회 완료 후 비로그인 사용자에게 입력 영역 하단에 Google 로그인 유도 표시
- 세션 단위 닫기 지원

### GDPR 동의 배너
- 기존 오버레이 → 입력 영역 하단 인라인 div로 전환
- 타이핑 3회 후 지연 노출, 동의 전까지 데이터 수집 안 함
- 로그인 유도와 겹침 표시: 동의 응답 시 로그인 유도가 바로 노출
- 문장 연습 / 단어 연습 모두 지원

### 통계 차트
- 팝업 위치를 getBoundingClientRect() 기반으로 데이터 점 좌하단에 고정