### PR TITLE
fix: 일별 통계 조회 시 days를 최근 N개로 해석하도록 변경

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberStatisticsService.java
@@ -104,17 +104,15 @@ public class MemberStatisticsService {
 
   public MemberDailyStatsResponse getDailyStats(Long memberId, QuoteLanguage language, int days) {
     LocalDate todayKst = LocalDate.now(TimeUtils.KST);
-    LocalDate from = todayKst.minusDays(days - 1);
-    LocalDate yesterday = todayKst.minusDays(1);
 
     List<MemberDailyStats> pgList =
-        memberDailyStatsRepository.findByMemberIdAndLanguageAndDateBetween(
-            memberId, language, from, yesterday);
+        memberDailyStatsRepository.findRecentByMemberIdAndLanguage(memberId, language, days);
 
     TodayTypingSnapshot today = todayTypingStatsRedisService.getTyping(memberId, language);
 
     MemberDailyAggregation yesterdayAgg = null;
     if (isYesterdayBatchPending(memberId, language)) {
+      LocalDate yesterday = todayKst.minusDays(1);
       LocalDateTime yesterdayFrom = TimeUtils.startOfDayKstToUtc(yesterday);
       LocalDateTime yesterdayTo = TimeUtils.endOfDayKstToUtc(yesterday);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/response/MemberDailyStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/dto/response/MemberDailyStatsResponse.java
@@ -47,6 +47,10 @@ public class MemberDailyStatsResponse {
       content.add(DayEntry.fromToday(today, todayDate));
     }
 
+    if (content.size() > days) {
+      content = content.subList(content.size() - days, content.size());
+    }
+
     return create(days, content);
   }
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberDailyStatsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/repository/MemberDailyStatsRepository.java
@@ -19,6 +19,21 @@ public class MemberDailyStatsRepository {
     em.persist(stats);
   }
 
+  public List<MemberDailyStats> findRecentByMemberIdAndLanguage(
+      Long memberId, QuoteLanguage language, int limit) {
+    return em.createQuery(
+            "select s from MemberDailyStats s "
+                + "where s.member.id = :memberId "
+                + "and s.language = :language "
+                + "order by s.date desc",
+            MemberDailyStats.class)
+        .setParameter("memberId", memberId)
+        .setParameter("language", language)
+        .setMaxResults(limit)
+        .getResultList()
+        .reversed();
+  }
+
   public Optional<MemberDailyStats> findByMemberIdAndDate(Long memberId, LocalDate date) {
     return em.createQuery(
             "select s from MemberDailyStats s where s.member.id = :memberId and s.date = :date",


### PR DESCRIPTION
## 주요 내용
- days 파라미터를 날짜 범위가 아닌 최근 N개의 일별 통계 개수로 해석
- 타이핑하지 않은 날이 있어도 항상 요청한 개수만큼 반환

## 세부 내용
### MemberDailyStatsRepository
- findRecentByMemberIdAndLanguage 메서드 추가 (date desc + setMaxResults + reversed)

### MemberStatisticsService
- getDailyStats에서 날짜 범위 조회를 최근 N개 조회로 변경

### MemberDailyStatsResponse
- 오늘/어제 pending 데이터 추가 후 content가 days를 초과하면 오래된 항목부터 제거