### PR TITLE
feat: 로그인 후 리다이렉트, Pretendard 폰트, 통계 차트 개선

### DIFF
--- a/tp-react/index.html
+++ b/tp-react/index.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8"/>
     <link rel="icon" href="/TPfavi.png" type="image/x-icon"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.min.css"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="theme-color" content="#6d28d9"/>
 

--- a/tp-react/src/Context/QuoteContext.tsx
+++ b/tp-react/src/Context/QuoteContext.tsx
@@ -4,6 +4,7 @@ import {useAuth} from "./AuthContext";
 import {useError} from "./ErrorContext";
 import {getQuotes} from "../utils/quoteApi";
 import {defaultQuotes} from "../data/default-quotes.const.ts";
+import {Session_Post_Login_Quote_Source} from "../const/config.const";
 import {t} from "../utils/i18n";
 
 interface Quote {
@@ -165,6 +166,14 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
     useEffect(() => {
         if (!user && quoteSource === QUOTE_SOURCE.MY) {
             setQuoteSource(QUOTE_SOURCE.ALL);
+        }
+        // 로그인 후 저장된 소스 전환 적용
+        if (user) {
+            const pendingSource = sessionStorage.getItem(Session_Post_Login_Quote_Source);
+            if (pendingSource === 'my') {
+                sessionStorage.removeItem(Session_Post_Login_Quote_Source);
+                setQuoteSource(QUOTE_SOURCE.MY);
+            }
         }
     }, [user, quoteSource]);
 

--- a/tp-react/src/components/Contact/Contact.css
+++ b/tp-react/src/components/Contact/Contact.css
@@ -2,8 +2,20 @@
     margin-top: auto;
     margin-bottom: 10rem;
     display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.contact-links {
+    display: flex;
     gap: 1.25rem;
     align-items: center;
+}
+
+.contact-copyright {
+    color: var(--color-text-placeholder);
+    font-size: 0.75rem;
 }
 
 .contact {

--- a/tp-react/src/components/Contact/Contact.jsx
+++ b/tp-react/src/components/Contact/Contact.jsx
@@ -1,28 +1,31 @@
-import { useTheme } from "../../Context/ThemeContext";
-import { Link } from "react-router-dom";
+import {useTheme} from "../../Context/ThemeContext";
+import {Link} from "react-router-dom";
 import "./Contact.css";
 
 const Contact = () => {
-  const { isDark } = useTheme();
+    const {isDark} = useTheme();
 
-  return (
-    <div className={`contact-wrapper ${isDark && "dark"}`}>
-      <a
-        href={"https://open.kakao.com/o/sMHDrAog"}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={`contact ${isDark && "dark"}`}
-      >
-        Contact
-      </a>
-      <Link to="/privacy" className={`contact ${isDark && "dark"}`}>
-        Privacy Policy
-      </Link>
-      <Link to="/terms" className={`contact ${isDark && "dark"}`}>
-        Terms
-      </Link>
-    </div>
-  );
+    return (
+        <div className={`contact-wrapper ${isDark && "dark"}`}>
+            <div className="contact-links">
+                <a
+                    href={"https://open.kakao.com/o/sMHDrAog"}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className={`contact ${isDark && "dark"}`}
+                >
+                    Contact
+                </a>
+                <Link to="/privacy" className={`contact ${isDark && "dark"}`}>
+                    Privacy Policy
+                </Link>
+                <Link to="/terms" className={`contact ${isDark && "dark"}`}>
+                    Terms
+                </Link>
+            </div>
+            <span className="contact-copyright">&copy; 2025 typing-practice.com</span>
+        </div>
+    );
 };
 
 export default Contact;

--- a/tp-react/src/components/Head/Head.jsx
+++ b/tp-react/src/components/Head/Head.jsx
@@ -9,7 +9,7 @@ import NicknamePopup from "../NicknamePopup/NicknamePopup";
 import {useAuth} from "../../Context/AuthContext";
 import {useGoogleLogin} from "@react-oauth/google";
 import {t} from "@/utils/i18n.ts";
-import {Storage_Last_Mode} from "@/const/config.const.ts";
+import {Storage_Last_Mode, Session_Login_Redirect} from "@/const/config.const.ts";
 import FeatureGuide from "../FeatureGuide/FeatureGuide";
 import "./Head.css";
 
@@ -86,6 +86,7 @@ const Head = () => {
                                 if (user) {
                                     navigate('/stats');
                                 } else {
+                                    sessionStorage.setItem(Session_Login_Redirect, '/stats');
                                     googleLogin();
                                 }
                             }}

--- a/tp-react/src/const/config.const.ts
+++ b/tp-react/src/const/config.const.ts
@@ -28,6 +28,8 @@ export const Session_Typing_Count = "Typing-Practice-sessionTypingCount" as cons
 export const LOGIN_PROMPT_THRESHOLD = 3 as const;
 export const CONSENT_BANNER_THRESHOLD = 3 as const;
 export const Session_Login_Prompt_Dismissed = "Typing-Practice-loginPromptDismissed" as const;
+export const Session_Login_Redirect = "Typing-Practice-loginRedirect" as const;
+export const Session_Post_Login_Quote_Source = "Typing-Practice-postLoginQuoteSource" as const;
 
 // Typing Record 관련 상수
 export const RESET_COUNT_THRESHOLD_RATIO = 0.3 as const;

--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -36,9 +36,18 @@ export function localize(item: LocalizedText): string {
 
 export const updateHistory: UpdateEntry[] = [
     {
+        version: "1.4.3",
+        date: "2026-04-12",
+        showPopup: true,
+        hidden: false,
+        improvements: [
+            {ko: "일별 추이 그래프가 최근 7개/30개의 일별 통계를 표시하도록 변경", ja: "日別推移グラフが最新7件/30件の日別統計を表示するよう変更", en: "Daily trend chart now shows the latest 7/30 daily entries"},
+        ]
+    },
+    {
         version: "1.4.2",
         date: "2026-04-07",
-        showPopup: true,
+        showPopup: false,
         hidden: false,
         improvements: [
             {ko: "일부 브라우저 환경에서 로그인 및 기록 조회가 동작하지 않던 문제 수정", ja: "一部のブラウザ環境でログインと記録照会が動作しなかった問題を修正", en: "Fixed login and stats not working in some browser environments"},

--- a/tp-react/src/index.css
+++ b/tp-react/src/index.css
@@ -138,7 +138,7 @@
    =========================================== */
 body {
     margin: 0;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    font-family: Pretendard, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
     -webkit-font-smoothing: antialiased;

--- a/tp-react/src/pages/Home/components/Quote/Quote.jsx
+++ b/tp-react/src/pages/Home/components/Quote/Quote.jsx
@@ -17,7 +17,7 @@ import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useQuote} from "@/Context/QuoteContext.tsx";
 import {useSetting} from "@/Context/SettingContext.tsx";
 import {useAuth} from "@/Context/AuthContext.tsx";
-import {Session_Typing_Count, LOGIN_PROMPT_THRESHOLD, Session_Login_Prompt_Dismissed} from "@/const/config.const.ts";
+import {Session_Typing_Count, LOGIN_PROMPT_THRESHOLD, Session_Login_Prompt_Dismissed, Session_Login_Redirect} from "@/const/config.const.ts";
 import {t} from "@/utils/i18n.ts";
 
 const Quote = () => {
@@ -59,6 +59,7 @@ const Quote = () => {
         if (user) {
             navigate('/quote/upload');
         } else {
+            sessionStorage.setItem(Session_Login_Redirect, '/quote/upload');
             triggerLogin();
         }
     };

--- a/tp-react/src/pages/Home/components/Quote/QuoteSourceSelector/QuoteSourceSelector.jsx
+++ b/tp-react/src/pages/Home/components/Quote/QuoteSourceSelector/QuoteSourceSelector.jsx
@@ -1,6 +1,7 @@
 import './QuoteSourceSelector.css';
 import {useQuote} from "@/Context/QuoteContext.tsx";
 import {useAuth} from "@/Context/AuthContext.tsx";
+import {Session_Post_Login_Quote_Source} from "@/const/config.const.ts";
 import {t} from "@/utils/i18n.ts";
 
 const QuoteSourceSelector = () => {
@@ -14,6 +15,7 @@ const QuoteSourceSelector = () => {
     const handleMyClick = () => {
         const success = changeQuoteSource('my');
         if (!success) {
+            sessionStorage.setItem(Session_Post_Login_Quote_Source, 'my');
             triggerLogin();
         }
     };

--- a/tp-react/src/pages/OAuthCallback/OAuthCallback.tsx
+++ b/tp-react/src/pages/OAuthCallback/OAuthCallback.tsx
@@ -3,6 +3,7 @@ import {useNavigate} from 'react-router-dom';
 import {useAuth} from '@/Context/AuthContext.tsx';
 import {useError} from '@/Context/ErrorContext';
 import {loginWithGoogle} from '@/utils/authApi.ts';
+import {Session_Login_Redirect} from '@/const/config.const.ts';
 import {t} from '@/utils/i18n.ts';
 import LoadingSpinner from '@/components/LoadingSpinner/LoadingSpinner';
 
@@ -46,7 +47,9 @@ const OAuthCallback = () => {
                     isNewMember: userData.newMember,
                 }, userData.accessToken, userData.refreshToken);
 
-                navigate('/', {replace: true});
+                const redirectPath = sessionStorage.getItem(Session_Login_Redirect) || '/';
+                sessionStorage.removeItem(Session_Login_Redirect);
+                navigate(redirectPath, {replace: true});
             } catch (err) {
                 console.error('로그인 실패:', err);
                 showError(t('loginFailed'));

--- a/tp-react/src/pages/Stats/Stats.css
+++ b/tp-react/src/pages/Stats/Stats.css
@@ -1,6 +1,6 @@
 .stats-container {
-    width: 80%;
-    max-width: 1100px;
+    width: 90%;
+    max-width: 1400px;
     min-width: 600px;
     margin: 0 auto;
     padding: 2rem;

--- a/tp-react/src/pages/Stats/components/DailyChart.css
+++ b/tp-react/src/pages/Stats/components/DailyChart.css
@@ -5,6 +5,7 @@
     border-radius: 0.75rem;
     padding: 1.5rem;
     margin-bottom: 1.25rem;
+    overflow-x: auto;
 }
 
 .daily-chart-header {
@@ -54,7 +55,9 @@
 
 .daily-chart-area {
     position: relative;
-    height: 11.25rem;
+    height: auto;
+    min-width: 600px;
+    overflow-x: auto;
 }
 
 .daily-chart-area svg {

--- a/tp-react/src/pages/Stats/components/DailyChart.jsx
+++ b/tp-react/src/pages/Stats/components/DailyChart.jsx
@@ -12,8 +12,8 @@ const formatDateLabel = (dateStr) => {
 const formatPopupTitle = t('formatPopupTitle');
 const formatTime = t('formatTime');
 
-const SVG_W = 600;
-const SVG_H = 180;
+const SVG_W = 1200;
+const SVG_H = 200;
 const PAD = {left: 48, right: 16, top: 24, bottom: 28};
 const CHART_W = SVG_W - PAD.left - PAD.right;
 const CHART_H = SVG_H - PAD.top - PAD.bottom;
@@ -90,7 +90,7 @@ function DailyChart({dailyStats, dailyRange, onRangeChange}) {
                 <div className="daily-chart-empty">{t('noData')}</div>
             ) : (
                 <div className="daily-chart-area" ref={chartRef}>
-                    <svg ref={svgRef} width="100%" height={SVG_H} viewBox={'0 0 ' + SVG_W + ' ' + SVG_H}>
+                    <svg ref={svgRef} width="100%" viewBox={'0 0 ' + SVG_W + ' ' + SVG_H}>
                         {gridLines.map((gl, i) => (
                             <g key={i}>
                                 <line x1={PAD.left} y1={gl.y} x2={SVG_W - PAD.right} y2={gl.y} className="daily-chart-grid"/>


### PR DESCRIPTION
## 주요 내용
- 로그인 후 원래 의도한 화면으로 자동 이동
- Pretendard 웹폰트 적용
- 통계 차트 너비 확장 및 v1.4.3 업데이트 내역 추가

## 세부 내용
### 로그인 후 리다이렉트
- 비로그인 상태에서 기록/업로드 클릭 시 의도한 경로를 sessionStorage에 저장
- OAuthCallback에서 로그인 성공 후 저장된 경로로 이동 (없으면 홈)
- "내 문장만" 클릭 시 로그인 후 자동으로 소스 전환 (Session_Post_Login_Quote_Source)

### Pretendard 폰트
- index.html에 CDN 링크 추가
- index.css font-family 맨 앞에 Pretendard 추가

### 통계 차트
- Stats 컨테이너 너비 80%/1100px → 90%/1400px
- SVG viewBox 600x180 → 1200x200, 고정 height 제거
- 차트 영역 min-width 600px + overflow-x auto (작은 화면 스크롤)

### 기타
- Footer에 copyright 표기 추가
- v1.4.3 업데이트 내역 추가 (일별 통계 조회 방식 변경)