### PR TITLE
refactor: request에서 추정값 제거 및 예외 처리 추가

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/GlobalExceptionHandler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.common.exception;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ProblemDetail;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -33,6 +34,15 @@ public class GlobalExceptionHandler {
     ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, message);
     problemDetail.setTitle("Invalid Parameter Type");
 
+    return problemDetail;
+  }
+
+  @ExceptionHandler(HttpMessageNotReadableException.class)
+  public ProblemDetail handleMessageNotReadable(HttpMessageNotReadableException e) {
+    ProblemDetail problemDetail =
+        ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+
+    problemDetail.setTitle("Invalid Request Body");
     return problemDetail;
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/controller/TypingRecordController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/controller/TypingRecordController.java
@@ -27,6 +27,9 @@ public class TypingRecordController {
   @PostMapping("/typing-records")
   public ApiResponse<Void> save(@RequestBody @Valid TypingRecordRequest request) {
     Long memberId = getMemberIdOrNull();
+
+    System.out.println("request = " + request);
+
     TypingRecordQuery query = TypingRecordQuery.from(request);
 
     typingRecordService.save(memberId, query);

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/request/TypingRecordRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/request/TypingRecordRequest.java
@@ -31,9 +31,6 @@ public class TypingRecordRequest {
 
   private ServingType servingType;
 
-  private Float estimatedDifficulty; // 추정된 적정 난이도
-  private Float estimatedUncertainty; // 추정의 불확실성
-
   public static TypingRecordRequest create(
       Long quoteId,
       String anonymousId,
@@ -43,9 +40,7 @@ public class TypingRecordRequest {
       Integer resetCount,
       List<TypoRequest> typos,
       TrackingRequest tracking,
-      ServingType servingType,
-      Float estimatedDifficulty,
-      Float estimatedUncertainty) {
+      ServingType servingType) {
     TypingRecordRequest request = new TypingRecordRequest();
 
     request.quoteId = quoteId;
@@ -57,8 +52,6 @@ public class TypingRecordRequest {
     request.typos = typos;
     request.tracking = tracking;
     request.servingType = servingType != null ? servingType : ServingType.RANDOM;
-    request.estimatedDifficulty = estimatedDifficulty;
-    request.estimatedUncertainty = estimatedUncertainty;
 
     return request;
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/query/TypingRecordQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/query/TypingRecordQuery.java
@@ -22,9 +22,6 @@ public class TypingRecordQuery {
   private final TrackingInfo tracking;
   private final ServingType servingType;
 
-  private final float estimatedDifficulty;
-  private final float estimatedUncertainty;
-
   private TypingRecordQuery(
       Long quoteId,
       int cpm,
@@ -34,9 +31,7 @@ public class TypingRecordQuery {
       List<Typo> typos,
       String anonymousId,
       TrackingInfo tracking,
-      ServingType servingType,
-      float estimatedDifficulty,
-      float estimatedUncertainty) {
+      ServingType servingType) {
     this.quoteId = quoteId;
     this.cpm = cpm;
     this.accuracy = accuracy;
@@ -46,9 +41,6 @@ public class TypingRecordQuery {
     this.anonymousId = anonymousId;
     this.tracking = tracking;
     this.servingType = servingType;
-
-    this.estimatedDifficulty = estimatedDifficulty;
-    this.estimatedUncertainty = estimatedUncertainty;
   }
 
   public static TypingRecordQuery from(TypingRecordRequest request) {
@@ -72,8 +64,6 @@ public class TypingRecordQuery {
         request.toTypos(),
         request.getAnonymousId(),
         tracking,
-        servingType,
-        request.getEstimatedDifficulty(),
-        request.getEstimatedUncertainty());
+        servingType);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/service/TypingRecordService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/service/TypingRecordService.java
@@ -26,8 +26,8 @@ public class TypingRecordService {
     Quote quote =
         quoteRepository.findById(query.getQuoteId()).orElseThrow(QuoteNotFoundException::new);
 
-    float avgCpm = quote.getTypingStats() != null ? quote.getTypingStats().getAvgCpm() : 0;
-    float avgAcc = quote.getTypingStats() != null ? quote.getTypingStats().getAvgAcc() : 0;
+    float quoteAvgCpm = quote.getTypingStats() != null ? quote.getTypingStats().getAvgCpm() : 0;
+    float quoteAvgAcc = quote.getTypingStats() != null ? quote.getTypingStats().getAvgAcc() : 0;
 
     TypingRecord record =
         TypingRecord.create(
@@ -43,10 +43,10 @@ public class TypingRecordService {
             query.getTypos(),
             query.getTracking(),
             query.getServingType(),
-            query.getEstimatedDifficulty(),
-            query.getEstimatedUncertainty(),
-            avgCpm,
-            avgAcc);
+            0, // estimatedDifficulty - 서버 계산으로 대체 예정
+            0, // estimatedUncertainty - 서버 계산으로 대체 예정
+            quoteAvgCpm,
+            quoteAvgAcc);
 
     TypingRecord saved;
     try {


### PR DESCRIPTION
## 주요 내용
- TypingRecordRequest/Query에서 estimatedDifficulty, estimatedUncertainty 제거 (서버 계산으로 전환)
- GlobalExceptionHandler에 HttpMessageNotReadableException 핸들러 추가

## 세부 내용
### 추정값 필드 제거
- TypingRecordRequest: estimatedDifficulty, estimatedUncertainty 필드 및 create 파라미터 제거
- TypingRecordQuery: estimatedDifficulty, estimatedUncertainty 필드 및 생성자/from() 파라미터 제거
- TypingRecordService: 제거된 필드 대신 0f 전달 (서버 계산으로 대체 예정)

### 예외 처리
- GlobalExceptionHandler: HttpMessageNotReadableException 핸들러 추가 (enum 등 잘못된 JSON 요청 시 400 응답)

### 코드 개선
- TypingRecordService: avgCpm/avgAcc 변수명을 quoteAvgCpm/quoteAvgAcc로 명확화