### PR TITLE
feat: 적응형 서빙 기반 작업 — 필드 추가 및 API 확장

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
@@ -5,11 +5,14 @@ import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.dto.*;
 import com.typingpractice.typing_practice_be.member.query.MemberUpdateQuery;
 import com.typingpractice.typing_practice_be.member.service.MemberService;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController()
 @RequestMapping("/members")
@@ -54,6 +57,15 @@ public class MemberController {
 
     memberService.deleteMember(memberId);
     return ApiResponse.ok(null);
+  }
+
+  @GetMapping("/me/typing-profile")
+  public ApiResponse<List<MemberTypingStats>> getTypingProfile() {
+    Long memberId = getAuthenticatedMemberId();
+
+    List<MemberTypingStats> memberTypingStats = memberService.findMemberTypingStats(memberId);
+
+    return ApiResponse.ok(memberTypingStats);
   }
 
   private Long getAuthenticatedMemberId() {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/MemberService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/MemberService.java
@@ -11,6 +11,8 @@ import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundExce
 import com.typingpractice.typing_practice_be.member.query.MemberCreateQuery;
 import com.typingpractice.typing_practice_be.member.query.MemberUpdateQuery;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypingStatsRepository;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -23,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberService {
   private final MemberRepository memberRepository;
+  private final MemberTypingStatsRepository memberTypingStatsRepository;
   private final RefreshTokenRepository refreshTokenRepository;
 
   private final AdminProperties adminProperties;
@@ -103,5 +106,9 @@ public class MemberService {
     refreshTokenRepository.deleteByMemberId(memberId);
 
     memberRepository.deleteMember(member);
+  }
+
+  public List<MemberTypingStats> findMemberTypingStats(Long memberId) {
+    return this.memberTypingStatsRepository.findByMemberId(memberId);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
@@ -28,7 +28,8 @@ public class QuoteRepository {
 
   public Optional<Quote> findById(Long quoteId) {
     return em.createQuery(
-            "select q from Quote q left join fetch q.member m where q.id = :quoteId", Quote.class)
+            "select q from Quote q left join fetch q.member m left join fetch q.typingStats qs where q.id = :quoteId",
+            Quote.class)
         .setParameter("quoteId", quoteId)
         .setMaxResults(1)
         .getResultStream()

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/domain/ServingType.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/domain/ServingType.java
@@ -1,0 +1,6 @@
+package com.typingpractice.typing_practice_be.typingrecord.domain;
+
+public enum ServingType {
+  RANDOM,
+  ADAPTIVE
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/domain/TypingRecord.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/domain/TypingRecord.java
@@ -39,6 +39,14 @@ public class TypingRecord {
   private LocalDateTime completedAt;
   private TrackingInfo tracking;
 
+  private ServingType servingType;
+
+  private float estimatedDifficulty;
+  private float estimatedUncertainty;
+
+  private float avgCpmSnapshot;
+  private float avgAccSnapshot;
+
   public static TypingRecord create(
       Long memberId,
       String anonymousId,
@@ -50,7 +58,12 @@ public class TypingRecord {
       int charLength,
       int resetCount,
       List<Typo> typos,
-      TrackingInfo tracking) {
+      TrackingInfo tracking,
+      ServingType servingType,
+      float estimatedDifficulty,
+      float estimatedUncertainty,
+      float avgCpmSnapshot,
+      float avgAccSnapshot) {
     TypingRecord record = new TypingRecord();
 
     record.memberId = memberId;
@@ -66,6 +79,12 @@ public class TypingRecord {
     record.typos = typos;
     record.completedAt = LocalDateTime.now();
     record.tracking = tracking;
+
+    record.servingType = servingType;
+    record.estimatedDifficulty = estimatedDifficulty;
+    record.estimatedUncertainty = estimatedUncertainty;
+    record.avgCpmSnapshot = avgCpmSnapshot;
+    record.avgAccSnapshot = avgAccSnapshot;
     return record;
   }
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/request/TypingRecordRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/request/TypingRecordRequest.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.typingrecord.dto.request;
 
+import com.typingpractice.typing_practice_be.typingrecord.domain.ServingType;
 import com.typingpractice.typing_practice_be.typingrecord.domain.Typo;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
@@ -28,6 +29,11 @@ public class TypingRecordRequest {
 
   private TrackingRequest tracking;
 
+  private ServingType servingType;
+
+  private Float estimatedDifficulty; // 추정된 적정 난이도
+  private Float estimatedUncertainty; // 추정의 불확실성
+
   public static TypingRecordRequest create(
       Long quoteId,
       String anonymousId,
@@ -36,7 +42,10 @@ public class TypingRecordRequest {
       Integer charLength,
       Integer resetCount,
       List<TypoRequest> typos,
-      TrackingRequest tracking) {
+      TrackingRequest tracking,
+      ServingType servingType,
+      Float estimatedDifficulty,
+      Float estimatedUncertainty) {
     TypingRecordRequest request = new TypingRecordRequest();
 
     request.quoteId = quoteId;
@@ -47,6 +56,9 @@ public class TypingRecordRequest {
     request.resetCount = resetCount;
     request.typos = typos;
     request.tracking = tracking;
+    request.servingType = servingType != null ? servingType : ServingType.RANDOM;
+    request.estimatedDifficulty = estimatedDifficulty;
+    request.estimatedUncertainty = estimatedUncertainty;
 
     return request;
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/query/TypingRecordQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/query/TypingRecordQuery.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.typingrecord.query;
 
+import com.typingpractice.typing_practice_be.typingrecord.domain.ServingType;
 import com.typingpractice.typing_practice_be.typingrecord.domain.TrackingInfo;
 import com.typingpractice.typing_practice_be.typingrecord.domain.Typo;
 import com.typingpractice.typing_practice_be.typingrecord.dto.request.TypingRecordRequest;
@@ -19,6 +20,10 @@ public class TypingRecordQuery {
   private final int resetCount;
   private final List<Typo> typos;
   private final TrackingInfo tracking;
+  private final ServingType servingType;
+
+  private final float estimatedDifficulty;
+  private final float estimatedUncertainty;
 
   private TypingRecordQuery(
       Long quoteId,
@@ -28,7 +33,10 @@ public class TypingRecordQuery {
       int resetCount,
       List<Typo> typos,
       String anonymousId,
-      TrackingInfo tracking) {
+      TrackingInfo tracking,
+      ServingType servingType,
+      float estimatedDifficulty,
+      float estimatedUncertainty) {
     this.quoteId = quoteId;
     this.cpm = cpm;
     this.accuracy = accuracy;
@@ -37,6 +45,10 @@ public class TypingRecordQuery {
     this.typos = typos;
     this.anonymousId = anonymousId;
     this.tracking = tracking;
+    this.servingType = servingType;
+
+    this.estimatedDifficulty = estimatedDifficulty;
+    this.estimatedUncertainty = estimatedUncertainty;
   }
 
   public static TypingRecordQuery from(TypingRecordRequest request) {
@@ -48,6 +60,8 @@ public class TypingRecordQuery {
               request.getTracking().getReferrer(),
               request.getTracking().getDeviceType());
     }
+    ServingType servingType =
+        request.getServingType() != null ? request.getServingType() : ServingType.RANDOM;
 
     return new TypingRecordQuery(
         request.getQuoteId(),
@@ -57,6 +71,9 @@ public class TypingRecordQuery {
         request.getResetCount(),
         request.toTypos(),
         request.getAnonymousId(),
-        tracking);
+        tracking,
+        servingType,
+        request.getEstimatedDifficulty(),
+        request.getEstimatedUncertainty());
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/service/TypingRecordService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/service/TypingRecordService.java
@@ -26,6 +26,9 @@ public class TypingRecordService {
     Quote quote =
         quoteRepository.findById(query.getQuoteId()).orElseThrow(QuoteNotFoundException::new);
 
+    float avgCpm = quote.getTypingStats() != null ? quote.getTypingStats().getAvgCpm() : 0;
+    float avgAcc = quote.getTypingStats() != null ? quote.getTypingStats().getAvgAcc() : 0;
+
     TypingRecord record =
         TypingRecord.create(
             memberId,
@@ -38,7 +41,12 @@ public class TypingRecordService {
             query.getCharLength(),
             query.getResetCount(),
             query.getTypos(),
-            query.getTracking());
+            query.getTracking(),
+            query.getServingType(),
+            query.getEstimatedDifficulty(),
+            query.getEstimatedUncertainty(),
+            avgCpm,
+            avgAcc);
 
     TypingRecord saved;
     try {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberTypingStats.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/MemberTypingStats.java
@@ -38,6 +38,9 @@ public class MemberTypingStats extends BaseEntity {
   private float totalPracticeTimeMin;
   private int totalResetCount;
 
+  private float estimatedDifficulty; // μ — 추정된 적정 난이도
+  private float estimatedUncertainty; // σ — 추정의 불확실성
+
   @Column(columnDefinition = "timestamp with time zone")
   private LocalDateTime lastPracticedAt;
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberTypingStatsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberTypingStatsRepository.java
@@ -6,6 +6,7 @@ import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,6 +16,14 @@ public class MemberTypingStatsRepository {
 
   public void save(MemberTypingStats stats) {
     em.persist(stats);
+  }
+
+  public List<MemberTypingStats> findByMemberId(Long memberId) {
+    return em.createQuery(
+            "select s from MemberTypingStats s where s.member.id = :memberId",
+            MemberTypingStats.class)
+        .setParameter("memberId", memberId)
+        .getResultList();
   }
 
   public Optional<MemberTypingStats> findByMemberIdAndLanguage(


### PR DESCRIPTION
## 주요 내용
- TypingRecord에 servingType, estimatedDifficulty/Uncertainty, avgCpm/AccSnapshot 필드 추가
- MemberTypingStats에 estimatedDifficulty, estimatedUncertainty 필드 추가
- GET /members/me/typing-profile 엔드포인트 추가
- 문장 조회 시 typingStats를 fetch join하여 avgCpm, avgAcc 응답에 포함

## 세부 내용
### TypingRecord (MongoDB)
- servingType 필드 추가 (RANDOM/ADAPTIVE enum)
- estimatedDifficulty, estimatedUncertainty 스냅샷 저장
- avgCpmSnapshot, avgAccSnapshot 저장 (타이핑 시점의 문장 평균 성능)
- typingStats null일 때 NPE 방지 처리

### MemberTypingStats (PostgreSQL)
- estimatedDifficulty (μ), estimatedUncertainty (σ) 필드 추가

### API
- GET /members/me/typing-profile: 회원의 언어별 MemberTypingStats 목록 조회
- TypingRecordRequest에 servingType, estimatedDifficulty, estimatedUncertainty 추가 (모두 nullable, 하위호환)