### PR TITLE
fix: 문장 셔플 순서가 무시되는 버그 수정

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
@@ -19,9 +19,9 @@ import com.typingpractice.typing_practice_be.quote.service.difficulty.QuoteProfi
 import com.typingpractice.typing_practice_be.quote.statistics.domain.GlobalQuoteStatistics;
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsService;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -73,8 +73,13 @@ public class QuoteService {
 		List<Long> slicedIds = ids.subList(from, to);
 		List<Quote> fetched = quoteRepository.findByIds(slicedIds, language);
 
-		boolean hasNext = fetched.size() > query.getCount();
-		List<Quote> content = hasNext ? fetched.subList(0, query.getCount()) : fetched;
+		// 셔플 순서 복원
+		Map<Long, Quote> map =
+						fetched.stream().collect(Collectors.toMap(Quote::getId, Function.identity()));
+		List<Quote> ordered = slicedIds.stream().map(map::get).filter(Objects::nonNull).toList();
+
+		boolean hasNext = ordered.size() > query.getCount();
+		List<Quote> content = hasNext ? ordered.subList(0, query.getCount()) : ordered;
 
 		return new PageResult<>(content, query.getPage(), query.getCount(), hasNext);
 	}


### PR DESCRIPTION
## 주요 내용
- findByIds의 IN 절이 순서를 보장하지 않아 셔플 결과가 무시되던 버그 수정
- DB 조회 후 원래 셔플 순서로 재정렬하여 문장 노출 편향 해소

## 세부 내용
### QuoteService.findRandomPublicQuotes
- DB 조회 결과를 Map으로 변환 후 slicedIds 순서에 맞게 재정렬
- 기존: seed별로 셔플해도 IN 절이 항상 ID 오름차순 반환 → 소수 문장에 편향
- 수정: 셔플 순서 복원으로 seed별 고유한 문장 순서 보장