### PR TITLE
chore: v1.4.1 업데이트 내역 추가

### DIFF
--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -36,9 +36,26 @@ export function localize(item: LocalizedText): string {
 
 export const updateHistory: UpdateEntry[] = [
     {
+        version: "1.4.1",
+        date: "2026-04-07",
+        showPopup: true,
+        hidden: false,
+        features: [
+            {ko: "상단 네비게이션 바 디자인 변경", ja: "上部ナビゲーションバーのデザイン変更", en: "Redesigned top navigation bar"},
+            {ko: "업데이트 내역 페이지 추가", ja: "アップデート履歴ページ追加", en: "Added update history page"},
+            {ko: "타이핑 속도/정확도 표시 및 설정 영역 디자인 변경", ja: "タイピング速度・正確度表示と設定エリアのデザイン変更", en: "Redesigned typing stats and settings area"},
+            {ko: "단어 연습에 실시간 WPM, 난이도, 단어수, 폰트 크기 설정 추가", ja: "単語練習にリアルタイムWPM・難易度・単語数・フォントサイズ設定を追加", en: "Added real-time WPM, difficulty, word count, font size settings to word mode"},
+            {ko: "문장 소스 선택 탭 디자인 변경", ja: "文章ソース選択タブのデザイン変更", en: "Redesigned sentence source selector tabs"},
+        ],
+        improvements: [
+            {ko: "문장 셔플 알고리즘 개선 — 문장 노출 편향 해소", ja: "文章シャッフルアルゴリズム改善 — 文章の偏り解消", en: "Improved sentence shuffle algorithm — resolved exposure bias"},
+            {ko: "다크모드 배경 및 보라색(primary) 색상 개선", ja: "ダークモードの背景とプライマリカラーの改善", en: "Improved dark mode background and primary colors"},
+        ]
+    },
+    {
         version: "1.4.0",
         date: "2026-04-06",
-        showPopup: true,
+        showPopup: false,
         hidden: false,
         features: [
             {ko: "상단 네비게이션 바 디자인 변경", ja: "上部ナビゲーションバーのデザイン変更", en: "Redesigned top navigation bar"},


### PR DESCRIPTION
## 주요 내용
- v1.4.1 항목 추가 (v1.4.0 주요 기능 + 셔플 개선 통합)
- v1.4.0 showPopup 비활성화

## 세부 내용
### updateHistory.ts
- v1.4.1: v1.4.0 features 병합 + 문장 셔플 편향 개선 항목 추가
- v1.4.0: showPopup false 처리 (새벽 배포로 실사용자 노출 없었으므로 v1.4.1에서 통합 노출)