### PR TITLE
v1.5.0: 기록 페이지 리디자인 및 Session Result 개선

### DIFF
--- a/tp-react/package-lock.json
+++ b/tp-react/package-lock.json
@@ -14,7 +14,8 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-icons": "^5.3.0",
-        "react-router-dom": "^7.13.0"
+        "react-router-dom": "^7.13.0",
+        "recharts": "^3.8.1"
       },
       "devDependencies": {
         "@types/react": "18.3.28",
@@ -808,6 +809,42 @@
         "react-dom": ">=16.8.0"
       }
     },
+    "node_modules/@reduxjs/toolkit": {
+      "version": "2.11.2",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.11.2.tgz",
+      "integrity": "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@standard-schema/utils": "^0.3.0",
+        "immer": "^11.0.0",
+        "redux": "^5.0.1",
+        "redux-thunk": "^3.1.0",
+        "reselect": "^5.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.9.0 || ^17.0.0 || ^18 || ^19",
+        "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-redux": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@reduxjs/toolkit/node_modules/immer": {
+      "version": "11.1.4",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.4.tgz",
+      "integrity": "sha512-XREFCPo6ksxVzP4E0ekD5aMdf8WMwmdNaz6vuvxgI40UaEiu6q3p8X52aU6GdyvLY3XXX/8R7JOTXStz/nBbRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1165,6 +1202,18 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1210,6 +1259,69 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1221,14 +1333,14 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.28",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1244,6 +1356,12 @@
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/use-sync-external-store": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
+      "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
     },
     "node_modules/@vercel/analytics": {
       "version": "1.6.1",
@@ -1399,6 +1517,15 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -1435,8 +1562,129 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1455,6 +1703,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js-light": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
+      "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==",
+      "license": "MIT"
     },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
@@ -1531,6 +1785,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-toolkit": {
+      "version": "1.45.1",
+      "resolved": "https://registry.npmjs.org/es-toolkit/-/es-toolkit-1.45.1.tgz",
+      "integrity": "sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==",
+      "license": "MIT",
+      "workspaces": [
+        "docs",
+        "benchmarks"
+      ]
+    },
     "node_modules/esbuild": {
       "version": "0.25.12",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
@@ -1582,6 +1846,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1757,6 +2027,25 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/immer": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-10.2.0.tgz",
+      "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/js-tokens": {
@@ -1965,6 +2254,36 @@
         "react": "*"
       }
     },
+    "node_modules/react-is": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.5.tgz",
+      "integrity": "sha512-Dn0t8IQhCmeIT3wu+Apm1/YVsJXsGWi6k4sPdnBIdqMVtHtv0IGi6dcpNpNkNac0zB2uUAqNX3MHzN8c+z2rwQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-redux": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
+      "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/use-sync-external-store": "^0.0.6",
+        "use-sync-external-store": "^1.4.0"
+      },
+      "peerDependencies": {
+        "@types/react": "^18.2.25 || ^19",
+        "react": "^18.0 || ^19",
+        "redux": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "redux": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -2012,6 +2331,57 @@
         "react": ">=18",
         "react-dom": ">=18"
       }
+    },
+    "node_modules/recharts": {
+      "version": "3.8.1",
+      "resolved": "https://registry.npmjs.org/recharts/-/recharts-3.8.1.tgz",
+      "integrity": "sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==",
+      "license": "MIT",
+      "workspaces": [
+        "www"
+      ],
+      "dependencies": {
+        "@reduxjs/toolkit": "^1.9.0 || 2.x.x",
+        "clsx": "^2.1.1",
+        "decimal.js-light": "^2.5.1",
+        "es-toolkit": "^1.39.3",
+        "eventemitter3": "^5.0.1",
+        "immer": "^10.1.1",
+        "react-redux": "8.x.x || 9.x.x",
+        "reselect": "5.1.1",
+        "tiny-invariant": "^1.3.3",
+        "use-sync-external-store": "^1.2.2",
+        "victory-vendor": "^37.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/redux": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
+      "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
+      "license": "MIT"
+    },
+    "node_modules/redux-thunk": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/redux-thunk/-/redux-thunk-3.1.0.tgz",
+      "integrity": "sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "redux": "^5.0.0"
+      }
+    },
+    "node_modules/reselect": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-5.1.1.tgz",
+      "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
+      "license": "MIT"
     },
     "node_modules/rollup": {
       "version": "4.57.1",
@@ -2093,6 +2463,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/tiny-invariant": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+      "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -2153,6 +2529,37 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/victory-vendor": {
+      "version": "37.3.6",
+      "resolved": "https://registry.npmjs.org/victory-vendor/-/victory-vendor-37.3.6.tgz",
+      "integrity": "sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==",
+      "license": "MIT AND ISC",
+      "dependencies": {
+        "@types/d3-array": "^3.0.3",
+        "@types/d3-ease": "^3.0.0",
+        "@types/d3-interpolate": "^3.0.1",
+        "@types/d3-scale": "^4.0.2",
+        "@types/d3-shape": "^3.1.0",
+        "@types/d3-time": "^3.0.0",
+        "@types/d3-timer": "^3.0.0",
+        "d3-array": "^3.1.6",
+        "d3-ease": "^3.0.1",
+        "d3-interpolate": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-shape": "^3.1.0",
+        "d3-time": "^3.0.0",
+        "d3-timer": "^3.0.1"
       }
     },
     "node_modules/vite": {

--- a/tp-react/package.json
+++ b/tp-react/package.json
@@ -10,7 +10,8 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-icons": "^5.3.0",
-    "react-router-dom": "^7.13.0"
+    "react-router-dom": "^7.13.0",
+    "recharts": "^3.8.1"
   },
   "scripts": {
     "dev": "vite",

--- a/tp-react/src/Context/ScoreContext.tsx
+++ b/tp-react/src/Context/ScoreContext.tsx
@@ -1,4 +1,5 @@
 import {createContext, Dispatch, ReactNode, SetStateAction, useContext, useState} from "react";
+import {TypoEntry} from "@/utils/typingRecordApi";
 
 type InputCheckState = ('none' | 'correct' | 'incorrect')[];
 
@@ -42,6 +43,12 @@ interface ScoreContextType {
     setShowPopup: Dispatch<SetStateAction<boolean>>;
     popupData: PopupData;
     setPopupData: Dispatch<SetStateAction<PopupData>>;
+    popupCpmList: number[];
+    setPopupCpmList: Dispatch<SetStateAction<number[]>>;
+    popupAccList: number[];
+    setPopupAccList: Dispatch<SetStateAction<number[]>>;
+    popupTypos: TypoEntry[];
+    setPopupTypos: Dispatch<SetStateAction<TypoEntry[]>>;
     cpmList: number[];
     setCpmList: Dispatch<SetStateAction<number[]>>;
     accList: number[];
@@ -89,6 +96,9 @@ export const ScoreContextProvider = ({children}: ScoreContextProviderProps) => {
 
     const [showPopup, setShowPopup] = useState<boolean>(false);
     const [popupData, setPopupData] = useState<PopupData>({avgCpm: 0, maxCpm: 0, acc: 0});
+    const [popupCpmList, setPopupCpmList] = useState<number[]>([]);
+    const [popupAccList, setPopupAccList] = useState<number[]>([]);
+    const [popupTypos, setPopupTypos] = useState<TypoEntry[]>([]);
 
     const [cpmList, setCpmList] = useState<number[]>([]);
     const [accList, setAccList] = useState<number[]>([]);
@@ -107,6 +117,9 @@ export const ScoreContextProvider = ({children}: ScoreContextProviderProps) => {
                 incorrectCount, setIncorrectCount,
                 showPopup, setShowPopup,
                 popupData, setPopupData,
+                popupCpmList, setPopupCpmList,
+                popupAccList, setPopupAccList,
+                popupTypos, setPopupTypos,
                 cpmList, setCpmList,
                 accList, setAccList,
                 resetCount, setResetCount,

--- a/tp-react/src/components/Head/Head.jsx
+++ b/tp-react/src/components/Head/Head.jsx
@@ -23,7 +23,7 @@ const isUuidFormat = (str) => {
 const Head = () => {
     const navigate = useNavigate();
     const location = useLocation();
-    const {user, accessToken, refreshToken, isLoading, setIsLoading, login, loginTrigger} = useAuth();
+    const {user, accessToken, refreshToken, isLoading, login, loginTrigger} = useAuth();
     const [showNicknamePopup, setShowNicknamePopup] = useState(false);
     const prevLoginTriggerRef = useRef(loginTrigger);
 

--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -43,6 +43,7 @@ export const updateHistory: UpdateEntry[] = [
         features: [
             {ko: "기록 페이지 디자인 전면 개편", ja: "記録ページのデザインを全面改修", en: "Complete redesign of the Records page"},
             {ko: "키보드 에러 히트맵 추가", ja: "キーボードエラーヒートマップ追加", en: "Added keyboard error heatmap"},
+            {ko: "세션 결과 팝업에 CPM/ACC 추이 그래프 및 히트맵 추가", ja: "セッション結果ポップアップにCPM/ACC推移グラフとヒートマップを追加", en: "Added CPM/ACC trend graph and heatmap to session result popup"},
             {ko: "업데이트 기록 페이지 타임라인 디자인 적용", ja: "アップデート履歴ページにタイムラインデザインを適用", en: "Applied timeline design to the Update History page"},
         ],
         improvements: [

--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -36,9 +36,24 @@ export function localize(item: LocalizedText): string {
 
 export const updateHistory: UpdateEntry[] = [
     {
-        version: "1.4.3",
+        version: "1.5.0",
         date: "2026-04-12",
         showPopup: true,
+        hidden: false,
+        features: [
+            {ko: "기록 페이지 디자인 전면 개편", ja: "記録ページのデザインを全面改修", en: "Complete redesign of the Records page"},
+            {ko: "키보드 에러 히트맵 추가", ja: "キーボードエラーヒートマップ追加", en: "Added keyboard error heatmap"},
+            {ko: "업데이트 기록 페이지 타임라인 디자인 적용", ja: "アップデート履歴ページにタイムラインデザインを適用", en: "Applied timeline design to the Update History page"},
+        ],
+        improvements: [
+            {ko: "일별 추이 차트 곡선 그래프로 개선", ja: "日別推移チャートを曲線グラフに改善", en: "Improved daily trend chart with curved graph"},
+            {ko: "Pretendard 웹폰트 적용", ja: "Pretendardウェブフォント適用", en: "Applied Pretendard web font"},
+        ]
+    },
+    {
+        version: "1.4.3",
+        date: "2026-04-12",
+        showPopup: false,
         hidden: false,
         improvements: [
             {ko: "일별 추이 그래프가 최근 7개/30개의 일별 통계를 표시하도록 변경", ja: "日別推移グラフが最新7件/30件の日別統計を表示するよう変更", en: "Daily trend chart now shows the latest 7/30 daily entries"},

--- a/tp-react/src/pages/Home/components/AverageScorePopUp/AverageScorePopUp.css
+++ b/tp-react/src/pages/Home/components/AverageScorePopUp/AverageScorePopUp.css
@@ -16,7 +16,9 @@
     transform: translate(-50%, -50%);
     background-color: var(--color-popup-bg);
     color: var(--color-text);
-    width: 22rem;
+    width: 52rem;
+    max-height: 90vh;
+    overflow-y: auto;
     border-radius: 1rem;
     display: flex;
     flex-direction: column;
@@ -142,4 +144,23 @@
 
 .popup-login-prompt:hover {
     opacity: 0.7;
+}
+
+/* 세션 데이터 영역 */
+.popup-session-data {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-border);
+}
+
+.popup-session-section-title {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
 }

--- a/tp-react/src/pages/Home/components/AverageScorePopUp/AverageScorePopUp.jsx
+++ b/tp-react/src/pages/Home/components/AverageScorePopUp/AverageScorePopUp.jsx
@@ -6,9 +6,11 @@ import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useAuth} from "@/Context/AuthContext.tsx";
 import {getTypingStats} from "@/utils/statsApi.ts";
 import {t} from "@/utils/i18n.ts";
+import SessionChart from "./SessionChart";
+import KeyboardHeatmap from "@/pages/Stats/components/KeyboardHeatmap";
 
 const AverageScorePopUp = () => {
-    const {showPopup, setShowPopup, popupData} = useScore();
+    const {showPopup, setShowPopup, popupData, popupCpmList, popupAccList, popupTypos, setPopupTypos} = useScore();
     const {isDark} = useTheme();
     const {user, triggerLogin} = useAuth();
     const navigate = useNavigate();
@@ -37,15 +39,18 @@ const AverageScorePopUp = () => {
 
     const handleBackgroundClick = () => {
         setShowPopup(false);
+        setPopupTypos([]);
     };
 
     const handleLoginClick = () => {
         setShowPopup(false);
+        setPopupTypos([]);
         triggerLogin();
     };
 
     const handleViewStats = () => {
         setShowPopup(false);
+        setPopupTypos([]);
         navigate('/stats');
     };
 
@@ -89,6 +94,20 @@ const AverageScorePopUp = () => {
                         </div>
                     )}
                 </div>
+
+                {/* 세션 차트 + 히트맵 */}
+                {popupCpmList.length > 0 && (
+                    <div className="popup-session-data">
+                        <div>
+                            <div className="popup-session-section-title">{t('sessionTrend')}</div>
+                            <SessionChart cpmList={popupCpmList} accList={popupAccList}/>
+                        </div>
+                        <div>
+                            <div className="popup-session-section-title">{t('keyboardHeatmap')}</div>
+                            <KeyboardHeatmap externalTypos={popupTypos} compact/>
+                        </div>
+                    </div>
+                )}
 
                 <div className="popup-bottom">
                     {user && (

--- a/tp-react/src/pages/Home/components/AverageScorePopUp/SessionChart.css
+++ b/tp-react/src/pages/Home/components/AverageScorePopUp/SessionChart.css
@@ -1,0 +1,41 @@
+.session-chart {
+    margin-top: 1.25rem;
+}
+
+.session-chart-title {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.75rem;
+}
+
+.session-chart .recharts-wrapper,
+.session-chart .recharts-wrapper * {
+    outline: none;
+}
+
+.session-chart-tooltip {
+    background: var(--color-popup-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.375rem;
+    padding: 0.5rem 0.75rem;
+    font-size: 0.75rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.session-chart-tooltip-row {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.session-chart-tooltip-label {
+    color: var(--color-text-muted);
+}
+
+.session-chart-tooltip-value {
+    font-weight: 600;
+    color: var(--color-text);
+}

--- a/tp-react/src/pages/Home/components/AverageScorePopUp/SessionChart.jsx
+++ b/tp-react/src/pages/Home/components/AverageScorePopUp/SessionChart.jsx
@@ -1,0 +1,52 @@
+import {ResponsiveContainer, LineChart, Line, XAxis, YAxis, Tooltip} from 'recharts';
+import {computeAxis} from '@/pages/Stats/components/dailyChartUtils';
+import './SessionChart.css';
+
+const CustomTooltip = ({active, payload, label}) => {
+    if (!active || !payload || payload.length === 0) return null;
+    return (
+        <div className="session-chart-tooltip">
+            <div className="session-chart-tooltip-row">
+                <span className="session-chart-tooltip-label">#{label}</span>
+            </div>
+            {payload.map((p, i) => (
+                <div key={i} className="session-chart-tooltip-row">
+                    <span className="session-chart-tooltip-label">{p.name}</span>
+                    <span className="session-chart-tooltip-value" style={{color: p.color}}>
+                        {p.name === 'ACC' ? p.value + '%' : p.value}
+                    </span>
+                </div>
+            ))}
+        </div>
+    );
+};
+
+function SessionChart({cpmList, accList}) {
+    if (!cpmList || cpmList.length === 0) return null;
+
+    const data = cpmList.map((cpm, i) => ({
+        index: i + 1,
+        CPM: Math.round(cpm),
+        ACC: accList[i] != null ? Math.round(accList[i]) : null,
+    }));
+
+    const cpmAxis = computeAxis(data.map(d => ({value: d.CPM})), 'cpm');
+    const accAxis = computeAxis(data.filter(d => d.ACC != null).map(d => ({value: d.ACC})), 'acc');
+
+    return (
+        <div className="session-chart">
+            <ResponsiveContainer width="100%" height={120}>
+                <LineChart data={data} margin={{top: 8, right: 8, bottom: 0, left: 0}}>
+                    <XAxis dataKey="index" tick={{fontSize: 10, fill: 'var(--color-text-placeholder)'}} axisLine={false} tickLine={false}/>
+                    <YAxis yAxisId="cpm" domain={cpmAxis.domain} ticks={cpmAxis.ticks} tick={{fontSize: 10, fill: 'var(--color-text-placeholder)'}} axisLine={false} tickLine={false} width={40}/>
+                    <YAxis yAxisId="acc" orientation="right" domain={accAxis.domain} ticks={accAxis.ticks} tick={{fontSize: 10, fill: 'var(--color-text-placeholder)'}} axisLine={false} tickLine={false} tickFormatter={v => v + '%'} width={40}/>
+                    <Tooltip content={<CustomTooltip/>} cursor={false}/>
+                    <Line yAxisId="cpm" type="monotone" dataKey="CPM" stroke="var(--color-primary)" strokeWidth={1.5} dot={{r: 3, fill: 'var(--color-primary)', strokeWidth: 0}} activeDot={{r: 5}}/>
+                    <Line yAxisId="acc" type="monotone" dataKey="ACC" stroke="var(--color-success)" strokeWidth={1.5} dot={{r: 3, fill: 'var(--color-success)', strokeWidth: 0}} activeDot={{r: 5}}/>
+                </LineChart>
+            </ResponsiveContainer>
+        </div>
+    );
+}
+
+export default SessionChart;

--- a/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
+++ b/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
@@ -35,6 +35,9 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
         showPopup,
         setShowPopup,
         setPopupData,
+        setPopupCpmList,
+        setPopupAccList,
+        setPopupTypos,
     } = useScore();
     const {sentence, currentQuote, setQuotesIndex} = useQuote(); // 예문, 예문의 인덱스
     const {resultPeriod, fontSize, isCompactMode} = useSetting();
@@ -185,6 +188,7 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
             // 팝업이 열려있으면 팝업 닫기
             if (showPopup) {
                 setShowPopup(false);
+                setPopupTypos([]);
                 return;
             }
 
@@ -221,6 +225,12 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
         const cpm = currentCpmRef.current;
         setLastCpm(cpm);
 
+        // 서버에 보내는 typo를 context에도 누적 (ref는 나중에 초기화되므로 값을 복사)
+        const currentTypos = [...typosRef.current];
+        if (currentTypos.length > 0) {
+            setPopupTypos(prev => [...prev, ...currentTypos]);
+        }
+
         // CPM, ACC 리스트에 추가
         cpmListRef.current = [...cpmListRef.current, cpm];
         accListRef.current = [...accListRef.current, newAcc];
@@ -245,6 +255,8 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
                     maxCpm: Math.round(max(recentCpmList)),
                     acc: Math.round(average(recentAccList)),
                 });
+                setPopupCpmList(recentCpmList);
+                setPopupAccList(recentAccList);
                 setShowPopup(true);
             }
 

--- a/tp-react/src/pages/QuoteUpload/components/UploadEntry.css
+++ b/tp-react/src/pages/QuoteUpload/components/UploadEntry.css
@@ -45,33 +45,34 @@
 /* 공개/비공개 토글 */
 .quote-upload-entry-type-toggle {
     display: flex;
-    gap: 0.5rem;
+    background: var(--color-bg-secondary);
+    padding: 0.125rem;
+    border-radius: 0.5rem;
+    width: fit-content;
     margin-bottom: 0.5rem;
 }
 
 .quote-upload-entry-type-btn {
-    padding: 0.25rem 0.5rem;
-    border: 1px solid var(--color-border);
-    border-radius: 0.25rem;
-    background-color: transparent;
-    color: var(--color-text-placeholder);
+    padding: 0.25rem 0.75rem;
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
     font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
     cursor: pointer;
-    transition: all 0.2s;
+    border-radius: 0.375rem;
+    transition: all 0.15s;
     display: flex;
     align-items: center;
     gap: 0.25rem;
 }
 
-.quote-upload-entry-type-btn:hover {
-    border-color: var(--color-primary);
-    color: var(--color-primary);
-}
-
 .quote-upload-entry-type-btn.active {
-    border-color: var(--color-primary);
-    background-color: var(--color-primary);
-    color: var(--color-white);
+    background: var(--color-popup-bg);
+    color: var(--color-primary);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
 /* 입력 필드 */

--- a/tp-react/src/pages/Stats/Stats.css
+++ b/tp-react/src/pages/Stats/Stats.css
@@ -10,14 +10,20 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 1.75rem;
+    margin-bottom: 3rem;
 }
 
 .stats-title {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--color-primary);
+    font-size: 1.875rem;
+    font-weight: 300;
+    color: var(--color-text);
     margin: 0;
+    letter-spacing: -0.025em;
+}
+
+:lang(ko) .stats-title,
+:lang(ko) .stats-number {
+    font-weight: 400;
 }
 
 .stats-refresh-btn {
@@ -61,25 +67,9 @@
     }
 }
 
-/* Footer */
-.stats-footer {
-    margin-top: 1.75rem;
-    display: flex;
-    justify-content: center;
-}
-
-.stats-back-btn {
-    padding: 0.75rem 2rem;
-    border: 1px solid var(--color-border);
-    border-radius: 0.5rem;
-    background-color: transparent;
-    color: var(--color-text-muted);
-    font-size: 1rem;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.stats-back-btn:hover {
-    background-color: var(--color-bg-secondary);
-    color: var(--color-text);
+.stats-bottom-grid {
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: 4rem;
+    margin-bottom: 1.75rem;
 }

--- a/tp-react/src/pages/Stats/Stats.jsx
+++ b/tp-react/src/pages/Stats/Stats.jsx
@@ -8,6 +8,7 @@ import {t} from '@/utils/i18n.ts';
 import StatsSummary from './components/StatsSummary';
 import DailyChart from './components/DailyChart';
 import TypoList from './components/TypoList';
+import KeyboardHeatmap from './components/KeyboardHeatmap';
 import './Stats.css';
 
 function Stats() {
@@ -108,16 +109,13 @@ function Stats() {
                     {/* 일별 추이 */}
                     <DailyChart dailyStats={dailyStats} dailyRange={dailyRange} onRangeChange={setDailyRange}/>
 
-                    {/* 오타 통계 */}
-                    <TypoList typoStats={typoStats}/>
+                    {/* 오타 통계 + 키보드 히트맵 */}
+                    <div className="stats-bottom-grid">
+                        <TypoList typoStats={typoStats}/>
+                        <KeyboardHeatmap/>
+                    </div>
                 </>
             )}
-
-            <div className="stats-footer">
-                <button className="stats-back-btn" onClick={() => navigate('/')}>
-                    {t('back')}
-                </button>
-            </div>
         </div>
     );
 }

--- a/tp-react/src/pages/Stats/components/DailyChart.css
+++ b/tp-react/src/pages/Stats/components/DailyChart.css
@@ -1,121 +1,63 @@
 .daily-chart-section {
     position: relative;
     background: var(--color-popup-bg);
-    border: 1px solid var(--color-border);
     border-radius: 0.75rem;
-    padding: 1.5rem;
-    margin-bottom: 1.25rem;
-    overflow-x: auto;
+    padding: 2.5rem;
+    margin-bottom: 4rem;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 }
 
 .daily-chart-header {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 1.25rem;
+    margin-bottom: 2.5rem;
 }
 
 .daily-chart-title {
     margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: 1.125rem;
+    font-weight: 500;
     color: var(--color-text);
 }
 
 .daily-chart-tabs {
     display: flex;
-    gap: 0.375rem;
+    gap: 1.5rem;
     align-items: center;
 }
 
-.daily-chart-tab {
-    padding: 0.375rem 0.875rem;
-    border-radius: 0.375rem;
-    border: 1px solid var(--color-border);
+.daily-chart-toggle-group {
+    display: flex;
+    background: var(--color-bg-secondary);
+    padding: 0.125rem;
+    border-radius: 0.5rem;
+}
+
+.daily-chart-toggle {
+    padding: 0.25rem 0.75rem;
+    border: none;
     background: transparent;
     color: var(--color-text-muted);
-    font-size: 0.8125rem;
-    font-weight: 500;
+    font-size: 0.625rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
     cursor: pointer;
+    border-radius: 0.375rem;
     transition: all 0.15s;
 }
 
-.daily-chart-tab.active {
-    border-color: var(--color-primary);
-    background: var(--color-primary-bg);
+.daily-chart-toggle.active {
+    background: var(--color-popup-bg);
     color: var(--color-primary);
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
 }
 
-.daily-chart-tab-divider {
-    width: 1px;
-    height: 1rem;
-    background: var(--color-border);
-    margin: 0 0.25rem;
-}
-
-.daily-chart-area {
-    position: relative;
-    height: auto;
-    min-width: 600px;
-    overflow-x: auto;
-}
-
-.daily-chart-area svg {
-    display: block;
-}
-
-.daily-chart-grid {
-    stroke: var(--color-border);
-    stroke-width: 0.5;
-}
-
-.daily-chart-grid-label {
-    font-size: 0.6875rem;
-    fill: var(--color-text-muted);
-    text-anchor: end;
-}
-
-.daily-chart-fill {
-    fill: var(--color-primary);
-    opacity: 0.08;
-}
-
-.daily-chart-line {
-    fill: none;
-    stroke: var(--color-primary);
-    stroke-width: 2;
-    stroke-linejoin: round;
-    stroke-linecap: round;
-}
-
-.daily-chart-dot {
-    fill: var(--color-primary);
-    stroke: var(--color-popup-bg);
-    stroke-width: 2;
-    transition: r 0.15s;
-}
-
-.daily-chart-tooltip {
-    transition: opacity 0.15s;
-    pointer-events: none;
-}
-
-.daily-chart-tooltip-bg {
-    fill: var(--color-popup-bg);
-    stroke: var(--color-border);
-    stroke-width: 0.5;
-}
-
-.daily-chart-tooltip-text {
-    font-size: 0.875rem;
-    fill: var(--color-text);
-    font-weight: 600;
-    text-anchor: middle;
-}
-
-.daily-chart-date-label {
-    font-size: 0.6875rem;
-    fill: var(--color-text-muted);
+.daily-chart-section .recharts-wrapper,
+.daily-chart-section .recharts-wrapper *,
+.daily-chart-section .recharts-responsive-container {
+    outline: none;
 }
 
 .daily-chart-empty {
@@ -127,46 +69,68 @@
 
 /* Hover popup */
 .daily-chart-popup {
-    position: absolute;
     z-index: 10;
     pointer-events: none;
     background: var(--color-popup-bg);
     border: 1px solid var(--color-border);
-    border-radius: 0.5rem;
-    padding: 0.875rem;
+    border-radius: 0.75rem;
+    padding: 1.25rem;
     width: 280px;
-    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.08);
+    box-shadow: 0 4px 24px rgba(0, 0, 0, 0.1);
+}
+
+.daily-chart-popup-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .daily-chart-popup-title {
-    font-size: 0.8125rem;
-    font-weight: 500;
-    color: var(--color-primary);
-    margin-bottom: 0.625rem;
+    font-size: 0.875rem;
+    font-weight: 700;
+    color: var(--color-text);
+    text-transform: uppercase;
+    letter-spacing: 0.02em;
 }
 
-.daily-chart-popup-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 0.5rem;
+.daily-chart-popup-dot {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: var(--color-primary);
 }
 
-.daily-chart-popup-item {
-    background: var(--color-bg-secondary);
-    border-radius: 0.375rem;
-    padding: 0.5rem 0.625rem;
+.daily-chart-popup-divider {
+    height: 1px;
+    background: var(--color-primary);
+    opacity: 0.3;
+    margin: 0.75rem 0;
+}
+
+.daily-chart-popup-list {
     display: flex;
     flex-direction: column;
-    gap: 0.125rem;
+    gap: 0.625rem;
+}
+
+.daily-chart-popup-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .daily-chart-popup-label {
-    font-size: 0.625rem;
+    font-size: 0.8125rem;
+    font-weight: 500;
     color: var(--color-text-muted);
 }
 
 .daily-chart-popup-value {
-    font-size: 0.8125rem;
-    font-weight: 500;
+    font-size: 0.875rem;
+    font-weight: 700;
     color: var(--color-text);
+}
+
+.daily-chart-popup-value.highlight {
+    color: var(--color-primary);
 }

--- a/tp-react/src/pages/Stats/components/DailyChart.css
+++ b/tp-react/src/pages/Stats/components/DailyChart.css
@@ -39,7 +39,7 @@
     border: none;
     background: transparent;
     color: var(--color-text-muted);
-    font-size: 0.625rem;
+    font-size: 0.75rem;
     font-weight: 700;
     text-transform: uppercase;
     letter-spacing: 0.1em;

--- a/tp-react/src/pages/Stats/components/DailyChart.jsx
+++ b/tp-react/src/pages/Stats/components/DailyChart.jsx
@@ -1,160 +1,103 @@
-import {useState, useRef, useCallback} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {Area, AreaChart, ResponsiveContainer, XAxis, YAxis} from 'recharts';
 import {t} from '@/utils/i18n.ts';
+import {formatDateLabel, computeAxis} from './dailyChartUtils';
+import DailyChartDot from './DailyChartDot';
+import DailyChartPopup from './DailyChartPopup';
 import './DailyChart.css';
-
-const MONTH_NAMES = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
-
-const formatDateLabel = (dateStr) => {
-    const parts = dateStr.split('-');
-    return MONTH_NAMES[parseInt(parts[1]) - 1] + ' ' + parseInt(parts[2]);
-};
-
-const formatPopupTitle = t('formatPopupTitle');
-const formatTime = t('formatTime');
-
-const SVG_W = 1200;
-const SVG_H = 200;
-const PAD = {left: 48, right: 16, top: 24, bottom: 28};
-const CHART_W = SVG_W - PAD.left - PAD.right;
-const CHART_H = SVG_H - PAD.top - PAD.bottom;
-const GRID_COUNT = 4;
 
 function DailyChart({dailyStats, dailyRange, onRangeChange}) {
     const [metric, setMetric] = useState('cpm');
     const [hoverIndex, setHoverIndex] = useState(null);
-    const [popupData, setPopupData] = useState(null);
+    const [lockedIndex, setLockedIndex] = useState(null);
     const [popupPos, setPopupPos] = useState({x: 0, y: 0});
-    const chartRef = useRef(null);
-    const svgRef = useRef(null);
+    const sectionRef = useRef(null);
+    const activeIndex = lockedIndex ?? hoverIndex;
 
-    const data = dailyStats || [];
-    const values = data.map(d => metric === 'cpm' ? d.avgCpm : Math.round(d.avgAcc * 100));
-    const maxVal = values.length > 0 ? Math.max(...values) : 0;
-    const minVal = values.length > 0 ? Math.min(...values) : 0;
-    const padding = (maxVal - minVal) * 0.1 || 5;
-    const yMax = metric === 'acc' ? Math.min(maxVal + padding, 100) : maxVal + padding;
-    const yMin = minVal - padding;
-    const yRange = yMax - yMin || 1;
+    const data = (dailyStats || []).map((d, i, arr) => ({
+        ...d,
+        displayDate: formatDateLabel(d.date, i > 0 ? arr[i - 1].date : null),
+        value: metric === 'cpm' ? Math.round(d.avgCpm) : Math.round(d.avgAcc * 100),
+    }));
 
-    const points = data.map((d, i) => {
-        const x = data.length > 1 ? PAD.left + (i / (data.length - 1)) * CHART_W : PAD.left + CHART_W / 2;
-        const y = PAD.top + CHART_H - ((values[i] - yMin) / yRange) * CHART_H;
-        return {x, y};
-    });
+    const {domain, ticks} = data.length > 0 ? computeAxis(data, metric) : {domain: [0, 100], ticks: [0, 25, 50, 75, 100]};
 
-    const linePoints = points.map(p => p.x + ',' + p.y).join(' ');
-    const areaPoints = points.length > 0
-        ? PAD.left + ',' + (PAD.top + CHART_H) + ' ' + linePoints + ' ' + points[points.length - 1].x + ',' + (PAD.top + CHART_H)
-        : '';
-
-    const gridLines = [];
-    for (let g = 0; g <= GRID_COUNT; g++) {
-        const gy = PAD.top + (g / GRID_COUNT) * CHART_H;
-        const gVal = Math.round(yMax - (g / GRID_COUNT) * yRange);
-        gridLines.push({y: gy, label: metric === 'cpm' ? gVal : gVal + '%'});
-    }
-
-    const labelInterval = data.length > 14 ? Math.ceil(data.length / 6) : 1;
-
-    const handleMouseEnter = useCallback((e, i) => {
-        setHoverIndex(i);
-        setPopupData(data[i]);
-        if (chartRef.current) {
+    const updatePopupPos = useCallback((e) => {
+        if (sectionRef.current) {
             const circle = e.target.getBoundingClientRect();
-            const area = chartRef.current.getBoundingClientRect();
-            setPopupPos({
-                x: circle.left - area.left + circle.width / 2 + 8,
-                y: circle.top - area.top + circle.height / 2 + 20,
-            });
+            const section = sectionRef.current.getBoundingClientRect();
+            const popupWidth = 280;
+            let x = circle.left - section.left + circle.width / 2 + 8;
+            const y = circle.top - section.top + circle.height / 2 + 20;
+            const overflow = x + popupWidth - section.width;
+            if (overflow > 0) x -= overflow + 16;
+            setPopupPos({x, y});
         }
-    }, [data]);
-
-    const handleMouseLeave = useCallback(() => {
-        setHoverIndex(null);
-        setPopupData(null);
     }, []);
 
+    const handleDotEnter = useCallback((e, index) => {
+        setHoverIndex(index);
+        if (lockedIndex === null) updatePopupPos(e);
+    }, [lockedIndex, updatePopupPos]);
+
+    const handleDotLeave = useCallback(() => {
+        setHoverIndex(null);
+    }, []);
+
+    const handleDotClick = useCallback((e, index) => {
+        if (lockedIndex === index) {
+            setLockedIndex(null);
+        } else {
+            setLockedIndex(index);
+            updatePopupPos(e);
+        }
+    }, [lockedIndex, updatePopupPos]);
+
+    useEffect(() => {
+        if (lockedIndex === null) return;
+        const handleDocClick = () => setLockedIndex(null);
+        document.addEventListener('click', handleDocClick);
+        return () => document.removeEventListener('click', handleDocClick);
+    }, [lockedIndex]);
+
     return (
-        <div className="daily-chart-section">
+        <div className="daily-chart-section" ref={sectionRef}>
             <div className="daily-chart-header">
                 <h3 className="daily-chart-title">{t('dailyTrend')}</h3>
                 <div className="daily-chart-tabs">
-                    <button className={'daily-chart-tab' + (metric === 'cpm' ? ' active' : '')} onClick={() => setMetric('cpm')}>CPM</button>
-                    <button className={'daily-chart-tab' + (metric === 'acc' ? ' active' : '')} onClick={() => setMetric('acc')}>{t('accuracyTab')}</button>
-                    <span className="daily-chart-tab-divider"/>
-                    <button className={'daily-chart-tab' + (dailyRange === 7 ? ' active' : '')} onClick={() => onRangeChange(7)}>{t('days')(7)}</button>
-                    <button className={'daily-chart-tab' + (dailyRange === 30 ? ' active' : '')} onClick={() => onRangeChange(30)}>{t('days')(30)}</button>
+                    <div className="daily-chart-toggle-group">
+                        <button className={'daily-chart-toggle' + (metric === 'cpm' ? ' active' : '')} onClick={() => setMetric('cpm')}>CPM</button>
+                        <button className={'daily-chart-toggle' + (metric === 'acc' ? ' active' : '')} onClick={() => setMetric('acc')}>{t('accuracyTab')}</button>
+                    </div>
+                    <div className="daily-chart-toggle-group">
+                        <button className={'daily-chart-toggle' + (dailyRange === 7 ? ' active' : '')} onClick={() => onRangeChange(7)}>{t('days')(7)}</button>
+                        <button className={'daily-chart-toggle' + (dailyRange === 30 ? ' active' : '')} onClick={() => onRangeChange(30)}>{t('days')(30)}</button>
+                    </div>
                 </div>
             </div>
             {data.length === 0 ? (
                 <div className="daily-chart-empty">{t('noData')}</div>
             ) : (
-                <div className="daily-chart-area" ref={chartRef}>
-                    <svg ref={svgRef} width="100%" viewBox={'0 0 ' + SVG_W + ' ' + SVG_H}>
-                        {gridLines.map((gl, i) => (
-                            <g key={i}>
-                                <line x1={PAD.left} y1={gl.y} x2={SVG_W - PAD.right} y2={gl.y} className="daily-chart-grid"/>
-                                <text x={PAD.left - 8} y={gl.y + 4} className="daily-chart-grid-label">{gl.label}</text>
-                            </g>
-                        ))}
-                        {areaPoints && data.length > 1 && <polygon points={areaPoints} className="daily-chart-fill"/>}
-                        {linePoints && data.length > 1 && <polyline points={linePoints} className="daily-chart-line"/>}
-                        {points.map((p, i) => {
-                            const showLabel = (i % labelInterval === 0) || (i === data.length - 1);
-                            let textAnchor = 'middle';
-                            if (showLabel && i === 0) textAnchor = 'start';
-                            else if (showLabel && i === data.length - 1) textAnchor = 'end';
-                            const displayVal = metric === 'cpm' ? Math.round(values[i]) : values[i] + '%';
-                            return (
-                                <g key={i}>
-                                    <circle cx={p.x} cy={p.y} r={hoverIndex === i ? 6 : 4} className="daily-chart-dot"/>
-                                    <g className="daily-chart-tooltip" style={{opacity: hoverIndex === i ? 1 : 0}}>
-                                        <rect x={p.x - 28} y={p.y - 32} width={56} height={24} rx={4} className="daily-chart-tooltip-bg"/>
-                                        <text x={p.x} y={p.y - 16} className="daily-chart-tooltip-text">{displayVal}</text>
-                                    </g>
-                                    <circle cx={p.x} cy={p.y} r={16} style={{fill: 'transparent', cursor: 'pointer'}}
-                                        onMouseEnter={(e) => handleMouseEnter(e, i)} onMouseLeave={handleMouseLeave}/>
-                                    {showLabel && (
-                                        <text x={p.x} y={PAD.top + CHART_H + 16} className="daily-chart-date-label" textAnchor={textAnchor}>
-                                            {formatDateLabel(data[i].date)}
-                                        </text>
-                                    )}
-                                </g>
-                            );
-                        })}
-                    </svg>
-                    {popupData && (
-                        <div className="daily-chart-popup" style={{left: popupPos.x, top: popupPos.y}}>
-                            <div className="daily-chart-popup-title">{formatPopupTitle(popupData.date)}</div>
-                            <div className="daily-chart-popup-grid">
-                                <div className="daily-chart-popup-item">
-                                    <span className="daily-chart-popup-label">{t('attempts')}</span>
-                                    <span className="daily-chart-popup-value">{popupData.attempts + t('countUnit')}</span>
-                                </div>
-                                <div className="daily-chart-popup-item">
-                                    <span className="daily-chart-popup-label">{t('practiceTime')}</span>
-                                    <span className="daily-chart-popup-value">{formatTime(popupData.practiceTimeMin)}</span>
-                                </div>
-                                <div className="daily-chart-popup-item">
-                                    <span className="daily-chart-popup-label">{t('avgSpeed')}</span>
-                                    <span className="daily-chart-popup-value">{Math.round(popupData.avgCpm) + ' CPM'}</span>
-                                </div>
-                                <div className="daily-chart-popup-item">
-                                    <span className="daily-chart-popup-label">{t('bestSpeed')}</span>
-                                    <span className="daily-chart-popup-value">{popupData.bestCpm + ' CPM'}</span>
-                                </div>
-                                <div className="daily-chart-popup-item">
-                                    <span className="daily-chart-popup-label">{t('avgAccuracy')}</span>
-                                    <span className="daily-chart-popup-value">{Math.round(popupData.avgAcc * 100) + '%'}</span>
-                                </div>
-                                <div className="daily-chart-popup-item">
-                                    <span className="daily-chart-popup-label">{t('avgResetCount')}</span>
-                                    <span className="daily-chart-popup-value">{(popupData.attempts > 0 ? (popupData.resetCount / popupData.attempts).toFixed(2) : '0') + t('countUnit')}</span>
-                                </div>
-                            </div>
-                        </div>
-                    )}
-                </div>
+                <>
+                <ResponsiveContainer width="100%" height={240}>
+                    <AreaChart data={data} margin={{top: 16, right: 16, bottom: 8, left: 0}}>
+                        <defs>
+                            <linearGradient id="colorValue" x1="0" y1="0" x2="0" y2="1">
+                                <stop offset="0%" stopColor="var(--color-primary)" stopOpacity={0.1}/>
+                                <stop offset="100%" stopColor="var(--color-primary)" stopOpacity={0}/>
+                            </linearGradient>
+                        </defs>
+                        <XAxis dataKey="displayDate" tick={{fontSize: 10, fontWeight: 700, fill: 'var(--color-text-placeholder)'}} axisLine={false} tickLine={false} dy={8}/>
+                        <YAxis domain={domain} ticks={ticks} tick={{fontSize: 10, fontWeight: 700, fill: 'var(--color-text-placeholder)'}} axisLine={false} tickLine={false} tickFormatter={v => metric === 'acc' ? v + '%' : v} width={44} allowDecimals={false}/>
+                        <Area type="monotone" dataKey="value" stroke="var(--color-primary)" strokeWidth={1.5} fill="url(#colorValue)"
+                              dot={(props) => <DailyChartDot {...props} activeIndex={activeIndex} metric={metric} onDotEnter={handleDotEnter} onDotLeave={handleDotLeave} onDotClick={handleDotClick}/>}
+                              activeDot={false}/>
+                    </AreaChart>
+                </ResponsiveContainer>
+                {activeIndex !== null && data[activeIndex] && (
+                    <DailyChartPopup data={data[activeIndex]} metric={metric} style={{position: 'absolute', left: popupPos.x, top: popupPos.y}}/>
+                )}
+                </>
             )}
         </div>
     );

--- a/tp-react/src/pages/Stats/components/DailyChartDot.jsx
+++ b/tp-react/src/pages/Stats/components/DailyChartDot.jsx
@@ -1,0 +1,23 @@
+const DailyChartDot = ({cx, cy, index, activeIndex, payload, metric, onDotEnter, onDotLeave, onDotClick}) => {
+    const isActive = index === activeIndex;
+    const displayValue = payload?.value;
+    return (
+        <g>
+            <circle cx={cx} cy={cy} r={isActive ? 6 : 4} fill="var(--color-primary)" stroke="var(--color-popup-bg)" strokeWidth={2}/>
+            {isActive && displayValue != null && (
+                <g>
+                    <rect x={cx - 28} y={cy - 32} width={56} height={24} rx={4}
+                          fill="var(--color-popup-bg)" stroke="var(--color-border)" strokeWidth={0.5}/>
+                    <text x={cx} y={cy - 16} textAnchor="middle" fontSize={13} fontWeight={600}
+                          fill="var(--color-text)">{metric === 'acc' ? displayValue + '%' : displayValue}</text>
+                </g>
+            )}
+            <circle cx={cx} cy={cy} r={16} fill="transparent" style={{cursor: 'pointer'}}
+                    onMouseEnter={(e) => onDotEnter(e, index)}
+                    onMouseLeave={onDotLeave}
+                    onClick={(e) => { e.stopPropagation(); onDotClick(e, index); }}/>
+        </g>
+    );
+};
+
+export default DailyChartDot;

--- a/tp-react/src/pages/Stats/components/DailyChartPopup.jsx
+++ b/tp-react/src/pages/Stats/components/DailyChartPopup.jsx
@@ -1,0 +1,35 @@
+import {t} from '@/utils/i18n.ts';
+
+const formatPopupTitle = t('formatPopupTitle');
+const formatTime = t('formatTime');
+
+const DailyChartPopup = ({data, metric, style}) => {
+    const rows = [
+        {label: t('attempts'), value: data.attempts + t('countUnit')},
+        {label: t('practiceTime'), value: formatTime(data.practiceTimeMin)},
+        {label: t('avgSpeed'), value: Math.round(data.avgCpm) + ' CPM', highlight: metric === 'cpm'},
+        {label: t('bestSpeed'), value: data.bestCpm + ' CPM'},
+        {label: t('avgAccuracy'), value: Math.round(data.avgAcc * 100) + '%', highlight: metric === 'acc'},
+        {label: t('avgResetCount'), value: (data.attempts > 0 ? (data.resetCount / data.attempts).toFixed(2) : '0') + t('countUnit')},
+    ];
+
+    return (
+        <div className="daily-chart-popup" style={style}>
+            <div className="daily-chart-popup-header">
+                <span className="daily-chart-popup-title">{formatPopupTitle(data.date)}</span>
+                <span className="daily-chart-popup-dot"/>
+            </div>
+            <div className="daily-chart-popup-divider"/>
+            <div className="daily-chart-popup-list">
+                {rows.map((row, i) => (
+                    <div className="daily-chart-popup-row" key={i}>
+                        <span className="daily-chart-popup-label">{row.label}</span>
+                        <span className={`daily-chart-popup-value${row.highlight ? ' highlight' : ''}`}>{row.value}</span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    );
+};
+
+export default DailyChartPopup;

--- a/tp-react/src/pages/Stats/components/KeyboardHeatmap.css
+++ b/tp-react/src/pages/Stats/components/KeyboardHeatmap.css
@@ -66,7 +66,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    font-size: 0.75rem;
+    font-size: 0.875rem;
     font-weight: 600;
     border-radius: 0.25rem;
     transition: all 0.2s;
@@ -128,6 +128,19 @@
     padding: 2rem;
     color: var(--color-text-muted);
     font-size: 0.875rem;
+}
+
+/* Compact 모드 (팝업용) */
+.heatmap-section.compact .heatmap-keyboard {
+    gap: 0.25rem;
+}
+
+.heatmap-section.compact .heatmap-row {
+    gap: 0.25rem;
+}
+
+.heatmap-section.compact .heatmap-key {
+    font-size: 0.75rem;
 }
 
 .heatmap-key.clickable,

--- a/tp-react/src/pages/Stats/components/KeyboardHeatmap.css
+++ b/tp-react/src/pages/Stats/components/KeyboardHeatmap.css
@@ -1,0 +1,209 @@
+.heatmap-section {
+    padding: 0;
+}
+
+.heatmap-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 2rem;
+}
+
+.heatmap-title {
+    margin: 0;
+    font-size: 1.125rem;
+    font-weight: 500;
+    color: var(--color-text);
+}
+
+.heatmap-legend {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+}
+
+.heatmap-legend-label {
+    font-size: 0.625rem;
+    font-weight: 700;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.heatmap-legend-colors {
+    display: flex;
+    gap: 0.25rem;
+}
+
+.heatmap-legend-swatch {
+    width: 0.75rem;
+    height: 0.75rem;
+    border-radius: 0.125rem;
+}
+
+.heatmap-keyboard {
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.heatmap-row {
+    display: grid;
+    grid-template-columns: repeat(10, 1fr);
+    gap: 0.5rem;
+}
+
+.heatmap-row-2 {
+    padding-left: 1rem;
+}
+
+.heatmap-row-3 {
+    padding-left: 2rem;
+}
+
+.heatmap-key {
+    aspect-ratio: 1 / 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.75rem;
+    font-weight: 600;
+    border-radius: 0.25rem;
+    transition: all 0.2s;
+    position: relative;
+}
+
+.heatmap-key:hover .heatmap-key-tooltip {
+    opacity: 1;
+    visibility: visible;
+}
+
+.heatmap-key-tooltip {
+    position: absolute;
+    bottom: calc(100% + 0.375rem);
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--color-text);
+    color: var(--color-popup-bg);
+    font-size: 0.625rem;
+    font-weight: 600;
+    padding: 0.25rem 0.5rem;
+    border-radius: 0.25rem;
+    white-space: nowrap;
+    opacity: 0;
+    visibility: hidden;
+    transition: all 0.15s;
+    pointer-events: none;
+}
+
+.heatmap-spacebar {
+    display: flex;
+    justify-content: center;
+    margin-top: 0.25rem;
+}
+
+.heatmap-space-key {
+    height: 2.5rem;
+    width: 66%;
+    background: var(--color-bg-secondary);
+    border-radius: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.625rem;
+    font-weight: 700;
+    color: var(--color-text-placeholder);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    position: relative;
+}
+
+.heatmap-space-key:hover .heatmap-key-tooltip {
+    opacity: 1;
+    visibility: visible;
+}
+
+.heatmap-loading {
+    text-align: center;
+    padding: 2rem;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+}
+
+.heatmap-key.clickable,
+.heatmap-space-key.clickable {
+    cursor: pointer;
+}
+
+.heatmap-key.selected {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 1px;
+}
+
+.heatmap-space-key.selected {
+    outline: 2px solid var(--color-primary);
+    outline-offset: 1px;
+}
+
+.heatmap-detail {
+    margin-top: 1.5rem;
+    padding-top: 1.5rem;
+    border-top: 1px solid var(--color-border);
+}
+
+.heatmap-detail-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 1rem;
+}
+
+.heatmap-detail-title {
+    font-size: 0.875rem;
+    font-weight: 600;
+    color: var(--color-text);
+}
+
+.heatmap-detail-total {
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+}
+
+.heatmap-detail-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+}
+
+.heatmap-detail-item {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 0.75rem;
+    background: var(--color-bg-secondary);
+    border-radius: 0.375rem;
+    font-size: 0.8125rem;
+}
+
+.heatmap-detail-expected {
+    font-weight: 700;
+    color: var(--color-primary);
+}
+
+.heatmap-detail-arrow {
+    color: var(--color-text-muted);
+    font-size: 0.75rem;
+}
+
+.heatmap-detail-actual {
+    font-weight: 700;
+    color: var(--color-error);
+}
+
+.heatmap-detail-count {
+    font-size: 0.6875rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+    margin-left: 0.25rem;
+}

--- a/tp-react/src/pages/Stats/components/KeyboardHeatmap.jsx
+++ b/tp-react/src/pages/Stats/components/KeyboardHeatmap.jsx
@@ -1,0 +1,198 @@
+import {useEffect, useState} from 'react';
+import {getTypoDetailStats} from '@/utils/statsApi.ts';
+import {t} from '@/utils/i18n.ts';
+import './KeyboardHeatmap.css';
+
+const KEYBOARD_ROWS = [
+    [
+        {label: 'ㅂ', variants: ['ㅂ', 'ㅃ']},
+        {label: 'ㅈ', variants: ['ㅈ', 'ㅉ']},
+        {label: 'ㄷ', variants: ['ㄷ', 'ㄸ']},
+        {label: 'ㄱ', variants: ['ㄱ', 'ㄲ']},
+        {label: 'ㅅ', variants: ['ㅅ', 'ㅆ']},
+        {label: 'ㅛ', variants: ['ㅛ']},
+        {label: 'ㅕ', variants: ['ㅕ']},
+        {label: 'ㅑ', variants: ['ㅑ']},
+        {label: 'ㅐ', variants: ['ㅐ', 'ㅒ']},
+        {label: 'ㅔ', variants: ['ㅔ', 'ㅖ']},
+    ],
+    [
+        {label: 'ㅁ', variants: ['ㅁ']},
+        {label: 'ㄴ', variants: ['ㄴ']},
+        {label: 'ㅇ', variants: ['ㅇ']},
+        {label: 'ㄹ', variants: ['ㄹ']},
+        {label: 'ㅎ', variants: ['ㅎ']},
+        {label: 'ㅗ', variants: ['ㅗ']},
+        {label: 'ㅓ', variants: ['ㅓ']},
+        {label: 'ㅏ', variants: ['ㅏ']},
+        {label: 'ㅣ', variants: ['ㅣ']},
+    ],
+    [
+        {label: 'ㅋ', variants: ['ㅋ']},
+        {label: 'ㅌ', variants: ['ㅌ']},
+        {label: 'ㅊ', variants: ['ㅊ']},
+        {label: 'ㅍ', variants: ['ㅍ']},
+        {label: 'ㅠ', variants: ['ㅠ']},
+        {label: 'ㅜ', variants: ['ㅜ']},
+        {label: 'ㅡ', variants: ['ㅡ']},
+    ],
+];
+
+const ALL_CHARS = KEYBOARD_ROWS.flat().flatMap(k => k.variants);
+const SPACE_CHAR = ' ';
+
+const getKeyColor = (count, maxCount) => {
+    if (!count || !maxCount) return {bg: 'var(--color-bg-secondary)', text: 'var(--color-text-muted)'};
+    const ratio = count / maxCount;
+    if (ratio > 0.7) return {bg: 'rgba(112, 73, 179, 1)', text: '#fff'};
+    if (ratio > 0.5) return {bg: 'rgba(112, 73, 179, 0.6)', text: '#fff'};
+    if (ratio > 0.3) return {bg: 'rgba(112, 73, 179, 0.4)', text: 'var(--color-text)'};
+    if (ratio > 0.1) return {bg: 'rgba(112, 73, 179, 0.2)', text: 'var(--color-text)'};
+    return {bg: 'var(--color-bg-secondary)', text: 'var(--color-text-muted)'};
+};
+
+function KeyboardHeatmap() {
+    const [keyData, setKeyData] = useState({});
+    const [keyCounts, setKeyCounts] = useState({});
+    const [selectedKey, setSelectedKey] = useState(null);
+    const [isLoading, setIsLoading] = useState(true);
+
+    useEffect(() => {
+        const fetchAll = async () => {
+            setIsLoading(true);
+            const data = {};
+            const counts = {};
+            try {
+                const results = await Promise.all(
+                    [...ALL_CHARS, SPACE_CHAR].map(ch =>
+                        getTypoDetailStats('KOREAN', ch)
+                            .then(res => ({ch, data: res.data.data.content || []}))
+                            .catch(() => ({ch, data: []}))
+                    )
+                );
+                for (const {ch, data: entries} of results) {
+                    data[ch] = entries;
+                    counts[ch] = entries.reduce((sum, entry) => sum + entry.typoCount, 0);
+                }
+            } catch (e) {
+                console.error('Heatmap data load failed:', e);
+            }
+            setKeyData(data);
+            setKeyCounts(counts);
+            setIsLoading(false);
+        };
+        fetchAll();
+    }, []);
+
+    const getKeyCount = (key) => {
+        return key.variants.reduce((sum, v) => sum + (keyCounts[v] || 0), 0);
+    };
+
+    const getKeyDetails = (key) => {
+        const entries = key.variants.flatMap(v => keyData[v] || []);
+        return entries.sort((a, b) => b.typoCount - a.typoCount);
+    };
+
+    const handleKeyClick = (key) => {
+        const count = getKeyCount(key);
+        if (count === 0) return;
+        setSelectedKey(selectedKey?.label === key.label ? null : key);
+    };
+
+    const handleSpaceClick = () => {
+        if (!spaceCount) return;
+        const spaceKey = {label: 'Space', variants: [SPACE_CHAR]};
+        setSelectedKey(selectedKey?.label === 'Space' ? null : spaceKey);
+    };
+
+    const displayChar = (ch) => {
+        if (ch === '' || ch === null) return '\u2205';
+        if (ch === ' ') return '\u2423';
+        return ch;
+    };
+
+    const allCounts = KEYBOARD_ROWS.flat().map(getKeyCount);
+    const spaceCount = keyCounts[SPACE_CHAR] || 0;
+    const maxCount = Math.max(...allCounts, spaceCount, 1);
+
+    return (
+        <div className="heatmap-section">
+            <div className="heatmap-header">
+                <h3 className="heatmap-title">{t('keyboardHeatmap')}</h3>
+                <div className="heatmap-legend">
+                    <span className="heatmap-legend-label">{t('accurate')}</span>
+                    <div className="heatmap-legend-colors">
+                        <div className="heatmap-legend-swatch" style={{background: 'var(--color-bg-secondary)'}}/>
+                        <div className="heatmap-legend-swatch" style={{background: 'rgba(112, 73, 179, 0.2)'}}/>
+                        <div className="heatmap-legend-swatch" style={{background: 'rgba(112, 73, 179, 0.5)'}}/>
+                        <div className="heatmap-legend-swatch" style={{background: 'rgba(112, 73, 179, 0.8)'}}/>
+                        <div className="heatmap-legend-swatch" style={{background: 'rgba(112, 73, 179, 1)'}}/>
+                    </div>
+                    <span className="heatmap-legend-label">{t('errorsLabel')}</span>
+                </div>
+            </div>
+            {isLoading ? (
+                <div className="heatmap-loading">{t('loading')}</div>
+            ) : (
+                <div className="heatmap-keyboard">
+                    {KEYBOARD_ROWS.map((row, ri) => (
+                        <div key={ri} className={`heatmap-row${ri > 0 ? ` heatmap-row-${ri + 1}` : ''}`}>
+                            {row.map((key) => {
+                                const count = getKeyCount(key);
+                                const color = getKeyColor(count, maxCount);
+                                return (
+                                    <div key={key.label}
+                                         className={`heatmap-key${selectedKey?.label === key.label ? ' selected' : ''}${count > 0 ? ' clickable' : ''}`}
+                                         style={{background: color.bg, color: color.text}}
+                                         onClick={() => handleKeyClick(key)}>
+                                        {key.label}
+                                        {count > 0 && (
+                                            <span className="heatmap-key-tooltip">{count}{t('errors')}</span>
+                                        )}
+                                    </div>
+                                );
+                            })}
+                        </div>
+                    ))}
+                    <div className="heatmap-spacebar">
+                        {(() => {
+                            const color = getKeyColor(spaceCount, maxCount);
+                            return (
+                                <div className={`heatmap-space-key${selectedKey?.label === 'Space' ? ' selected' : ''}${spaceCount > 0 ? ' clickable' : ''}`}
+                                     style={{background: color.bg, color: color.text}}
+                                     onClick={handleSpaceClick}>
+                                    Space
+                                    {spaceCount > 0 && (
+                                        <span className="heatmap-key-tooltip">{spaceCount}{t('errors')}</span>
+                                    )}
+                                </div>
+                            );
+                        })()}
+                    </div>
+                    {selectedKey && (
+                        <div className="heatmap-detail">
+                            <div className="heatmap-detail-header">
+                                <span className="heatmap-detail-title">
+                                    '{displayChar(selectedKey.label)}' {t('typoDetailTitle')}
+                                </span>
+                                <span className="heatmap-detail-total">{getKeyCount(selectedKey)}{t('errors')}</span>
+                            </div>
+                            <div className="heatmap-detail-list">
+                                {getKeyDetails(selectedKey).map((entry, i) => (
+                                    <div key={i} className="heatmap-detail-item">
+                                        <span className="heatmap-detail-expected">{displayChar(entry.expected)}</span>
+                                        <span className="heatmap-detail-arrow">{'\u2192'}</span>
+                                        <span className="heatmap-detail-actual">{displayChar(entry.actual)}</span>
+                                        <span className="heatmap-detail-count">{entry.typoCount}{t('errors')}</span>
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+}
+
+export default KeyboardHeatmap;

--- a/tp-react/src/pages/Stats/components/KeyboardHeatmap.jsx
+++ b/tp-react/src/pages/Stats/components/KeyboardHeatmap.jsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import {getTypoDetailStats} from '@/utils/statsApi.ts';
 import {t} from '@/utils/i18n.ts';
 import './KeyboardHeatmap.css';
@@ -51,13 +51,32 @@ const getKeyColor = (count, maxCount) => {
     return {bg: 'var(--color-bg-secondary)', text: 'var(--color-text-muted)'};
 };
 
-function KeyboardHeatmap() {
+function KeyboardHeatmap({externalTypos, compact}) {
     const [keyData, setKeyData] = useState({});
     const [keyCounts, setKeyCounts] = useState({});
     const [selectedKey, setSelectedKey] = useState(null);
-    const [isLoading, setIsLoading] = useState(true);
+    const [isLoading, setIsLoading] = useState(!externalTypos);
+
+    // externalTypos가 있으면 useMemo로 즉시 계산
+    const externalCounts = useMemo(() => {
+        if (!externalTypos) return null;
+        const data = {};
+        const counts = {};
+        for (const typo of externalTypos) {
+            const ch = typo.expected;
+            if (!data[ch]) data[ch] = [];
+            data[ch].push(typo);
+            counts[ch] = (counts[ch] || 0) + 1;
+        }
+        return {data, counts};
+    }, [externalTypos]);
+
+    const activeKeyData = externalTypos ? (externalCounts?.data || {}) : keyData;
+    const activeKeyCounts = externalTypos ? (externalCounts?.counts || {}) : keyCounts;
 
     useEffect(() => {
+        if (externalTypos) return;
+        // API 호출 (Stats 페이지용)
         const fetchAll = async () => {
             setIsLoading(true);
             const data = {};
@@ -82,14 +101,24 @@ function KeyboardHeatmap() {
             setIsLoading(false);
         };
         fetchAll();
-    }, []);
+    }, [externalTypos]);
 
     const getKeyCount = (key) => {
-        return key.variants.reduce((sum, v) => sum + (keyCounts[v] || 0), 0);
+        return key.variants.reduce((sum, v) => sum + (activeKeyCounts[v] || 0), 0);
     };
 
     const getKeyDetails = (key) => {
-        const entries = key.variants.flatMap(v => keyData[v] || []);
+        const entries = key.variants.flatMap(v => activeKeyData[v] || []);
+        if (externalTypos) {
+            // 외부 데이터: (expected, actual) 쌍별로 집계
+            const grouped = {};
+            for (const e of entries) {
+                const k = e.expected + '→' + e.actual;
+                if (!grouped[k]) grouped[k] = {expected: e.expected, actual: e.actual, typoCount: 0};
+                grouped[k].typoCount += 1;
+            }
+            return Object.values(grouped).sort((a, b) => b.typoCount - a.typoCount);
+        }
         return entries.sort((a, b) => b.typoCount - a.typoCount);
     };
 
@@ -112,12 +141,13 @@ function KeyboardHeatmap() {
     };
 
     const allCounts = KEYBOARD_ROWS.flat().map(getKeyCount);
-    const spaceCount = keyCounts[SPACE_CHAR] || 0;
+    const spaceCount = activeKeyCounts[SPACE_CHAR] || 0;
     const maxCount = Math.max(...allCounts, spaceCount, 1);
 
     return (
-        <div className="heatmap-section">
-            <div className="heatmap-header">
+        <div className={`heatmap-section${compact ? ' compact' : ''}`}>
+            {!compact && (
+                <div className="heatmap-header">
                 <h3 className="heatmap-title">{t('keyboardHeatmap')}</h3>
                 <div className="heatmap-legend">
                     <span className="heatmap-legend-label">{t('accurate')}</span>
@@ -130,7 +160,8 @@ function KeyboardHeatmap() {
                     </div>
                     <span className="heatmap-legend-label">{t('errorsLabel')}</span>
                 </div>
-            </div>
+                </div>
+            )}
             {isLoading ? (
                 <div className="heatmap-loading">{t('loading')}</div>
             ) : (
@@ -146,9 +177,7 @@ function KeyboardHeatmap() {
                                          style={{background: color.bg, color: color.text}}
                                          onClick={() => handleKeyClick(key)}>
                                         {key.label}
-                                        {count > 0 && (
-                                            <span className="heatmap-key-tooltip">{count}{t('errors')}</span>
-                                        )}
+                                        <span className="heatmap-key-tooltip">{count}{t('errors')}</span>
                                     </div>
                                 );
                             })}
@@ -162,9 +191,7 @@ function KeyboardHeatmap() {
                                      style={{background: color.bg, color: color.text}}
                                      onClick={handleSpaceClick}>
                                     Space
-                                    {spaceCount > 0 && (
-                                        <span className="heatmap-key-tooltip">{spaceCount}{t('errors')}</span>
-                                    )}
+                                    <span className="heatmap-key-tooltip">{spaceCount}{t('errors')}</span>
                                 </div>
                             );
                         })()}

--- a/tp-react/src/pages/Stats/components/StatsSummary.css
+++ b/tp-react/src/pages/Stats/components/StatsSummary.css
@@ -1,94 +1,60 @@
 .stats-summary {
     display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 0.75rem;
+    grid-template-columns: repeat(5, 1fr);
+    gap: 3rem;
     margin-bottom: 1.75rem;
+    padding: 0.5rem 0;
 }
 
-.stats-main-card {
-    background: var(--color-popup-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 0.75rem;
-    padding: 1.5rem;
+.stats-item {
     display: flex;
     flex-direction: column;
-    justify-content: center;
+    gap: 0.25rem;
 }
 
-.stats-main-label {
+.stats-label {
     font-size: 0.75rem;
-    color: var(--color-text-muted);
     font-weight: 500;
-    margin-bottom: 0.25rem;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
 }
 
-.stats-main-value {
+.stats-value {
     display: flex;
     align-items: baseline;
-    gap: 0.5rem;
+    gap: 0.75rem;
+    margin-top: 0.25rem;
 }
 
-.stats-main-number {
-    font-size: 2.5rem;
-    font-weight: 700;
+.stats-number {
+    font-size: 2.25rem;
+    font-weight: 300;
     color: var(--color-text);
-    letter-spacing: -1px;
 }
 
-.stats-main-unit {
-    font-size: 0.875rem;
+.stats-unit {
+    font-size: 1rem;
     color: var(--color-text-muted);
+    font-weight: 400;
 }
 
 .stats-trend {
-    font-size: 0.875rem;
-    font-weight: 600;
-}
-
-.stats-trend.up {
-    color: var(--color-success);
+    font-size: 0.625rem;
+    font-weight: 500;
+    color: var(--color-primary);
+    background: var(--color-primary-bg);
+    padding: 0.125rem 0.5rem;
+    border-radius: 1rem;
+    white-space: nowrap;
 }
 
 .stats-trend.down {
     color: var(--color-error);
+    background: rgba(239, 68, 68, 0.1);
 }
 
 .stats-trend.neutral {
     color: var(--color-text-muted);
-}
-
-.stats-main-sub {
-    margin-top: 0.375rem;
-    font-size: 0.8125rem;
-    color: var(--color-text-muted);
-}
-
-.stats-sub-grid {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    gap: 0.5rem;
-}
-
-.stats-sub-card {
     background: var(--color-bg-secondary);
-    border-radius: 0.5rem;
-    padding: 0.75rem;
-}
-
-.stats-sub-label {
-    font-size: 0.6875rem;
-    color: var(--color-text-muted);
-}
-
-.stats-sub-value {
-    font-size: 1.25rem;
-    font-weight: 700;
-    color: var(--color-text);
-    margin-top: 0.125rem;
-}
-
-.stats-sub-unit {
-    font-size: 0.6875rem;
-    color: var(--color-text-muted);
-    margin-left: 0.125rem;
 }

--- a/tp-react/src/pages/Stats/components/StatsSummary.jsx
+++ b/tp-react/src/pages/Stats/components/StatsSummary.jsx
@@ -34,41 +34,40 @@ function StatsSummary({typingStats, dailyStats}) {
         ? (typingStats.totalResetCount / typingStats.totalAttempts).toFixed(2)
         : '0';
 
+    const trendText = trend.text ? trend.text.replace('▲ ', '+').replace('▼ ', '-') + ' ' + t('vsOverall') : '';
+
     return (
         <div className="stats-summary">
-            <div className="stats-main-card">
-                <span className="stats-main-label">{t('recent7DayAvg')}</span>
-                <div className="stats-main-value">
-                    <span className="stats-main-number">{recentAvg}</span>
-                    <span className="stats-main-unit">CPM</span>
-                    {trend.text && <span className={trend.className}>{trend.text}</span>}
-                </div>
-                <div className="stats-main-sub">
-                    {t('best')} {typingStats.bestCpm} CPM · {t('accuracy')} {Math.round(typingStats.avgAcc * 100)}%
+            <div className="stats-item">
+                <span className="stats-label">{t('recent7DayAvg')}</span>
+                <div className="stats-value">
+                    <span className="stats-number">{recentAvg}</span>
+                    {trendText && <span className={trend.className}>{trendText}</span>}
                 </div>
             </div>
-            <div className="stats-sub-grid">
-                <div className="stats-sub-card">
-                    <span className="stats-sub-label">{t('practiceTime')}</span>
-                    <div className="stats-sub-value">{formatTime(typingStats.totalPracticeTimeMin)}</div>
+            <div className="stats-item">
+                <span className="stats-label">{t('totalAverage')}</span>
+                <div className="stats-value">
+                    <span className="stats-number">{Math.round(typingStats.avgCpm)}</span>
+                    <span className="stats-unit">CPM</span>
                 </div>
-                <div className="stats-sub-card">
-                    <span className="stats-sub-label">{t('practiceCount')}</span>
-                    <div className="stats-sub-value">
-                        {typingStats.totalAttempts}<span className="stats-sub-unit">{t('times')}</span>
-                    </div>
+            </div>
+            <div className="stats-item">
+                <span className="stats-label">{t('practiceCount')}</span>
+                <div className="stats-value">
+                    <span className="stats-number">{typingStats.totalAttempts}</span>
                 </div>
-                <div className="stats-sub-card">
-                    <span className="stats-sub-label">{t('totalAverage')}</span>
-                    <div className="stats-sub-value">
-                        {Math.round(typingStats.avgCpm)}<span className="stats-sub-unit">CPM</span>
-                    </div>
+            </div>
+            <div className="stats-item">
+                <span className="stats-label">{t('practiceTime')}</span>
+                <div className="stats-value">
+                    <span className="stats-number">{formatTime(typingStats.totalPracticeTimeMin)}</span>
                 </div>
-                <div className="stats-sub-card">
-                    <span className="stats-sub-label">{t('avgReset')}</span>
-                    <div className="stats-sub-value">
-                        {avgReset}<span className="stats-sub-unit">{t('times')}</span>
-                    </div>
+            </div>
+            <div className="stats-item">
+                <span className="stats-label">{t('avgReset')}</span>
+                <div className="stats-value">
+                    <span className="stats-number">{avgReset}</span>
                 </div>
             </div>
         </div>

--- a/tp-react/src/pages/Stats/components/TypoList.css
+++ b/tp-react/src/pages/Stats/components/TypoList.css
@@ -9,20 +9,17 @@
 }
 
 .typo-section {
-    background: var(--color-popup-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 0.75rem;
-    padding: 1.5rem;
+    padding: 0;
 }
 
 .typo-section-header {
-    margin-bottom: 1.25rem;
+    margin-bottom: 2rem;
 }
 
 .typo-section-title {
     margin: 0;
-    font-size: 1rem;
-    font-weight: 600;
+    font-size: 1.125rem;
+    font-weight: 500;
     color: var(--color-text);
 }
 
@@ -34,64 +31,66 @@
 .typo-list {
     display: flex;
     flex-direction: column;
-    gap: 0.25rem;
+    gap: 1.5rem;
 }
 
 .typo-item {
     display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.625rem 0.875rem;
-    border-radius: 0.5rem;
+    flex-direction: column;
+    gap: 0.5rem;
     cursor: pointer;
     border: 1px solid transparent;
     transition: all 0.15s;
 }
 
-.typo-item:hover {
-    background: var(--color-primary-bg);
+.typo-item:hover .typo-bar-fill {
+    opacity: 1;
 }
 
 .typo-item.selected {
     background: var(--color-primary-bg);
     border-color: var(--color-primary);
+    border-radius: 0.5rem;
+    padding: 0.625rem 0.875rem;
+    margin: -0.625rem -0.875rem;
+}
+
+.typo-item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
 }
 
 .typo-char {
-    width: 2rem;
-    height: 2rem;
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: center;
-    background: var(--color-primary-bg);
-    border-radius: 0.5rem;
-    font-size: 1rem;
+    background: var(--color-bg-secondary);
+    padding: 0.25rem 0.75rem;
+    border-radius: 0.25rem;
+    font-size: 0.875rem;
     font-weight: 700;
-    color: var(--color-primary);
-    flex-shrink: 0;
+    font-family: monospace;
+    color: var(--color-text);
 }
 
 .typo-bar-container {
-    flex: 1;
-    height: 0.375rem;
-    background: var(--color-border);
-    border-radius: 0.1875rem;
+    height: 0.25rem;
+    background: var(--color-bg-secondary);
+    border-radius: 9999px;
     overflow: hidden;
 }
 
 .typo-bar-fill {
     height: 100%;
     background: var(--color-primary);
-    border-radius: 0.1875rem;
-    opacity: 0.7;
+    border-radius: 9999px;
 }
 
 .typo-count {
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: var(--color-text);
-    min-width: 2rem;
-    text-align: right;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
 }
 
 .typo-empty {

--- a/tp-react/src/pages/Stats/components/TypoList.css
+++ b/tp-react/src/pages/Stats/components/TypoList.css
@@ -1,13 +1,3 @@
-.typo-area {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 1rem;
-}
-
-.typo-area:has(.typo-section:nth-child(2)) {
-    grid-template-columns: 1fr 1fr;
-}
-
 .typo-section {
     padding: 0;
 }
@@ -23,11 +13,6 @@
     color: var(--color-text);
 }
 
-.typo-detail-char {
-    color: var(--color-primary);
-    font-weight: 700;
-}
-
 .typo-list {
     display: flex;
     flex-direction: column;
@@ -38,21 +23,6 @@
     display: flex;
     flex-direction: column;
     gap: 0.5rem;
-    cursor: pointer;
-    border: 1px solid transparent;
-    transition: all 0.15s;
-}
-
-.typo-item:hover .typo-bar-fill {
-    opacity: 1;
-}
-
-.typo-item.selected {
-    background: var(--color-primary-bg);
-    border-color: var(--color-primary);
-    border-radius: 0.5rem;
-    padding: 0.625rem 0.875rem;
-    margin: -0.625rem -0.875rem;
 }
 
 .typo-item-header {
@@ -98,50 +68,4 @@
     padding: 2rem;
     color: var(--color-text-muted);
     font-size: 0.875rem;
-}
-
-/* Detail */
-.typo-detail-list {
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.typo-detail-item {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    padding: 0.625rem 0.875rem;
-    background: var(--color-bg-secondary);
-    border-radius: 0.5rem;
-}
-
-.typo-detail-expected {
-    padding: 0.25rem 0.625rem;
-    background: var(--color-primary-bg);
-    border-radius: 0.375rem;
-    font-size: 0.9375rem;
-    font-weight: 700;
-    color: var(--color-primary);
-}
-
-.typo-detail-arrow {
-    font-size: 0.875rem;
-    color: var(--color-text-muted);
-}
-
-.typo-detail-actual {
-    padding: 0.25rem 0.625rem;
-    background: var(--color-error-light);
-    border-radius: 0.375rem;
-    font-size: 0.9375rem;
-    font-weight: 700;
-    color: var(--color-error);
-}
-
-.typo-detail-count {
-    margin-left: auto;
-    font-size: 0.875rem;
-    font-weight: 600;
-    color: var(--color-text);
 }

--- a/tp-react/src/pages/Stats/components/TypoList.jsx
+++ b/tp-react/src/pages/Stats/components/TypoList.jsx
@@ -25,6 +25,7 @@ function TypoList({typoStats}) {
         );
     }
 
+    const displayItems = typoStats.slice(0, 4);
     const maxCount = typoStats[0].count;
 
     const handleTypoClick = async (expected) => {
@@ -53,17 +54,19 @@ function TypoList({typoStats}) {
                     <h3 className="typo-section-title">{t('typoTop10')}</h3>
                 </div>
                 <div className="typo-list">
-                    {typoStats.map((item, i) => (
+                    {displayItems.map((item, i) => (
                         <div
                             key={i}
                             className={'typo-item' + (selectedTypo === item.expected ? ' selected' : '')}
                             onClick={() => handleTypoClick(item.expected)}
                         >
-                            <span className="typo-char">{displayChar(item.expected)}</span>
+                            <div className="typo-item-header">
+                                <span className="typo-char">{displayChar(item.expected)}</span>
+                                <span className="typo-count">{item.count} {t('errors')}</span>
+                            </div>
                             <div className="typo-bar-container">
                                 <div className="typo-bar-fill" style={{width: (item.count / maxCount * 100) + '%'}}/>
                             </div>
-                            <span className="typo-count">{item.count}</span>
                         </div>
                     ))}
                 </div>

--- a/tp-react/src/pages/Stats/components/TypoList.jsx
+++ b/tp-react/src/pages/Stats/components/TypoList.jsx
@@ -1,5 +1,3 @@
-import {useState} from 'react';
-import {getTypoDetailStats} from '@/utils/statsApi.ts';
 import {t} from '@/utils/i18n.ts';
 import './TypoList.css';
 
@@ -10,10 +8,6 @@ const displayChar = (ch) => {
 };
 
 function TypoList({typoStats}) {
-    const [selectedTypo, setSelectedTypo] = useState(null);
-    const [typoDetail, setTypoDetail] = useState([]);
-    const [detailLoading, setDetailLoading] = useState(false);
-
     if (!typoStats || typoStats.length === 0) {
         return (
             <div className="typo-section">
@@ -28,75 +22,24 @@ function TypoList({typoStats}) {
     const displayItems = typoStats.slice(0, 4);
     const maxCount = typoStats[0].count;
 
-    const handleTypoClick = async (expected) => {
-        if (selectedTypo === expected) {
-            setSelectedTypo(null);
-            setTypoDetail([]);
-            return;
-        }
-        setSelectedTypo(expected);
-        setDetailLoading(true);
-        try {
-            const res = await getTypoDetailStats('KOREAN', expected);
-            setTypoDetail(res.data.data.content || []);
-        } catch (error) {
-            console.error('typo detail load failed:', error);
-            setTypoDetail([]);
-        } finally {
-            setDetailLoading(false);
-        }
-    };
-
     return (
-        <div className="typo-area">
-            <div className="typo-section">
-                <div className="typo-section-header">
-                    <h3 className="typo-section-title">{t('typoTop10')}</h3>
-                </div>
-                <div className="typo-list">
-                    {displayItems.map((item, i) => (
-                        <div
-                            key={i}
-                            className={'typo-item' + (selectedTypo === item.expected ? ' selected' : '')}
-                            onClick={() => handleTypoClick(item.expected)}
-                        >
-                            <div className="typo-item-header">
-                                <span className="typo-char">{displayChar(item.expected)}</span>
-                                <span className="typo-count">{item.count} {t('errors')}</span>
-                            </div>
-                            <div className="typo-bar-container">
-                                <div className="typo-bar-fill" style={{width: (item.count / maxCount * 100) + '%'}}/>
-                            </div>
-                        </div>
-                    ))}
-                </div>
+        <div className="typo-section">
+            <div className="typo-section-header">
+                <h3 className="typo-section-title">{t('typoTop10')}</h3>
             </div>
-
-            {selectedTypo && (
-                <div className="typo-section">
-                    <div className="typo-section-header">
-                        <h3 className="typo-section-title">
-                            &lsquo;<span className="typo-detail-char">{displayChar(selectedTypo)}</span>&rsquo; {t('typoDetailTitle')}
-                        </h3>
-                    </div>
-                    {detailLoading ? (
-                        <div className="typo-empty">{t('loading')}</div>
-                    ) : typoDetail.length === 0 ? (
-                        <div className="typo-empty">{t('noDetailData')}</div>
-                    ) : (
-                        <div className="typo-detail-list">
-                            {typoDetail.map((d, i) => (
-                                <div key={i} className="typo-detail-item">
-                                    <span className="typo-detail-expected">{displayChar(d.expected)}</span>
-                                    <span className="typo-detail-arrow">{'\u2192'}</span>
-                                    <span className="typo-detail-actual">{displayChar(d.actual)}</span>
-                                    <span className="typo-detail-count">{d.typoCount + t('countUnit')}</span>
-                                </div>
-                            ))}
+            <div className="typo-list">
+                {displayItems.map((item, i) => (
+                    <div key={i} className="typo-item">
+                        <div className="typo-item-header">
+                            <span className="typo-char">{displayChar(item.expected)}</span>
+                            <span className="typo-count">{item.count} {t('errors')}</span>
                         </div>
-                    )}
-                </div>
-            )}
+                        <div className="typo-bar-container">
+                            <div className="typo-bar-fill" style={{width: (item.count / maxCount * 100) + '%'}}/>
+                        </div>
+                    </div>
+                ))}
+            </div>
         </div>
     );
 }

--- a/tp-react/src/pages/Stats/components/dailyChartUtils.js
+++ b/tp-react/src/pages/Stats/components/dailyChartUtils.js
@@ -1,0 +1,37 @@
+const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+
+export const formatDateLabel = (dateStr, prevDateStr) => {
+    const parts = dateStr.split('-');
+    const day = parseInt(parts[2]);
+    if (!prevDateStr) {
+        return MONTH_NAMES[parseInt(parts[1]) - 1] + ' ' + day;
+    }
+    const prevParts = prevDateStr.split('-');
+    if (parts[1] !== prevParts[1]) {
+        return MONTH_NAMES[parseInt(parts[1]) - 1] + ' ' + day;
+    }
+    return String(day);
+};
+
+const niceStep = (range) => {
+    const rough = range / 4;
+    const mag = Math.pow(10, Math.floor(Math.log10(rough)));
+    const norm = rough / mag;
+    if (norm <= 1) return mag;
+    if (norm <= 2) return 2 * mag;
+    if (norm <= 5) return 5 * mag;
+    return 10 * mag;
+};
+
+export const computeAxis = (data, metric) => {
+    const vals = data.map(d => d.value);
+    const min = Math.min(...vals);
+    const max = Math.max(...vals);
+    const range = max - min || 1;
+    const s = metric === 'acc' ? Math.max(niceStep(range), 2) : niceStep(range);
+    const lo = Math.floor((min - s * 0.5) / s) * s;
+    const hi = metric === 'acc' ? Math.min(Math.ceil((max + s * 0.5) / s) * s, 100) : Math.ceil((max + s * 0.5) / s) * s;
+    const ticks = [];
+    for (let v = lo; v <= hi; v += s) ticks.push(v);
+    return {domain: [lo, hi], ticks};
+};

--- a/tp-react/src/pages/Updates/Updates.css
+++ b/tp-react/src/pages/Updates/Updates.css
@@ -107,12 +107,28 @@
     gap: 3rem;
 }
 
+.timeline-section-header {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.75rem;
+}
+
+.timeline-section-icon {
+    font-size: 1.25rem;
+    color: var(--color-text-muted);
+}
+
+.timeline-section-icon.primary {
+    color: var(--color-primary);
+}
+
 .timeline-section-title {
     font-size: 1.125rem;
     font-weight: 700;
     color: var(--color-text);
     letter-spacing: -0.025em;
-    margin: 0 0 0.75rem;
+    margin: 0;
 }
 
 .timeline-section-full {

--- a/tp-react/src/pages/Updates/Updates.css
+++ b/tp-react/src/pages/Updates/Updates.css
@@ -1,109 +1,151 @@
 .updates-container {
-    width: 80%;
-    max-width: 800px;
-    min-width: 600px;
+    max-width: 56rem;
     margin: 0 auto;
+    padding: 2.5rem 2rem;
 }
 
 .updates-header {
-    margin-bottom: 1.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+    margin-bottom: 3rem;
+}
+
+.updates-latest-badge {
+    width: fit-content;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    background: var(--color-primary-bg);
+    color: var(--color-primary);
+    font-size: 0.75rem;
+    font-weight: 500;
 }
 
 .updates-title {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--color-primary);
-}
-
-.updates-list {
-    display: flex;
-    flex-direction: column;
-    gap: 1.25rem;
-    padding-bottom: 3rem;
-}
-
-.update-card {
-    background: var(--color-popup-bg);
-    border: 1px solid var(--color-border);
-    border-radius: 0.75rem;
-    padding: 1.5rem;
-}
-
-.update-card-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 1rem;
-}
-
-.update-card-version {
-    font-weight: 600;
-    color: var(--color-primary);
-    font-size: 1rem;
-}
-
-.update-card-date {
-    font-size: 0.8rem;
-    color: var(--color-text-placeholder);
-}
-
-.update-card-section {
-    margin-bottom: 0.75rem;
-}
-
-.update-card-section:last-child {
-    margin-bottom: 0;
-}
-
-.update-card-section-title {
-    font-size: 0.875rem;
-    font-weight: 600;
+    font-size: 2.25rem;
+    font-weight: 500;
     color: var(--color-text);
-    margin-bottom: 0.375rem;
-}
-
-.update-card-list {
-    list-style: none;
-    padding: 0;
+    letter-spacing: -0.025em;
     margin: 0;
 }
 
-.update-card-list li {
+/* Timeline */
+.updates-timeline {
     position: relative;
-    padding-left: 1rem;
-    margin-bottom: 0.25rem;
-    font-size: 0.875rem;
-    color: var(--color-text-muted);
-    line-height: 1.5;
 }
 
-.update-card-list li::before {
-    content: "•";
+.timeline-line {
+    position: absolute;
+    left: 11px;
+    top: 0.5rem;
+    bottom: 0;
+    width: 1px;
+    background: var(--color-border);
+    opacity: 0.5;
+}
+
+.timeline-entry {
+    position: relative;
+    padding-left: 3rem;
+    margin-bottom: 5rem;
+}
+
+.timeline-entry.past {
+    opacity: 0.75;
+}
+
+.timeline-dot {
     position: absolute;
     left: 0;
-    color: var(--color-primary);
-}
-
-.updates-footer {
-    margin-top: 1.75rem;
-    display: flex;
-    justify-content: center;
-}
-
-.updates-back-btn {
+    top: 0.5rem;
+    width: 1.5rem;
+    height: 1.5rem;
+    border-radius: 50%;
+    background: var(--color-border);
     display: flex;
     align-items: center;
-    gap: 0.5rem;
-    padding: 0.625rem 1.5rem;
-    border-radius: 0.5rem;
-    border: 1px solid var(--color-border);
-    background: var(--color-popup-bg);
-    color: var(--color-text-muted);
-    font-size: 0.875rem;
-    cursor: pointer;
-    transition: background-color 0.15s;
+    justify-content: center;
+    box-shadow: 0 0 0 4px var(--color-bg);
 }
 
-.updates-back-btn:hover {
-    background-color: var(--color-bg-secondary);
+.timeline-dot.latest {
+    background: var(--color-primary);
+}
+
+.timeline-dot-inner {
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 50%;
+    background: white;
+}
+
+.timeline-version-row {
+    display: flex;
+    align-items: baseline;
+    gap: 1rem;
+    margin-bottom: 1rem;
+}
+
+.timeline-version {
+    font-size: 1.875rem;
+    font-weight: 700;
+    color: var(--color-text);
+    letter-spacing: -0.025em;
+    margin: 0;
+}
+
+.timeline-date {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
+}
+
+/* Sections grid */
+.timeline-sections {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 3rem;
+}
+
+.timeline-section-title {
+    font-size: 1.125rem;
+    font-weight: 700;
+    color: var(--color-text);
+    letter-spacing: -0.025em;
+    margin: 0 0 0.75rem;
+}
+
+.timeline-section-full {
+    grid-column: 1 / -1;
+}
+
+.timeline-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.timeline-list li {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    line-height: 1.6;
+}
+
+.timeline-bullet {
+    width: 0.375rem;
+    height: 0.375rem;
+    border-radius: 50%;
+    background: var(--color-border);
+    flex-shrink: 0;
+    margin-top: 0.5rem;
+}
+
+.timeline-bullet.primary {
+    background: var(--color-primary);
 }

--- a/tp-react/src/pages/Updates/Updates.jsx
+++ b/tp-react/src/pages/Updates/Updates.jsx
@@ -1,5 +1,6 @@
 import {formatUpdateDate, localize, updateHistory} from '@/data/updateHistory.ts';
 import {t} from '@/utils/i18n.ts';
+import {MdAutoAwesome, MdTune, MdCampaign} from 'react-icons/md';
 import './Updates.css';
 
 function Updates() {
@@ -28,7 +29,10 @@ function Updates() {
                                 <div className="timeline-sections">
                                     {update.notices && update.notices.length > 0 && (
                                         <div className="timeline-section timeline-section-full">
-                                            <h3 className="timeline-section-title">{t('updateNotices')}</h3>
+                                            <div className="timeline-section-header">
+                                                <MdCampaign className="timeline-section-icon primary"/>
+                                                <h3 className="timeline-section-title">{t('updateNotices')}</h3>
+                                            </div>
                                             <ul className="timeline-list">
                                                 {update.notices.map((item, i) => (
                                                     <li key={i}>
@@ -41,7 +45,10 @@ function Updates() {
                                     )}
                                     {update.features && update.features.length > 0 && (
                                         <div className="timeline-section">
-                                            <h3 className="timeline-section-title">{t('updateFeatures')}</h3>
+                                            <div className="timeline-section-header">
+                                                <MdAutoAwesome className="timeline-section-icon primary"/>
+                                                <h3 className="timeline-section-title">{t('updateFeatures')}</h3>
+                                            </div>
                                             <ul className="timeline-list">
                                                 {update.features.map((item, i) => (
                                                     <li key={i}>
@@ -54,7 +61,10 @@ function Updates() {
                                     )}
                                     {update.improvements && update.improvements.length > 0 && (
                                         <div className="timeline-section">
-                                            <h3 className="timeline-section-title">{t('updateImprovements')}</h3>
+                                            <div className="timeline-section-header">
+                                                <MdTune className="timeline-section-icon"/>
+                                                <h3 className="timeline-section-title">{t('updateImprovements')}</h3>
+                                            </div>
                                             <ul className="timeline-list">
                                                 {update.improvements.map((item, i) => (
                                                     <li key={i}>

--- a/tp-react/src/pages/Updates/Updates.jsx
+++ b/tp-react/src/pages/Updates/Updates.jsx
@@ -7,34 +7,69 @@ function Updates() {
 
     return (
         <div className="updates-container">
-            <div className="updates-header">
-                <h1 className="updates-title">{t('updateHistory')}</h1>
-            </div>
-            <div className="updates-list">
-                {visibleUpdates.map((update) => (
-                    <div className="update-card" key={update.version}>
-                        <div className="update-card-header">
-                            <span className="update-card-version">v{update.version}</span>
-                            <span className="update-card-date">{formatUpdateDate(update.date)}</span>
-                        </div>
-                        {update.features && update.features.length > 0 && (
-                            <div className="update-card-section">
-                                <div className="update-card-section-title">{t('updateFeatures')}</div>
-                                <ul className="update-card-list">
-                                    {update.features.map((item, i) => <li key={i}>{localize(item)}</li>)}
-                                </ul>
+            <header className="updates-header">
+                <span className="updates-latest-badge">v{visibleUpdates[0]?.version} Released</span>
+                <h1 className="updates-title">{t('updateHistoryTitle')}</h1>
+            </header>
+            <div className="updates-timeline">
+                <div className="timeline-line"/>
+                {visibleUpdates.map((update, idx) => {
+                    const isLatest = idx === 0;
+                    return (
+                        <section className={`timeline-entry${isLatest ? '' : ' past'}`} key={update.version}>
+                            <div className={`timeline-dot${isLatest ? ' latest' : ''}`}>
+                                <div className="timeline-dot-inner"/>
                             </div>
-                        )}
-                        {update.improvements && update.improvements.length > 0 && (
-                            <div className="update-card-section">
-                                <div className="update-card-section-title">{t('updateImprovements')}</div>
-                                <ul className="update-card-list">
-                                    {update.improvements.map((item, i) => <li key={i}>{localize(item)}</li>)}
-                                </ul>
+                            <div className="timeline-content">
+                                <div className="timeline-version-row">
+                                    <h2 className="timeline-version">v{update.version}</h2>
+                                    <time className="timeline-date">{formatUpdateDate(update.date)}</time>
+                                </div>
+                                <div className="timeline-sections">
+                                    {update.notices && update.notices.length > 0 && (
+                                        <div className="timeline-section timeline-section-full">
+                                            <h3 className="timeline-section-title">{t('updateNotices')}</h3>
+                                            <ul className="timeline-list">
+                                                {update.notices.map((item, i) => (
+                                                    <li key={i}>
+                                                        <span className="timeline-bullet primary"/>
+                                                        <span>{localize(item)}</span>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        </div>
+                                    )}
+                                    {update.features && update.features.length > 0 && (
+                                        <div className="timeline-section">
+                                            <h3 className="timeline-section-title">{t('updateFeatures')}</h3>
+                                            <ul className="timeline-list">
+                                                {update.features.map((item, i) => (
+                                                    <li key={i}>
+                                                        <span className={`timeline-bullet${isLatest ? ' primary' : ''}`}/>
+                                                        <span>{localize(item)}</span>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        </div>
+                                    )}
+                                    {update.improvements && update.improvements.length > 0 && (
+                                        <div className="timeline-section">
+                                            <h3 className="timeline-section-title">{t('updateImprovements')}</h3>
+                                            <ul className="timeline-list">
+                                                {update.improvements.map((item, i) => (
+                                                    <li key={i}>
+                                                        <span className="timeline-bullet"/>
+                                                        <span>{localize(item)}</span>
+                                                    </li>
+                                                ))}
+                                            </ul>
+                                        </div>
+                                    )}
+                                </div>
                             </div>
-                        )}
-                    </div>
-                ))}
+                        </section>
+                    );
+                })}
             </div>
         </div>
     );

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -201,6 +201,7 @@ const translations = {
     keyboardHeatmap: l('키보드 에러 히트맵', 'キーボードエラーヒートマップ', 'Keyboard Error Heatmap'),
     accurate: l('정확', '正確', 'Accurate'),
     errorsLabel: l('오류', 'エラー', 'Errors'),
+    sessionTrend: l('세션 추이', 'セッション推移', 'Session Trend'),
     noTypoData: l('오타 데이터가 없습니다.', '誤字データがありません。', 'No typo data available.'),
     typoDetailTitle: l('오타 상세', '誤字の詳細', 'Typo Details'),
     noDetailData: l('상세 데이터가 없습니다.', '詳細データがありません。', 'No detail data available.'),

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -295,6 +295,7 @@ const translations = {
     // 업데이트 팝업
     updateNotice: l('업데이트 안내', 'アップデート情報', 'Update'),
     updateHistory: l('업데이트', 'アップデート', 'Updates'),
+    updateHistoryTitle: l('업데이트 기록', 'アップデート履歴', 'Update History'),
     updateClose: l('확인', '確認', 'OK'),
     updateViewHistory: l('지난 업데이트 보기', '過去のアップデートを見る', 'View past updates'),
     updateDontShow: l('다시 보지 않기', '次から表示しない', 'Don\'t show again'),

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -1,5 +1,6 @@
 type Lang = 'ko' | 'ja' | 'en';
 const lang: Lang = navigator.language.startsWith('ko') ? 'ko' : navigator.language.startsWith('ja') ? 'ja' : 'en';
+document.documentElement.lang = lang;
 const l = (ko: string, ja: string, en: string) => lang === 'ko' ? ko : lang === 'ja' ? ja : en;
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
@@ -145,26 +146,31 @@ const translations = {
 
     // 기록 페이지
     myTypingRecords: l('내 타이핑 기록', 'マイタイピング記録', 'My Typing Records'),
+    statsSubtitle: l('연습 기록을 확인하고 개선할 부분을 찾아보세요.', '練習記録を確認し、改善点を見つけましょう。', 'Review your progress and identify areas for improvement.'),
     statsLoadFailed: l('기록을 불러오는데 실패했습니다.', '記録の読み込みに失敗しました。', 'Failed to load records.'),
     refreshCooldown: l('새로고침은 1분에 한 번만 가능합니다.', '更新は1分に1回のみ可能です。', 'Refresh is available once per minute.'),
     refreshFailed: l('새로고침에 실패했습니다.', '更新に失敗しました。', 'Refresh failed.'),
 
     // 종합 통계
-    recent7DayAvg: l('최근 7일 평균', '直近7日間の平均', '7-Day Average'),
+    recent7DayAvg: l('7일 평균 CPM', '7日間平均CPM', '7D Avg CPM'),
     best: l('최고', '最高', 'Best'),
     accuracy: l('정확도', '正確度', 'Accuracy'),
     practiceTime: l('연습 시간', '練習時間', 'Practice Time'),
     practiceCount: l('연습 횟수', '練習回数', 'Practices'),
     totalAverage: l('전체 평균', '全体平均', 'Overall Avg'),
     avgReset: l('평균 초기화', '平均リセット', 'Avg Resets'),
+    vsOverall: l('vs 전체', 'vs 全体', 'vs overall'),
     times: l('회', '回', ''),
     formatTime: (min: number) => {
         if (!min || min <= 0) return l('0분', '0分', '0m');
-        const h = Math.floor(min / 60);
-        const m = Math.round(min % 60);
-        if (lang === 'ko') return h > 0 ? `${h}시간 ${m}분` : `${m}분`;
-        if (lang === 'ja') return h > 0 ? `${h}時間${m}分` : `${m}分`;
-        return h > 0 ? `${h}h ${m}m` : `${m}m`;
+        const h = min / 60;
+        if (h >= 1) {
+            const rounded = Math.round(h * 10) / 10;
+            const display = Number.isInteger(rounded) ? rounded.toString() : rounded.toFixed(1);
+            return l(`${display}시간`, `${display}時間`, `${display}h`);
+        }
+        const m = Math.round(min);
+        return l(`${m}분`, `${m}分`, `${m}m`);
     },
 
     // 에러 컨텍스트
@@ -189,7 +195,12 @@ const translations = {
     countUnit: l('회', '回', ''),
 
     // 오타 통계
-    typoTop10: l('자주 틀리는 글자 TOP 10', 'よく間違える文字 TOP 10', 'Most Missed Characters TOP 10'),
+    typoTop10: l('자주 틀리는 글자', 'よく間違える文字', 'Most Missed'),
+    typoSubtitle: l('타이핑 흐름을 방해하는 글자들', 'タイピングの流れを妨げる文字', 'Characters causing friction in flow.'),
+    errors: l('회', '回', 'errors'),
+    keyboardHeatmap: l('키보드 에러 히트맵', 'キーボードエラーヒートマップ', 'Keyboard Error Heatmap'),
+    accurate: l('정확', '正確', 'Accurate'),
+    errorsLabel: l('오류', 'エラー', 'Errors'),
     noTypoData: l('오타 데이터가 없습니다.', '誤字データがありません。', 'No typo data available.'),
     typoDetailTitle: l('오타 상세', '誤字の詳細', 'Typo Details'),
     noDetailData: l('상세 데이터가 없습니다.', '詳細データがありません。', 'No detail data available.'),


### PR DESCRIPTION
## 요약
기록 페이지를 전면 리디자인하고, Session Result 팝업에 추이 그래프와 키보드 에러 히트맵을 추가했습니다. 업데이트 페이지는 타임라인 레이아웃으로 전환했습니다.

## 주요 변경사항

### 기록 페이지 리디자인
- 종합 통계를 5열 균등 그리드로 변경, 트렌드 pill 뱃지 추가
- DailyChart를 커스텀 SVG에서 Recharts AreaChart로 전환 (곡선 그래프, niceStep Y축, hover/click 팝업)
- DailyChart 컴포넌트 분리 (DailyChartDot, DailyChartPopup, dailyChartUtils)
- 키보드 에러 히트맵 신규: 33개 자모 + 스페이스 병렬 API 호출, 5단계 강도, 키 클릭 시 오타 상세
- TypoList: 4개만 표시, 상세(detail) 기능 제거 (히트맵으로 대체)
- 돌아가기 버튼 제거

### Session Result 팝업
- SessionChart 신규: CPM+ACC 듀얼 Y축 LineChart, computeAxis 적용
- KeyboardHeatmap 재사용: externalTypos/compact prop으로 팝업용 분기
- ScoreContext에 popupCpmList, popupAccList, popupTypos 추가
- 매 문장 완료 시 typo를 값 복사 후 context에 누적, 팝업 닫힘 시 초기화
- 팝업 너비 52rem 확장, 세션 데이터 2열 그리드

### 업데이트 페이지
- 카드 → 타임라인 레이아웃 (세로선 + dot, 최신 보라색/이전 회색)
- 릴리즈 뱃지, 2열 그리드, 섹션 아이콘(MdAutoAwesome, MdTune, MdCampaign) 추가

### 기타
- 문장 업로드 공개/비공개 토글을 pill 그룹 디자인으로 통일
- Pretendard 웹폰트 적용
- i18n: updateHistoryTitle 분리, sessionTrend 등 키 추가

## 커밋 목록
1. `feat: 기록 페이지 리디자인 및 Recharts 전환`
2. `feat: 업데이트 페이지 타임라인 디자인 적용 및 TypoList 단순화`
3. `feat: Session Result 팝업에 추이 그래프 및 히트맵 추가`