### PR TITLE
feat: Adaptive Kalman Filter 기반 실시간 mu/sigma 추정

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/config/AdaptiveServingProperties.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/config/AdaptiveServingProperties.java
@@ -1,0 +1,33 @@
+package com.typingpractice.typing_practice_be.adaptiveserving.config;
+
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@ConfigurationProperties(prefix = "adaptive-serving")
+public class AdaptiveServingProperties {
+  private final float beta;
+  private final float sigmaObs;
+  private final float perfCoefficient;
+  private final float defaultMu;
+  private final float defaultSigma;
+  private final float sigmaProcess;
+  private final float surpriseThreshold;
+
+  public AdaptiveServingProperties(
+      float beta,
+      float sigmaObs,
+      float perfCoefficient,
+      float defaultMu,
+      float defaultSigma,
+      float sigmaProcess,
+      float surpriseThreshold) {
+    this.beta = beta;
+    this.sigmaObs = sigmaObs;
+    this.perfCoefficient = perfCoefficient;
+    this.defaultMu = defaultMu;
+    this.defaultSigma = defaultSigma;
+    this.sigmaProcess = sigmaProcess;
+    this.surpriseThreshold = surpriseThreshold;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/dto/AdaptiveServingEstimation.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/dto/AdaptiveServingEstimation.java
@@ -1,0 +1,20 @@
+package com.typingpractice.typing_practice_be.adaptiveserving.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class AdaptiveServingEstimation {
+  private float mu;
+  private float sigma;
+
+  private AdaptiveServingEstimation(float mu, float sigma) {
+    this.mu = mu;
+    this.sigma = sigma;
+  }
+
+  public static AdaptiveServingEstimation of(float mu, float sigma) {
+    return new AdaptiveServingEstimation(mu, sigma);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/service/AdaptiveServingCalculator.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/service/AdaptiveServingCalculator.java
@@ -1,0 +1,62 @@
+package com.typingpractice.typing_practice_be.adaptiveserving.service;
+
+import com.typingpractice.typing_practice_be.adaptiveserving.config.AdaptiveServingProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class AdaptiveServingCalculator {
+  private final AdaptiveServingProperties properties;
+
+  /**
+   * 해당 문장의 평균 대비 사용자의 실력을 -1 ~ +1 범위로 정규화
+   *
+   * @param userCpm 사용자 타자 속도
+   * @param userAcc 사용자 정확도
+   * @param quoteAvgCpm 문장의 평균 타자 속도
+   * @param quoteAvgAcc 문장의 평균 정확도
+   * @return 정규화 값
+   */
+  public float calcPerfNormalized(
+      float userCpm, float userAcc, float quoteAvgCpm, float quoteAvgAcc) {
+    if (quoteAvgCpm == 0 || quoteAvgAcc == 0) return 0f;
+
+    float cpmGain = userCpm / quoteAvgCpm - 1;
+    float accGain = userAcc / quoteAvgAcc - 1;
+
+    return clip(properties.getPerfCoefficient() * (cpmGain + accGain), -1f, 1f);
+  }
+
+  /** 관측값 X 를 산출 이 사용자의 적정 난이도는 이 정도일 것이다라는 추정치 */
+  public float calcObservation(float difficulty, float perfNormalized) {
+    return difficulty + properties.getBeta() * perfNormalized;
+  }
+
+  public float[] update(float mu, float sigma, float x) {
+    float sigmaObs = properties.getSigmaObs();
+    float baseProcessNoise = properties.getSigmaProcess();
+    float surpriseThreshold = properties.getSurpriseThreshold();
+
+    // Adaptive process noise: surprise 가 크면 sigma 를 더 넓힘 -> 평소와 다른 데이터
+    float surprise = Math.abs(x - mu) / sigma;
+    float processNoise =
+        surprise > surpriseThreshold ? baseProcessNoise * surprise : baseProcessNoise;
+
+    // 칼만 필터: 상태 예측 (process noise 반영)
+    float sigmaSq = sigma * sigma + processNoise * processNoise;
+
+    // 칼만 필터: 관측 업데이트
+    float sigmaObsSq = sigmaObs * sigmaObs;
+    float K = sigmaSq / (sigmaSq + sigmaObsSq);
+    float newMu = mu + K * (x - mu);
+    float newSigmaSq = 1f / (1f / sigmaSq + 1f / sigmaObsSq);
+    float newSigma = (float) Math.sqrt(newSigmaSq);
+
+    return new float[] {newMu, newSigma};
+  }
+
+  private float clip(float value, float min, float max) {
+    return Math.max(min, Math.min(max, value));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/service/AdaptiveServingRedisService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/service/AdaptiveServingRedisService.java
@@ -1,0 +1,117 @@
+package com.typingpractice.typing_practice_be.adaptiveserving.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.typingpractice.typing_practice_be.adaptiveserving.config.AdaptiveServingProperties;
+import com.typingpractice.typing_practice_be.adaptiveserving.dto.AdaptiveServingEstimation;
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.typingrecord.event.TypingRecordSavedEvent;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
+import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypingStatsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AdaptiveServingRedisService {
+  private final StringRedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
+  private final AdaptiveServingCalculator calculator;
+  private final AdaptiveServingProperties properties;
+  private final MemberTypingStatsRepository memberTypingStatsRepository;
+
+  private static final String KEY_PREFIX = "adaptive:";
+
+  private String key(Long memberId, QuoteLanguage language) {
+    return KEY_PREFIX + memberId + ":" + language;
+  }
+
+  private Duration ttlUntilNextBatch() {
+    LocalDateTime nowKst = LocalDateTime.now(TimeUtils.KST);
+    LocalDateTime nextBatch = nowKst.toLocalDate().plusDays(1).atTime(LocalTime.of(3, 0));
+    return Duration.between(nowKst, nextBatch);
+  }
+
+  /*
+  Redis -> PostgreSQL -> 기본값 순서로 fallback 하여 조회
+   */
+  public AdaptiveServingEstimation getEstimation(Long memberId, QuoteLanguage language) {
+    // 1. Redis
+    String json = redisTemplate.opsForValue().get(key(memberId, language));
+    if (json != null) {
+      return deserialize(json);
+    }
+
+    // 2. PostgreSQL fallback
+    MemberTypingStats stats =
+        memberTypingStatsRepository.findByMemberIdAndLanguage(memberId, language).orElse(null);
+
+    if (stats != null && stats.getEstimatedDifficulty() != 0) {
+      AdaptiveServingEstimation estimation =
+          AdaptiveServingEstimation.of(
+              stats.getEstimatedDifficulty(), stats.getEstimatedUncertainty());
+      setEstimation(memberId, language, estimation);
+      return estimation;
+    }
+
+    // 3. 기본값
+    return AdaptiveServingEstimation.of(properties.getDefaultMu(), properties.getDefaultSigma());
+  }
+
+  public void updateEstimation(TypingRecordSavedEvent event) {
+    if (event.getMemberId() == null) return;
+    if (event.isOutlier()) return;
+    if (event.getAvgCpmSnapshot() == 0 || event.getAvgAccSnapshot() == 0) return;
+
+    AdaptiveServingEstimation current = getEstimation(event.getMemberId(), event.getLanguage());
+
+    float perfNormalized =
+        calculator.calcPerfNormalized(
+            event.getCpm(),
+            event.getAccuracy(),
+            event.getAvgCpmSnapshot(),
+            event.getAvgAccSnapshot());
+
+    System.out.println("perfNormalized = " + perfNormalized);
+
+    float x = calculator.calcObservation(event.getDifficulty(), perfNormalized);
+    float[] updated = calculator.update(current.getMu(), current.getSigma(), x);
+
+    AdaptiveServingEstimation newEstimation = AdaptiveServingEstimation.of(updated[0], updated[1]);
+    setEstimation(event.getMemberId(), event.getLanguage(), newEstimation);
+  }
+
+  public void setEstimation(
+      Long memberId, QuoteLanguage language, AdaptiveServingEstimation estimation) {
+    String json = serialize(estimation);
+    redisTemplate.opsForValue().set(key(memberId, language), json, ttlUntilNextBatch());
+  }
+
+  public void deleteEstimation(Long memberId, QuoteLanguage language) {
+    redisTemplate.delete(key(memberId, language));
+  }
+
+  private String serialize(AdaptiveServingEstimation estimation) {
+    try {
+      return objectMapper.writeValueAsString(estimation);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("AdaptiveServing Redis 직렬화 실패", e);
+    }
+  }
+
+  private AdaptiveServingEstimation deserialize(String json) {
+    try {
+      return objectMapper.readValue(json, AdaptiveServingEstimation.class);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("AdaptiveServing Redis 역직렬화 실패", e);
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/controller/MemberController.java
@@ -1,24 +1,25 @@
 package com.typingpractice.typing_practice_be.member.controller;
 
+import com.typingpractice.typing_practice_be.adaptiveserving.dto.AdaptiveServingEstimation;
+import com.typingpractice.typing_practice_be.adaptiveserving.service.AdaptiveServingRedisService;
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.dto.*;
 import com.typingpractice.typing_practice_be.member.query.MemberUpdateQuery;
 import com.typingpractice.typing_practice_be.member.service.MemberService;
-import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController()
 @RequestMapping("/members")
 @RequiredArgsConstructor
 public class MemberController {
   private final MemberService memberService;
+  private final AdaptiveServingRedisService adaptiveServingRedisService;
 
   @GetMapping("/me")
   public ApiResponse<MemberResponse> findMember() {
@@ -60,12 +61,14 @@ public class MemberController {
   }
 
   @GetMapping("/me/typing-profile")
-  public ApiResponse<List<MemberTypingStats>> getTypingProfile() {
+  public ApiResponse<AdaptiveServingEstimation> getTypingProfile(
+      @RequestParam QuoteLanguage language) {
     Long memberId = getAuthenticatedMemberId();
 
-    List<MemberTypingStats> memberTypingStats = memberService.findMemberTypingStats(memberId);
+    AdaptiveServingEstimation estimation =
+        adaptiveServingRedisService.getEstimation(memberId, language);
 
-    return ApiResponse.ok(memberTypingStats);
+    return ApiResponse.ok(estimation);
   }
 
   private Long getAuthenticatedMemberId() {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/MemberService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/service/MemberService.java
@@ -11,8 +11,6 @@ import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundExce
 import com.typingpractice.typing_practice_be.member.query.MemberCreateQuery;
 import com.typingpractice.typing_practice_be.member.query.MemberUpdateQuery;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
-import com.typingpractice.typing_practice_be.typingrecord.statistics.domain.MemberTypingStats;
-import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.MemberTypingStatsRepository;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -25,7 +23,6 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class MemberService {
   private final MemberRepository memberRepository;
-  private final MemberTypingStatsRepository memberTypingStatsRepository;
   private final RefreshTokenRepository refreshTokenRepository;
 
   private final AdminProperties adminProperties;
@@ -106,9 +103,5 @@ public class MemberService {
     refreshTokenRepository.deleteByMemberId(memberId);
 
     memberRepository.deleteMember(member);
-  }
-
-  public List<MemberTypingStats> findMemberTypingStats(Long memberId) {
-    return this.memberTypingStatsRepository.findByMemberId(memberId);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/domain/TypingRecord.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/domain/TypingRecord.java
@@ -44,6 +44,7 @@ public class TypingRecord {
   private float estimatedDifficulty;
   private float estimatedUncertainty;
 
+  private float quoteDifficulty;
   private float avgCpmSnapshot;
   private float avgAccSnapshot;
 
@@ -62,6 +63,7 @@ public class TypingRecord {
       ServingType servingType,
       float estimatedDifficulty,
       float estimatedUncertainty,
+      float quoteDifficulty,
       float avgCpmSnapshot,
       float avgAccSnapshot) {
     TypingRecord record = new TypingRecord();
@@ -83,6 +85,7 @@ public class TypingRecord {
     record.servingType = servingType;
     record.estimatedDifficulty = estimatedDifficulty;
     record.estimatedUncertainty = estimatedUncertainty;
+    record.quoteDifficulty = quoteDifficulty;
     record.avgCpmSnapshot = avgCpmSnapshot;
     record.avgAccSnapshot = avgAccSnapshot;
     return record;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/event/TypingRecordEventListener.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/event/TypingRecordEventListener.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.typingrecord.event;
 
+import com.typingpractice.typing_practice_be.adaptiveserving.service.AdaptiveServingRedisService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.TodayTypingStatsRedisService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,12 +12,15 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class TypingRecordEventListener {
   private final TodayTypingStatsRedisService todayTypingStatsRedisService;
+  private final AdaptiveServingRedisService adaptiveServingRedisService;
 
   @EventListener
   public void handleTypingRecordSaved(TypingRecordSavedEvent event) {
     try {
       todayTypingStatsRedisService.incrementTyping(event);
       todayTypingStatsRedisService.incrementTypoAndDetail(event);
+
+      adaptiveServingRedisService.updateEstimation(event);
     } catch (Exception e) {
       log.error("Redis 오늘 통계 증분 실패 - memberId: {}", event.getMemberId());
     }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/event/TypingRecordSavedEvent.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/event/TypingRecordSavedEvent.java
@@ -20,6 +20,10 @@ public class TypingRecordSavedEvent {
   private final boolean outlier;
   private final List<Typo> typos;
 
+  private final float difficulty;
+  private final float avgCpmSnapshot;
+  private final float avgAccSnapshot;
+
   private TypingRecordSavedEvent(
       Long memberId,
       QuoteLanguage language,
@@ -28,7 +32,10 @@ public class TypingRecordSavedEvent {
       int charLength,
       int resetCount,
       boolean outlier,
-      List<Typo> typos) {
+      List<Typo> typos,
+      float difficulty,
+      float avgCpmSnapshot,
+      float avgAccSnapshot) {
     this.memberId = memberId;
     this.language = language;
     this.cpm = cpm;
@@ -37,6 +44,10 @@ public class TypingRecordSavedEvent {
     this.resetCount = resetCount;
     this.outlier = outlier;
     this.typos = typos;
+
+    this.difficulty = difficulty;
+    this.avgCpmSnapshot = avgCpmSnapshot;
+    this.avgAccSnapshot = avgAccSnapshot;
   }
 
   public static TypingRecordSavedEvent from(TypingRecord record) {
@@ -48,6 +59,9 @@ public class TypingRecordSavedEvent {
         record.getCharLength(),
         record.getResetCount(),
         record.isOutlier(),
-        record.getTypos());
+        record.getTypos(),
+        record.getQuoteDifficulty(),
+        record.getAvgCpmSnapshot(),
+        record.getAvgAccSnapshot());
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/MemberDailyAggregationRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/MemberDailyAggregationRepository.java
@@ -30,6 +30,8 @@ public class MemberDailyAggregationRepository {
                     .and("completedAt")
                     .gte(from)
                     .lt(to)
+                    .and("outlier")
+                    .is(false)
                     .and("cpm")
                     .gt(0)),
             Aggregation.addFields()
@@ -79,6 +81,8 @@ public class MemberDailyAggregationRepository {
                     .and("completedAt")
                     .gte(from)
                     .lt(to)
+                    .and("outlier")
+                    .is(false)
                     .and("cpm")
                     .gt(0)),
             Aggregation.addFields()

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/MemberTypingAggregationRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/MemberTypingAggregationRepository.java
@@ -19,7 +19,8 @@ public class MemberTypingAggregationRepository {
   public List<MemberTypingAggregation> aggregateByMemberIds(List<Long> memberIds) {
     Aggregation aggregation =
         Aggregation.newAggregation(
-            Aggregation.match(Criteria.where("memberId").in(memberIds).and("cpm").gt(0)),
+            Aggregation.match(
+                Criteria.where("memberId").in(memberIds).and("outlier").is(false).and("cpm").gt(0)),
             Aggregation.group("memberId", "language")
                 .count()
                 .as("totalAttempts")
@@ -64,6 +65,8 @@ public class MemberTypingAggregationRepository {
                     .and("completedAt")
                     .gte(from)
                     .lt(to)
+                    .and("outlier")
+                    .is(false)
                     .and("cpm")
                     .gt(0)),
             Aggregation.group("memberId", "language")
@@ -109,6 +112,8 @@ public class MemberTypingAggregationRepository {
                     .in(memberIds)
                     .and("language")
                     .is(language.name())
+                    .and("outlier")
+                    .is(false)
                     .and("cpm")
                     .gt(0)),
             Aggregation.group("memberId", "language")
@@ -157,6 +162,8 @@ public class MemberTypingAggregationRepository {
                     .and("completedAt")
                     .gte(from)
                     .lt(to)
+                    .and("outlier")
+                    .is(false)
                     .and("cpm")
                     .gt(0)),
             Aggregation.group("memberId", "language")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/service/TypingRecordService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/service/TypingRecordService.java
@@ -26,8 +26,9 @@ public class TypingRecordService {
     Quote quote =
         quoteRepository.findById(query.getQuoteId()).orElseThrow(QuoteNotFoundException::new);
 
-    float quoteAvgCpm = quote.getTypingStats() != null ? quote.getTypingStats().getAvgCpm() : 0;
-    float quoteAvgAcc = quote.getTypingStats() != null ? quote.getTypingStats().getAvgAcc() : 0;
+    float quoteDifficulty = quote.getDifficulty() != null ? quote.getDifficulty() : 0f;
+    float quoteAvgCpm = quote.getTypingStats() != null ? quote.getTypingStats().getAvgCpm() : 0f;
+    float quoteAvgAcc = quote.getTypingStats() != null ? quote.getTypingStats().getAvgAcc() : 0f;
 
     TypingRecord record =
         TypingRecord.create(
@@ -43,8 +44,9 @@ public class TypingRecordService {
             query.getTypos(),
             query.getTracking(),
             query.getServingType(),
-            0, // estimatedDifficulty - 서버 계산으로 대체 예정
-            0, // estimatedUncertainty - 서버 계산으로 대체 예정
+            0f, // estimatedDifficulty - 서버 계산으로 대체 예정
+            0f, // estimatedUncertainty - 서버 계산으로 대체 예정
+            quoteDifficulty,
             quoteAvgCpm,
             quoteAvgAcc);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/TodayTypingStatsRedisService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/TodayTypingStatsRedisService.java
@@ -66,6 +66,7 @@ public class TodayTypingStatsRedisService {
 
   // 이벤트 수신 후 오늘 통계 업데이트
   public void incrementTyping(TypingRecordSavedEvent event) {
+    if (event.isOutlier()) return;
     String key = typingKey(event.getMemberId(), event.getLanguage());
 
     TodayTypingSnapshot snapshot = getSnapshotOrEmpty(key);

--- a/typing-practice-be/src/main/resources/application.yaml
+++ b/typing-practice-be/src/main/resources/application.yaml
@@ -31,3 +31,12 @@ quote:
   similarity-threshold:
     korean: 0.5
     english: 0.5
+
+adaptive-serving:
+  beta: 15
+  sigma-obs: 4 #10
+  perf-coefficient: 1.5
+  sigma-process: 1 #2
+  surprise-threshold: 2
+  default-mu: 50
+  default-sigma: 15


### PR DESCRIPTION
## 주요 내용
- adaptiveserving 패키지 신규 생성 (Properties, Calculator, RedisService, DTO)
- Adaptive Kalman Filter로 회원의 적정 난이도를 실시간 추정
- surprise 기반 adaptive process noise 도입으로 sigma 무한 축소 문제 해결
- outlier 기록을 타이핑 통계 집계에서 전면 제외

## 세부 내용
### adaptiveserving 패키지 (신규)
- AdaptiveServingProperties: yml 설정 매핑 (beta, sigmaObs, sigmaProcess, surpriseThreshold 등)
- AdaptiveServingCalculator: perfNormalized 산출, 관측값 계산, adaptive Kalman update
- AdaptiveServingRedisService: Redis 실시간 mu/sigma 관리, Redis → PostgreSQL → 기본값 fallback
- AdaptiveServingEstimation: Redis 값 DTO

### 이벤트 연동
- TypingRecordSavedEvent: difficulty, avgCpmSnapshot, avgAccSnapshot 필드 추가
- TypingRecord: quoteDifficulty 스냅샷 필드 추가
- TypingRecordEventListener: AdaptiveServingRedisService.updateEstimation() 호출 추가
- updateEstimation 스킵 조건: 비회원, outlier, typingStats 미존재 문장

### API
- GET /members/me/typing-profile?language=KOREAN → AdaptiveServingRedisService.getEstimation() 직접 연결
- MemberService에서 미사용 findMemberTypingStats 제거

### outlier 필터링
- MemberTypingAggregationRepository: 4개 메서드에 outlier: false 조건 추가
- MemberDailyAggregationRepository: 2개 메서드에 outlier: false 조건 추가
- TodayTypingStatsRedisService.incrementTyping(): outlier 체크 추가

### 파라미터 설정 (실데이터 기반 튜닝)
- sigma-obs: 10 → 4 (동일 사용자-문장 반복 타이핑 변동 측정 기반)
- sigma-process: 2 → 1 (sigma-obs의 1/4 수준)