### PR TITLE
refactor: Google OAuth 로그인 팝업 → 리다이렉트 방식 전환

### DIFF
--- a/tp-react/package-lock.json
+++ b/tp-react/package-lock.json
@@ -17,8 +17,8 @@
         "react-router-dom": "^7.13.0"
       },
       "devDependencies": {
-        "@types/react": "^19.2.11",
-        "@types/react-dom": "^19.2.3",
+        "@types/react": "18.3.28",
+        "@types/react-dom": "18.3.7",
         "@vitejs/plugin-react": "^4.3.4",
         "typescript": "^5.9.3",
         "vite": "^6.0.7"
@@ -1217,24 +1217,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
-      "version": "19.2.11",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.11.tgz",
-      "integrity": "sha512-tORuanb01iEzWvMGVGv2ZDhYZVeRMrw453DCSAIn/5yvcSVnMoUMTyf33nQJLahYEnv9xqrTNbgz4qY5EfSh0g==",
+      "version": "18.3.28",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
-      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.2.0"
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@vercel/analytics": {

--- a/tp-react/package.json
+++ b/tp-react/package.json
@@ -19,8 +19,8 @@
     "typecheck": "tsc --noEmit"
   },
   "devDependencies": {
-    "@types/react": "^19.2.11",
-    "@types/react-dom": "^19.2.3",
+    "@types/react": "18.3.28",
+    "@types/react-dom": "18.3.7",
     "@vitejs/plugin-react": "^4.3.4",
     "typescript": "^5.9.3",
     "vite": "^6.0.7"

--- a/tp-react/src/App.jsx
+++ b/tp-react/src/App.jsx
@@ -16,6 +16,7 @@ import MyQuotes from "./pages/MyQuotes/MyQuotes";
 import MyReports from "./pages/MyReports/MyReports";
 import Stats from "./pages/Stats/Stats";
 import Updates from "./pages/Updates/Updates";
+import OAuthCallback from "./pages/OAuthCallback/OAuthCallback";
 import PrivacyPolicy from "./pages/PrivacyPolicy/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService/TermsOfService";
 import {Analytics} from "@vercel/analytics/react";
@@ -38,6 +39,7 @@ function App() {
                   <Route path="/quote/report" element={<MyReports />} />
                   <Route path="/stats" element={<Stats />} />
                   <Route path="/updates" element={<Updates />} />
+                  <Route path="/oauth/callback" element={<OAuthCallback />} />
                   <Route path="/privacy" element={<PrivacyPolicy />} />
                   <Route path="/terms" element={<TermsOfService />} />
                   <Route path="*" element={<Navigate to="/" replace />} />

--- a/tp-react/src/components/Head/Head.jsx
+++ b/tp-react/src/components/Head/Head.jsx
@@ -7,9 +7,7 @@ import ProfileDropdown from "../ProfileDropdown/ProfileDropdown";
 import LoadingSpinner from "../LoadingSpinner/LoadingSpinner";
 import NicknamePopup from "../NicknamePopup/NicknamePopup";
 import {useAuth} from "../../Context/AuthContext";
-import {useError} from "../../Context/ErrorContext";
 import {useGoogleLogin} from "@react-oauth/google";
-import {loginWithGoogle} from "@/utils/authApi.ts";
 import {t} from "@/utils/i18n.ts";
 import {Storage_Last_Mode} from "@/const/config.const.ts";
 import FeatureGuide from "../FeatureGuide/FeatureGuide";
@@ -25,7 +23,6 @@ const isUuidFormat = (str) => {
 const Head = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const {showError} = useError();
     const {user, accessToken, refreshToken, isLoading, setIsLoading, login, loginTrigger} = useAuth();
     const [showNicknamePopup, setShowNicknamePopup] = useState(false);
     const prevLoginTriggerRef = useRef(loginTrigger);
@@ -40,36 +37,8 @@ const Head = () => {
 
     const googleLogin = useGoogleLogin({
         flow: 'auth-code',
-        onSuccess: async (codeResponse) => {
-            setIsLoading(true);
-            try {
-                const response = await loginWithGoogle(codeResponse.code);
-
-                const userData = response.data;
-
-                login({
-                    nickname: userData.nickname,
-                    email: userData.email,
-                    role: userData.role,
-                    createdAt: userData.createdAt,
-                    isNewMember: userData.newMember,
-                }, userData.accessToken, userData.refreshToken);
-
-                if (isUuidFormat(userData.nickname)) {
-                    setShowNicknamePopup(true);
-                }
-
-                setIsLoading(false);
-            } catch (error) {
-                console.error('로그인 실패:', error);
-                showError(t('loginFailed'));
-                setIsLoading(false);
-            }
-        },
-        onError: (error) => {
-            console.error('구글 로그인 실패:', error);
-            showError(t('googleLoginFailed'));
-        },
+        ux_mode: 'redirect',
+        redirect_uri: import.meta.env.VITE_GOOGLE_REDIRECT_URI,
     });
 
     // 다른 컴포넌트에서 로그인 트리거 시 googleLogin 호출

--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -36,9 +36,18 @@ export function localize(item: LocalizedText): string {
 
 export const updateHistory: UpdateEntry[] = [
     {
-        version: "1.4.1",
+        version: "1.4.2",
         date: "2026-04-07",
         showPopup: true,
+        hidden: false,
+        improvements: [
+            {ko: "일부 브라우저 환경에서 로그인 및 기록 조회가 동작하지 않던 문제 수정", ja: "一部のブラウザ環境でログインと記録照会が動作しなかった問題を修正", en: "Fixed login and stats not working in some browser environments"},
+        ]
+    },
+    {
+        version: "1.4.1",
+        date: "2026-04-07",
+        showPopup: false,
         hidden: false,
         features: [
             {ko: "상단 네비게이션 바 디자인 변경", ja: "上部ナビゲーションバーのデザイン変更", en: "Redesigned top navigation bar"},

--- a/tp-react/src/pages/OAuthCallback/OAuthCallback.tsx
+++ b/tp-react/src/pages/OAuthCallback/OAuthCallback.tsx
@@ -1,0 +1,63 @@
+import {useEffect, useRef} from 'react';
+import {useNavigate} from 'react-router-dom';
+import {useAuth} from '@/Context/AuthContext.tsx';
+import {useError} from '@/Context/ErrorContext';
+import {loginWithGoogle} from '@/utils/authApi.ts';
+import {t} from '@/utils/i18n.ts';
+import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
+
+const OAuthCallback = () => {
+    const navigate = useNavigate();
+    const {login} = useAuth();
+    const {showError} = useError();
+    const processedRef = useRef(false);
+
+    useEffect(() => {
+        if (processedRef.current) return;
+        processedRef.current = true;
+
+        const params = new URLSearchParams(window.location.search);
+        const code = params.get('code');
+        const error = params.get('error');
+
+        if (error) {
+            console.error('Google OAuth error:', error);
+            showError(t('googleLoginFailed'));
+            navigate('/', {replace: true});
+            return;
+        }
+
+        if (!code) {
+            showError(t('googleLoginFailed'));
+            navigate('/', {replace: true});
+            return;
+        }
+
+        const processLogin = async () => {
+            try {
+                const response = await loginWithGoogle(code);
+                const userData = response.data;
+
+                login({
+                    nickname: userData.nickname,
+                    email: userData.email,
+                    role: userData.role,
+                    createdAt: userData.createdAt,
+                    isNewMember: userData.newMember,
+                }, userData.accessToken, userData.refreshToken);
+
+                navigate('/', {replace: true});
+            } catch (err) {
+                console.error('로그인 실패:', err);
+                showError(t('loginFailed'));
+                navigate('/', {replace: true});
+            }
+        };
+
+        processLogin();
+    }, []);
+
+    return <LoadingSpinner/>;
+};
+
+export default OAuthCallback;

--- a/tp-react/src/utils/authApi.ts
+++ b/tp-react/src/utils/authApi.ts
@@ -28,7 +28,7 @@ interface MemberInfo {
 export const loginWithGoogle = async (code: string): Promise<ApiResponse<LoginResponse>> => {
     const response = await apiClient.post<ApiResponse<LoginResponse>>('/auth/google', {
         code,
-        redirectUri: import.meta.env.VITE_REDIRECT_URI
+        redirectUri: import.meta.env.VITE_GOOGLE_REDIRECT_URI
     });
     return response.data;
 };


### PR DESCRIPTION
## 주요 내용
- 서드파티 쿠키 차단 시 로그인 불가 문제 해결을 위해 OAuth 플로우를 팝업에서 리다이렉트로 전환
- OAuth 콜백 페이지 신규 추가
- @types/react를 React 18에 맞게 다운그레이드

## 세부 내용
### OAuth 리다이렉트 전환
- useGoogleLogin에 ux_mode: 'redirect', redirect_uri 옵션 추가
- Head.jsx에서 onSuccess/onError 콜백 및 관련 import 제거

### OAuthCallback 페이지 신규
- /oauth/callback 라우트 추가 (App.jsx)
- URL 파라미터에서 authorization code 추출 후 백엔드 로그인 처리
- 에러/code 누락 시 메인 페이지로 리다이렉트
- 중복 실행 방지 (useRef)

### 환경변수 통일
- VITE_REDIRECT_URI → VITE_GOOGLE_REDIRECT_URI로 변경 (authApi.ts, .env)
- useGoogleLogin의 redirect_uri와 백엔드 전송 redirectUri가 동일한 환경변수 참조

### @types/react 버전 수정
- @types/react 19.2.11 → 18.3.28
- @types/react-dom 19.2.3 → 18.3.7
- React 18과 타입 정의 버전 불일치로 인한 JSX.Element 경고 해소

### 업데이트 내역
- v1.4.2 항목 추가: 일부 브라우저 환경에서 로그인 및 기록 조회 미동작 문제 수정