### PR TITLE
fix: 문장 셔플 seed 범위 확장

### DIFF
--- a/tp-react/src/Context/QuoteContext.tsx
+++ b/tp-react/src/Context/QuoteContext.tsx
@@ -43,7 +43,7 @@ const QUOTE_SOURCE = {
     MY: 'my' as const,
 };
 
-const generateSeed = () => Math.round((Math.random() * 2 - 1) * 1000) / 1000;
+const generateSeed = () => Math.floor(Math.random() * 1_999_999_999) - 999_999_999;
 
 const shuffleArray = <T, >(array: T[]): T[] => {
     const shuffled = [...array];


### PR DESCRIPTION
## 주요 내용
- seed 생성 범위를 [-1.0, 1.0] 소수에서 [-999999999, 999999999] 정수로 변경
- 백엔드 seed 검증 범위 확장에 대응하여 문장 노출 편향 완화