### PR TITLE
refactor: 업데이트 알림 팝업 디자인 개선

### DIFF
--- a/tp-react/src/pages/Home/components/UpdatePopup/LatestUpdate/LatestUpdate.css
+++ b/tp-react/src/pages/Home/components/UpdatePopup/LatestUpdate/LatestUpdate.css
@@ -1,12 +1,29 @@
+.update-popup-badge {
+    display: inline-block;
+    padding: 0.25rem 0.75rem;
+    border-radius: 9999px;
+    background: var(--color-primary-bg);
+    color: var(--color-primary);
+    font-size: 0.75rem;
+    font-weight: 500;
+    margin-bottom: 0.375rem;
+}
+
+.update-popup-version-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    margin-bottom: 1.25rem;
+}
+
 .update-popup-version {
-    font-size: 0.85rem;
-    color: var(--color-text-placeholder);
-    background-color: transparent;
+    font-size: 1.25rem;
+    font-weight: 500;
+    color: var(--color-text);
 }
 
 .update-popup-date {
-    font-size: 0.85rem;
-    color: var(--color-text-placeholder);
-    margin-bottom: 1.5rem;
-    background-color: transparent;
+    font-size: 0.75rem;
+    font-weight: 500;
+    color: var(--color-text-muted);
 }

--- a/tp-react/src/pages/Home/components/UpdatePopup/LatestUpdate/LatestUpdate.jsx
+++ b/tp-react/src/pages/Home/components/UpdatePopup/LatestUpdate/LatestUpdate.jsx
@@ -1,7 +1,7 @@
 import {updateHistory, formatUpdateDate} from "@/data/updateHistory";
 import UpdateSection from "../UpdateSection/UpdateSection";
+import {t} from "@/utils/i18n.ts";
 import "./LatestUpdate.css";
-import {useTheme} from "@/Context/ThemeContext.tsx";
 
 // showPopup: true인 최신 업데이트 찾기
 const getLatestPopupUpdate = () => {
@@ -9,18 +9,16 @@ const getLatestPopupUpdate = () => {
 };
 
 const LatestUpdate = () => {
-    const {isDark} = useTheme();
     const latestPopupUpdate = getLatestPopupUpdate();
 
     if (!latestPopupUpdate) return null;
 
     return (
         <>
-            <div className={`update-popup-version ${isDark ? "dark" : ""}`}>
-                v{latestPopupUpdate.version}
-            </div>
-            <div className={`update-popup-date ${isDark ? "dark" : ""}`}>
-                {formatUpdateDate(latestPopupUpdate.date)}
+            <span className="update-popup-badge">v{latestPopupUpdate.version} Released</span>
+            <div className="update-popup-version-row">
+                <span className="update-popup-version">{t('updateNotice')}</span>
+                <span className="update-popup-date">{formatUpdateDate(latestPopupUpdate.date)}</span>
             </div>
             <UpdateSection update={latestPopupUpdate}/>
         </>

--- a/tp-react/src/pages/Home/components/UpdatePopup/UpdatePopup.css
+++ b/tp-react/src/pages/Home/components/UpdatePopup/UpdatePopup.css
@@ -1,19 +1,3 @@
-/* 공지 아이콘 */
-.notice-icon {
-    position: fixed;
-    top: 1rem;
-    right: 1rem;
-    color: var(--color-text-placeholder);
-    cursor: pointer;
-    font-size: 1.25rem;
-    transition: color 0.2s;
-    z-index: 100;
-}
-
-.notice-icon:hover {
-    color: var(--color-text-muted);
-}
-
 /* 팝업 오버레이 */
 .update-popup-overlay {
     position: fixed;
@@ -21,7 +5,7 @@
     left: 0;
     width: 100%;
     height: 100%;
-    background-color: rgba(0, 0, 0, 0.5);
+    background-color: rgba(0, 0, 0, 0.4);
     display: flex;
     justify-content: center;
     align-items: center;
@@ -34,75 +18,65 @@
     color: var(--color-text);
     border-radius: 1rem;
     padding: 2rem;
-    max-width: 480px;
+    max-width: 420px;
     width: 90%;
     max-height: 80vh;
     overflow-y: auto;
+    border: 1px solid var(--color-border);
     box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
 }
 
-.update-popup-header {
+/* 버튼 영역 */
+.update-popup-actions {
+    margin-top: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-border);
     display: flex;
-    justify-content: space-between;
+    flex-direction: column;
     align-items: center;
-    margin-bottom: 1.5rem;
-}
-
-.update-popup-title {
-    font-size: 1.5rem;
-    font-weight: 600;
-    color: var(--color-primary);
+    gap: 0.75rem;
 }
 
 .update-popup-close {
     width: 100%;
-    padding: 0.75rem;
-    margin-top: 1rem;
+    padding: 0.625rem;
     border: none;
     border-radius: 0.5rem;
     background-color: var(--color-primary);
     color: white;
-    font-size: 1rem;
+    font-size: 0.875rem;
+    font-weight: 500;
     cursor: pointer;
-    transition: background-color 0.2s;
+    transition: opacity 0.15s;
 }
 
 .update-popup-close:hover {
-    background-color: var(--color-primary-dark);
+    opacity: 0.85;
 }
 
-.update-popup-dont-show-btn {
-    width: 100%;
-    padding: 0.5rem;
-    margin-top: 0.5rem;
-    border: none;
-    border-radius: 0.5rem;
-    background-color: transparent;
+.update-popup-secondary {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+
+.update-popup-separator {
     color: var(--color-text-placeholder);
-    font-size: 0.85rem;
-    cursor: pointer;
-    transition: all 0.2s;
+    font-size: 0.75rem;
 }
 
+.update-popup-history-btn,
+.update-popup-dont-show-btn {
+    border: none;
+    background: transparent;
+    color: var(--color-text-muted);
+    font-size: 0.75rem;
+    cursor: pointer;
+    padding: 0;
+    transition: color 0.15s;
+}
+
+.update-popup-history-btn:hover,
 .update-popup-dont-show-btn:hover {
-    background-color: var(--color-bg-secondary);
-    color: var(--color-text-muted);
-}
-
-.update-popup-history-btn {
-    width: 100%;
-    padding: 0.5rem;
-    margin-top: 0.5rem;
-    border: 1px solid var(--color-border);
-    border-radius: 0.5rem;
-    background-color: transparent;
-    color: var(--color-text-muted);
-    font-size: 0.85rem;
-    cursor: pointer;
-    transition: all 0.2s;
-}
-
-.update-popup-history-btn:hover {
-    background-color: var(--color-bg-secondary);
     color: var(--color-text);
 }

--- a/tp-react/src/pages/Home/components/UpdatePopup/UpdatePopup.jsx
+++ b/tp-react/src/pages/Home/components/UpdatePopup/UpdatePopup.jsx
@@ -40,21 +40,23 @@ const UpdatePopup = () => {
     return (
         <div className="update-popup-overlay" onClick={handleClose}>
             <div className="update-popup" onClick={e => e.stopPropagation()}>
-                <div className="update-popup-header">
-                    <span className="update-popup-title">{t('updateNotice')}</span>
-                </div>
                 <div className="update-content">
                     <LatestUpdate/>
                 </div>
-                <button className="update-popup-close" onClick={handleClose}>
-                    {t('updateClose')}
-                </button>
-                <button className="update-popup-history-btn" onClick={handleViewHistory}>
-                    {t('updateViewHistory')}
-                </button>
-                <button className="update-popup-dont-show-btn" onClick={handleDontShowAgain}>
-                    {t('updateDontShow')}
-                </button>
+                <div className="update-popup-actions">
+                    <button className="update-popup-close" onClick={handleClose}>
+                        {t('updateClose')}
+                    </button>
+                    <div className="update-popup-secondary">
+                        <button className="update-popup-history-btn" onClick={handleViewHistory}>
+                            {t('updateViewHistory')}
+                        </button>
+                        <span className="update-popup-separator">·</span>
+                        <button className="update-popup-dont-show-btn" onClick={handleDontShowAgain}>
+                            {t('updateDontShow')}
+                        </button>
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/tp-react/src/pages/Home/components/UpdatePopup/UpdateSection/UpdateSection.css
+++ b/tp-react/src/pages/Home/components/UpdatePopup/UpdateSection/UpdateSection.css
@@ -2,11 +2,26 @@
     margin-bottom: 1.25rem;
 }
 
-.update-popup-section-title {
+.update-popup-section-header {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin-bottom: 0.625rem;
+}
+
+.update-popup-section-icon {
     font-size: 1rem;
-    font-weight: 600;
+    color: var(--color-text-muted);
+}
+
+.update-popup-section-icon.primary {
+    color: var(--color-primary);
+}
+
+.update-popup-section-title {
+    font-size: 0.875rem;
+    font-weight: 700;
     color: var(--color-text);
-    margin-bottom: 0.5rem;
     background-color: transparent;
 }
 
@@ -14,37 +29,30 @@
     list-style: none;
     padding: 0;
     margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
 }
 
 .update-popup-list li {
-    position: relative;
-    padding-left: 1.25rem;
-    margin-bottom: 0.5rem;
-    font-size: 0.95rem;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.625rem;
+    font-size: 0.8125rem;
     color: var(--color-text-muted);
     line-height: 1.5;
     background-color: transparent;
 }
 
-.update-popup-list li::before {
-    content: "•";
-    position: absolute;
-    left: 0;
-    color: var(--color-primary);
+.update-popup-bullet {
+    width: 0.3125rem;
+    height: 0.3125rem;
+    border-radius: 50%;
+    background: var(--color-border);
+    flex-shrink: 0;
+    margin-top: 0.4375rem;
 }
 
-/* 히스토리 모드 (작은 사이즈) */
-.update-popup.history-mode .update-popup-section {
-    margin-bottom: 0.75rem;
-}
-
-.update-popup.history-mode .update-popup-section-title {
-    font-size: 0.9rem;
-    margin-bottom: 0.25rem;
-}
-
-.update-popup.history-mode .update-popup-list li {
-    padding-left: 1rem;
-    margin-bottom: 0.25rem;
-    font-size: 0.85rem;
+.update-popup-bullet.primary {
+    background: var(--color-primary);
 }

--- a/tp-react/src/pages/Home/components/UpdatePopup/UpdateSection/UpdateSection.jsx
+++ b/tp-react/src/pages/Home/components/UpdatePopup/UpdateSection/UpdateSection.jsx
@@ -2,6 +2,7 @@ import "./UpdateSection.css";
 import {useTheme} from "@/Context/ThemeContext.tsx";
 import {t} from "@/utils/i18n.ts";
 import {localize} from "@/data/updateHistory.ts";
+import {MdAutoAwesome, MdTune, MdCampaign} from 'react-icons/md';
 
 const UpdateSection = ({update}) => {
     const {isDark} = useTheme();
@@ -10,36 +11,54 @@ const UpdateSection = ({update}) => {
         <>
             {update.notices && update.notices.length > 0 && (
                 <div className="update-popup-section">
-                    <div className={`update-popup-section-title ${isDark ? "dark" : ""}`}>
-                        {t('updateNotices')}
+                    <div className="update-popup-section-header">
+                        <MdCampaign className="update-popup-section-icon primary"/>
+                        <div className={`update-popup-section-title ${isDark ? "dark" : ""}`}>
+                            {t('updateNotices')}
+                        </div>
                     </div>
                     <ul className="update-popup-list">
                         {update.notices.map((item, index) => (
-                            <li key={index} className={isDark ? "dark" : ""}>{localize(item)}</li>
+                            <li key={index} className={isDark ? "dark" : ""}>
+                                <span className="update-popup-bullet primary"/>
+                                <span>{localize(item)}</span>
+                            </li>
                         ))}
                     </ul>
                 </div>
             )}
             {update.features && update.features.length > 0 && (
                 <div className="update-popup-section">
-                    <div className={`update-popup-section-title ${isDark ? "dark" : ""}`}>
-                        ✨ {t('updateFeatures')}
+                    <div className="update-popup-section-header">
+                        <MdAutoAwesome className="update-popup-section-icon primary"/>
+                        <div className={`update-popup-section-title ${isDark ? "dark" : ""}`}>
+                            {t('updateFeatures')}
+                        </div>
                     </div>
                     <ul className="update-popup-list">
                         {update.features.map((item, index) => (
-                            <li key={index} className={isDark ? "dark" : ""}>{localize(item)}</li>
+                            <li key={index} className={isDark ? "dark" : ""}>
+                                <span className="update-popup-bullet primary"/>
+                                <span>{localize(item)}</span>
+                            </li>
                         ))}
                     </ul>
                 </div>
             )}
             {update.improvements && update.improvements.length > 0 && (
                 <div className="update-popup-section">
-                    <div className={`update-popup-section-title ${isDark ? "dark" : ""}`}>
-                        🔧 {t('updateImprovements')}
+                    <div className="update-popup-section-header">
+                        <MdTune className="update-popup-section-icon"/>
+                        <div className={`update-popup-section-title ${isDark ? "dark" : ""}`}>
+                            {t('updateImprovements')}
+                        </div>
                     </div>
                     <ul className="update-popup-list">
                         {update.improvements.map((item, index) => (
-                            <li key={index} className={isDark ? "dark" : ""}>{localize(item)}</li>
+                            <li key={index} className={isDark ? "dark" : ""}>
+                                <span className="update-popup-bullet"/>
+                                <span>{localize(item)}</span>
+                            </li>
                         ))}
                     </ul>
                 </div>


### PR DESCRIPTION
## 주요 내용
- 업데이트 알림 팝업을 업데이트 기록 페이지와 통일된 디자인으로 변경
- 이모지를 react-icons로 교체
- 버튼 레이아웃 정리

## 세부 내용
### LatestUpdate
- 버전 릴리즈 뱃지 추가 (v1.5.0 Released pill)
- 타이틀(업데이트 알림)과 날짜를 한 줄에 좌우 끝 배치 (space-between)
- 미사용 useTheme import 제거

### UpdateSection
- 이모지(✨🔧) → react-icons (MdAutoAwesome, MdTune, MdCampaign)
- 아이콘+타이틀 flex row 헤더 구조로 변경
- 항목 앞 ::before pseudo → span dot 컴포넌트 (features/notices: primary, improvements: border 색)

### UpdatePopup
- 타이틀을 LatestUpdate 내부 릴리즈 뱃지로 이동, 헤더 영역 제거
- 버튼 영역: 확인 버튼 + 하단 "전체 기록 보기 · 다시 보지 않기" 인라인 배치
- 중복 badge/header CSS 제거