### PR TITLE
feat: 적응형 문장 서빙 API 및 선택 편향 방지

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/controller/AdaptiveServingController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/controller/AdaptiveServingController.java
@@ -1,0 +1,36 @@
+package com.typingpractice.typing_practice_be.adaptiveserving.controller;
+
+import com.typingpractice.typing_practice_be.adaptiveserving.dto.AdaptiveQuoteListResponse;
+import com.typingpractice.typing_practice_be.adaptiveserving.dto.AdaptiveQuoteRequest;
+import com.typingpractice.typing_practice_be.adaptiveserving.dto.AdaptiveQuoteResponse;
+import com.typingpractice.typing_practice_be.adaptiveserving.service.AdaptiveQuoteService;
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AdaptiveServingController {
+  private final AdaptiveQuoteService adaptiveQuoteService;
+
+  private Long getMemberId() {
+    return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+  }
+
+  @GetMapping("/quotes/adaptive")
+  public ApiResponse<AdaptiveQuoteListResponse> getAdaptiveQuotes(
+      @ModelAttribute @Valid AdaptiveQuoteRequest request) {
+    Long memberId = getMemberId();
+
+    List<AdaptiveQuoteResponse> quotes =
+        adaptiveQuoteService.getAdaptiveQuotes(
+            memberId, request.getLanguage(), request.getCount(), request.getExcludeIds());
+
+    return ApiResponse.ok(AdaptiveQuoteListResponse.of(quotes));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/dto/AdaptiveQuoteListResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/dto/AdaptiveQuoteListResponse.java
@@ -1,0 +1,19 @@
+package com.typingpractice.typing_practice_be.adaptiveserving.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class AdaptiveQuoteListResponse {
+  private int count;
+  private List<AdaptiveQuoteResponse> content;
+
+  public static AdaptiveQuoteListResponse of(List<AdaptiveQuoteResponse> content) {
+    AdaptiveQuoteListResponse response = new AdaptiveQuoteListResponse();
+    response.content = content;
+    response.count = content.size();
+
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/dto/AdaptiveQuoteRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/dto/AdaptiveQuoteRequest.java
@@ -1,0 +1,22 @@
+package com.typingpractice.typing_practice_be.adaptiveserving.dto;
+
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import java.util.List;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Range;
+
+@Getter
+public class AdaptiveQuoteRequest {
+  private final QuoteLanguage language;
+
+  @Range(min = 50, max = 100)
+  private final int count;
+
+  private final List<Long> excludeIds;
+
+  public AdaptiveQuoteRequest(QuoteLanguage language, Integer count, List<Long> excludeIds) {
+    this.language = language;
+    this.count = count != null ? count : 50;
+    this.excludeIds = excludeIds;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/dto/AdaptiveQuoteResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/dto/AdaptiveQuoteResponse.java
@@ -1,0 +1,18 @@
+package com.typingpractice.typing_practice_be.adaptiveserving.dto;
+
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.dto.QuoteResponse;
+import com.typingpractice.typing_practice_be.typingrecord.domain.ServingType;
+import lombok.Getter;
+
+@Getter
+public class AdaptiveQuoteResponse extends QuoteResponse {
+  private ServingType servingType;
+
+  public static AdaptiveQuoteResponse from(Quote quote, ServingType servingType) {
+    AdaptiveQuoteResponse response = new AdaptiveQuoteResponse();
+    response.fillFrom(quote);
+    response.servingType = servingType;
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/service/AdaptiveQuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/service/AdaptiveQuoteService.java
@@ -1,0 +1,131 @@
+package com.typingpractice.typing_practice_be.adaptiveserving.service;
+
+import com.typingpractice.typing_practice_be.adaptiveserving.dto.AdaptiveQuoteResponse;
+import com.typingpractice.typing_practice_be.adaptiveserving.dto.AdaptiveServingEstimation;
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.dto.QuoteIdWithDifficulty;
+import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
+import com.typingpractice.typing_practice_be.quote.service.QuoteIdCacheService;
+import com.typingpractice.typing_practice_be.typingrecord.domain.ServingType;
+import java.util.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdaptiveQuoteService {
+  private final AdaptiveServingRedisService redisService;
+  private final QuoteIdCacheService quoteIdCacheService;
+  private final QuoteRepository quoteRepository;
+
+  private static final int EASY_RATIO = 2;
+  private static final int FIT_RATIO = 5;
+  private static final int HARD_RATIO = 3;
+  private static final float MIN_HALF_WIDTH = 3f;
+  private static final float RANDOM_RATIO = 0.2f;
+
+  public List<AdaptiveQuoteResponse> getAdaptiveQuotes(
+      Long memberId, QuoteLanguage language, int count, List<Long> excludeIds) {
+    AdaptiveServingEstimation estimation = redisService.getEstimation(memberId, language);
+    float mu = estimation.getMu();
+    float sigma = estimation.getSigma();
+
+    List<QuoteIdWithDifficulty> allQuotes = quoteIdCacheService.getPublicQuotes(language);
+
+    // 이미 친 문장 제외
+    Set<Long> excludeSet = excludeIds != null ? new HashSet<>(excludeIds) : Set.of();
+    float halfWidth = Math.max(0.5f * sigma, MIN_HALF_WIDTH);
+    float easyMax = mu - halfWidth;
+    float hardMin = mu + halfWidth;
+
+    List<QuoteIdWithDifficulty> easyPool = new ArrayList<>();
+    List<QuoteIdWithDifficulty> fitPool = new ArrayList<>();
+    List<QuoteIdWithDifficulty> hardPool = new ArrayList<>();
+
+    for (QuoteIdWithDifficulty q : allQuotes) {
+      if (excludeSet.contains(q.getId())) continue;
+
+      float d = q.getDifficulty();
+      if (d < easyMax) easyPool.add(q);
+      else if (d > hardMin) hardPool.add(q);
+      else fitPool.add(q);
+    }
+
+    Set<Long> picked = new HashSet<>(excludeSet);
+
+    int totalAvailable = easyPool.size() + fitPool.size() + hardPool.size();
+    if (totalAvailable < count) {
+      easyPool.clear();
+      fitPool.clear();
+      hardPool.clear();
+      picked.clear();
+      for (QuoteIdWithDifficulty q : allQuotes) {
+        float d = q.getDifficulty();
+        if (d < easyMax) easyPool.add(q);
+        else if (d > hardMin) hardPool.add(q);
+        else fitPool.add(q);
+      }
+    }
+
+    // RANDOM / ADAPTIVE 슬롯 수 계산
+    int randomCount = Math.max(1, Math.round(count * RANDOM_RATIO));
+    int adaptiveCount = count - randomCount;
+
+    int totalRatio = EASY_RATIO + FIT_RATIO + HARD_RATIO;
+    int easyCount = Math.round((float) adaptiveCount * EASY_RATIO / totalRatio);
+    int hardCount = Math.round((float) adaptiveCount * HARD_RATIO / totalRatio);
+    int fitCount = adaptiveCount - easyCount - hardCount;
+
+    // 비율에 맞게 선택
+    Random random = new Random();
+    List<Long> adaptiveIds = new ArrayList<>();
+    adaptiveIds.addAll(pickRandomIds(easyPool, easyCount, random, picked));
+    adaptiveIds.addAll(pickRandomIds(fitPool, fitCount, random, picked));
+    adaptiveIds.addAll(pickRandomIds(hardPool, hardCount, random, picked));
+
+    // 부족분은 random 으로 보충
+    randomCount += (adaptiveCount - adaptiveIds.size());
+
+    List<Long> randomSelectedIds = pickRandomIds(allQuotes, randomCount, random, picked);
+    Set<Long> randomIdSet = new HashSet<>(randomSelectedIds);
+
+    // 전체 ID
+    List<Long> allIds = new ArrayList<>(adaptiveIds);
+    allIds.addAll(randomSelectedIds);
+
+    // DB fetch → 셔플 → 응답
+    List<Quote> fetched = quoteRepository.findByIds(allIds, language);
+    Collections.shuffle(fetched, random);
+
+    return fetched.stream()
+        .map(
+            q ->
+                AdaptiveQuoteResponse.from(
+                    q, randomIdSet.contains(q.getId()) ? ServingType.RANDOM : ServingType.ADAPTIVE))
+        .toList();
+  }
+
+  private List<Long> pickRandomIds(
+      List<QuoteIdWithDifficulty> pool, int count, Random random, Set<Long> picked) {
+    if (pool.isEmpty() || count <= 0) return new ArrayList<>();
+
+    List<Long> result = new ArrayList<>();
+    List<QuoteIdWithDifficulty> candidates = new ArrayList<>(pool);
+
+    while (result.size() < count && !candidates.isEmpty()) {
+      int idx = random.nextInt(candidates.size());
+      QuoteIdWithDifficulty q = candidates.remove(idx);
+      if (!picked.contains(q.getId())) {
+        result.add(q.getId());
+        picked.add(q.getId());
+      }
+    }
+
+    return result;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/service/AdaptiveServingCalculator.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/service/AdaptiveServingCalculator.java
@@ -38,6 +38,10 @@ public class AdaptiveServingCalculator {
     float baseProcessNoise = properties.getSigmaProcess();
     float surpriseThreshold = properties.getSurpriseThreshold();
 
+    // sigma 최소값 보장 (0 또는 음수 방지)
+    if (sigma <= 0) sigma = properties.getDefaultSigma();
+    if (sigmaObs <= 0) return new float[] {mu, sigma};
+
     // Adaptive process noise: surprise 가 크면 sigma 를 더 넓힘 -> 평소와 다른 데이터
     float surprise = Math.abs(x - mu) / sigma;
     float processNoise =

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/service/AdaptiveServingRedisService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/service/AdaptiveServingRedisService.java
@@ -103,8 +103,6 @@ public class AdaptiveServingRedisService {
             event.getAvgCpmSnapshot(),
             event.getAvgAccSnapshot());
 
-    System.out.println("perfNormalized = " + perfNormalized);
-
     float x = calculator.calcObservation(event.getDifficulty(), perfNormalized);
     float[] updated = calculator.update(current.getMu(), current.getSigma(), x);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteIdWithDifficulty.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/QuoteIdWithDifficulty.java
@@ -1,0 +1,19 @@
+package com.typingpractice.typing_practice_be.quote.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QuoteIdWithDifficulty {
+  private Long id;
+  private float difficulty;
+
+  public static QuoteIdWithDifficulty create(Long id, float difficulty) {
+    QuoteIdWithDifficulty dto = new QuoteIdWithDifficulty();
+    dto.id = id;
+    dto.difficulty = difficulty;
+
+    return dto;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
@@ -3,15 +3,14 @@ package com.typingpractice.typing_practice_be.quote.repository;
 import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.quote.config.SimilarityThresholdProperties;
 import com.typingpractice.typing_practice_be.quote.domain.*;
+import com.typingpractice.typing_practice_be.quote.dto.QuoteIdWithDifficulty;
 import com.typingpractice.typing_practice_be.quote.query.PublicQuoteQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
-
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -86,6 +85,25 @@ public class QuoteRepository {
     }
 
     return query.getResultList();
+  }
+
+  public List<QuoteIdWithDifficulty> findAllPublicIdsWithDifficulty(QuoteLanguage language) {
+    List<Object[]> rows =
+        em.createQuery(
+                "select q.id, q.difficulty from Quote q "
+                    + "where q.type = :type and q.status = :status and q.language = :language",
+                Object[].class)
+            .setParameter("type", QuoteType.PUBLIC)
+            .setParameter("status", QuoteStatus.ACTIVE)
+            .setParameter("language", language)
+            .getResultList();
+
+    return rows.stream()
+        .map(
+            row ->
+                QuoteIdWithDifficulty.create(
+                    (Long) row[0], row[1] != null ? ((Number) row[1]).floatValue() : 0f))
+        .toList();
   }
 
   public List<Quote> findAll(QuotePaginationQuery query) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteIdCacheService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteIdCacheService.java
@@ -3,101 +3,111 @@ package com.typingpractice.typing_practice_be.quote.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.typingpractice.typing_practice_be.quote.domain.QuoteDifficultyTier;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
+import com.typingpractice.typing_practice_be.quote.dto.QuoteIdWithDifficulty;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
+import java.time.Duration;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
-
-import java.time.Duration;
-import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class QuoteIdCacheService {
-	private final StringRedisTemplate redisTemplate;
-	private final ObjectMapper objectMapper;
-	private final QuoteRepository quoteRepository;
+  private final StringRedisTemplate redisTemplate;
+  private final ObjectMapper objectMapper;
+  private final QuoteRepository quoteRepository;
 
-	private static final Duration PUBLIC_TTL = Duration.ofMinutes(25);
+  private static final Duration PUBLIC_TTL = Duration.ofMinutes(25);
 
-	private String publicKey(QuoteLanguage language, QuoteDifficultyTier tier) {
-		return "quote:public-ids:" + language.name() + ":" + tier.name();
-	}
+  private String publicKey(QuoteLanguage language) {
+    return "quote:public:" + language.name();
+  }
 
-	private String memberKey(Long memberId, QuoteLanguage language) {
-		return "quote:member-ids:" + memberId + ":" + language.name();
-	}
+  private String memberKey(Long memberId, QuoteLanguage language) {
+    return "quote:member-ids:" + memberId + ":" + language.name();
+  }
 
-	public List<Long> getPublicIds(QuoteLanguage language, QuoteDifficultyTier tier) {
-		String key = publicKey(language, tier);
-		String json = redisTemplate.opsForValue().get(key);
+  public List<QuoteIdWithDifficulty> getPublicQuotes(QuoteLanguage language) {
+    String key = publicKey(language);
+    String json = redisTemplate.opsForValue().get(key);
 
-		if (json != null) {
-			// log.info("[QuoteIdCache] 공개 문장 ID 캐시 히트 - language={}", language);
-			return deserialize(json);
-		}
+    if (json != null) {
+      // log.info("[QuoteIdCache] 공개 문장 ID 캐시 히트 - language={}", language);
+      return deserializeQuotes(json);
+    }
 
-		List<Long> ids = quoteRepository.findAllPublicIds(language, tier);
-		redisTemplate.opsForValue().set(key, serialize(ids), PUBLIC_TTL);
-		log.info("[QuoteIdCache] 공개 문장 ID 캐시 로드 - language={}, size={}", language, ids.size());
-		return ids;
-	}
+    List<QuoteIdWithDifficulty> quotes = quoteRepository.findAllPublicIdsWithDifficulty(language);
+    redisTemplate.opsForValue().set(key, serializeQuotes(quotes), PUBLIC_TTL);
+    log.info("[QuoteIdCache] 공개 문장 캐시 로드 - language={}, size={}", language, quotes.size());
+    return quotes;
+  }
 
-	public List<Long> getIdsByMemberId(Long memberId, QuoteLanguage language) {
-		String key = memberKey(memberId, language);
-		String json = redisTemplate.opsForValue().get(key);
+  public List<Long> getIdsByMemberId(Long memberId, QuoteLanguage language) {
+    String key = memberKey(memberId, language);
+    String json = redisTemplate.opsForValue().get(key);
 
-		if (json != null) {
-			return deserialize(json);
-		}
+    if (json != null) {
+      return deserialize(json);
+    }
 
-		List<Long> ids = quoteRepository.findIdsByMemberId(memberId, language);
-		redisTemplate.opsForValue().set(key, serialize(ids));
-		log.info(
-						"[QuoteIdCache] 멤버 문장 ID 캐시 로드 - memberId={}, language={}, size={}",
-						memberId,
-						language,
-						ids.size());
-		return ids;
-	}
+    List<Long> ids = quoteRepository.findIdsByMemberId(memberId, language);
+    redisTemplate.opsForValue().set(key, serialize(ids));
+    log.info(
+        "[QuoteIdCache] 멤버 문장 ID 캐시 로드 - memberId={}, language={}, size={}",
+        memberId,
+        language,
+        ids.size());
+    return ids;
+  }
 
-	public void refreshAllPublicIds() {
-		for (QuoteLanguage language : QuoteLanguage.values()) {
-			for (QuoteDifficultyTier tier : QuoteDifficultyTier.values()) {
-				List<Long> ids = quoteRepository.findAllPublicIds(language, tier);
-				redisTemplate.opsForValue().set(publicKey(language, tier), serialize(ids), PUBLIC_TTL);
-				log.info(
-								"[QuoteIdCache] 공개 문장 ID 캐시 갱신 - language={}, tier={}, size={}",
-								language,
-								tier,
-								ids.size());
-			}
-		}
-	}
+  public void refreshAllPublicIds() {
+    for (QuoteLanguage language : QuoteLanguage.values()) {
+      List<QuoteIdWithDifficulty> quotes = quoteRepository.findAllPublicIdsWithDifficulty(language);
+      redisTemplate.opsForValue().set(publicKey(language), serializeQuotes(quotes));
+      log.info("[QuoteIdCache] 공개 문장 캐시 갱신 - language={}, size={}", language, quotes.size());
+    }
+  }
 
-	public void invalidateMemberIds(Long memberId, QuoteLanguage language) {
-		redisTemplate.delete(memberKey(memberId, language));
-		log.info("[QuoteIdCache] 멤버 문장 ID 캐시 삭제 - memberId={}, language={}", memberId, language);
-	}
+  public void invalidateMemberIds(Long memberId, QuoteLanguage language) {
+    redisTemplate.delete(memberKey(memberId, language));
+    log.info("[QuoteIdCache] 멤버 문장 ID 캐시 삭제 - memberId={}, language={}", memberId, language);
+  }
 
-	private String serialize(List<Long> ids) {
-		try {
-			return objectMapper.writeValueAsString(ids);
-		} catch (JsonProcessingException e) {
-			throw new RuntimeException("QuoteIdCache 직렬화 실패", e);
-		}
-	}
+  private String serialize(List<Long> ids) {
+    try {
+      return objectMapper.writeValueAsString(ids);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("QuoteIdCache 직렬화 실패", e);
+    }
+  }
 
-	private List<Long> deserialize(String json) {
-		try {
-			return objectMapper.readValue(json, new TypeReference<List<Long>>() {
-			});
-		} catch (JsonProcessingException e) {
-			throw new RuntimeException("QuoteIdCache 역직렬화 실패", e);
-		}
-	}
+  private String serializeQuotes(List<QuoteIdWithDifficulty> quotes) {
+    try {
+      return objectMapper.writeValueAsString(quotes);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("QuoteIdCache 직렬화 실패", e);
+    }
+  }
+
+  private List<Long> deserialize(String json) {
+    try {
+      return objectMapper.readValue(json, new TypeReference<List<Long>>() {});
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("QuoteIdCache 역직렬화 실패", e);
+    }
+  }
+
+  private List<QuoteIdWithDifficulty> deserializeQuotes(String json) {
+    try {
+      return objectMapper.readValue(json, new TypeReference<List<QuoteIdWithDifficulty>>() {});
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("QuoteIdCache 역직렬화 실패", e);
+    }
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/QuoteService.java
@@ -7,6 +7,7 @@ import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
 import com.typingpractice.typing_practice_be.quote.domain.*;
+import com.typingpractice.typing_practice_be.quote.dto.QuoteIdWithDifficulty;
 import com.typingpractice.typing_practice_be.quote.exception.*;
 import com.typingpractice.typing_practice_be.quote.query.PublicQuoteQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuoteCreateQuery;
@@ -18,11 +19,9 @@ import com.typingpractice.typing_practice_be.quote.service.difficulty.Difficulty
 import com.typingpractice.typing_practice_be.quote.service.difficulty.QuoteProfileCalculator;
 import com.typingpractice.typing_practice_be.quote.statistics.domain.GlobalQuoteStatistics;
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsService;
-
 import java.util.*;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -48,33 +47,37 @@ public class QuoteService {
   private final QuoteIdCacheService quoteIdCacheService;
 
   public PageResult<Quote> findRandomPublicQuotes(PublicQuoteQuery query) {
-
     QuoteLanguage language = query.getLanguage();
     Random random = new Random((long) (query.getSeed() * 1_000));
 
-    List<Long> ids;
-    if (query.getOnlyMyQuotes() && query.getMemberId() != null) {
-      // 로그인한 유저의 내 문장만 조회
-      ids = quoteIdCacheService.getIdsByMemberId(query.getMemberId(), language);
-    } else {
-      // 전체 문장 랜덤 조회
-      ids = quoteIdCacheService.getPublicIds(language, QuoteDifficultyTier.ALL);
-    }
-
-    Collections.shuffle(ids, random);
-
     int from = (query.getPage() - 1) * query.getCount();
-    int to = Math.min(from + query.getCount() + 1, ids.size());
+    List<Long> slicedIds;
 
-    if (from >= ids.size()) {
-      return new PageResult<>(List.of(), query.getPage(), query.getCount(), false);
+    if (query.getOnlyMyQuotes() && query.getMemberId() != null) {
+      // 내 문장만
+      List<Long> ids = quoteIdCacheService.getIdsByMemberId(query.getMemberId(), language);
+      Collections.shuffle(ids, random);
+
+      int to = Math.min(from + query.getCount() + 1, ids.size());
+      if (from >= ids.size()) {
+        return new PageResult<>(List.of(), query.getPage(), query.getCount(), false);
+      }
+      slicedIds = ids.subList(from, to);
+    } else {
+      // 공개 문장
+      List<QuoteIdWithDifficulty> quotes = quoteIdCacheService.getPublicQuotes(language);
+      Collections.shuffle(quotes, random);
+
+      int to = Math.min(from + query.getCount() + 1, quotes.size());
+      if (from >= quotes.size()) {
+        return new PageResult<>(List.of(), query.getPage(), query.getCount(), false);
+      }
+      slicedIds = quotes.subList(from, to).stream().map(QuoteIdWithDifficulty::getId).toList();
     }
-
-    List<Long> slicedIds = ids.subList(from, to);
 
     List<Quote> fetched = quoteRepository.findByIds(slicedIds, language);
 
-    // 셔플 순서 복원
+    // 셔플 순서로 복원
     Map<Long, Quote> map =
         fetched.stream().collect(Collectors.toMap(Quote::getId, Function.identity()));
     List<Quote> ordered = slicedIds.stream().map(map::get).filter(Objects::nonNull).toList();

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/controller/TypingRecordController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/controller/TypingRecordController.java
@@ -28,8 +28,6 @@ public class TypingRecordController {
   public ApiResponse<Void> save(@RequestBody @Valid TypingRecordRequest request) {
     Long memberId = getMemberIdOrNull();
 
-    System.out.println("request = " + request);
-
     TypingRecordQuery query = TypingRecordQuery.from(request);
 
     typingRecordService.save(memberId, query);

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/QuoteTypingAggregationRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/QuoteTypingAggregationRepository.java
@@ -36,7 +36,13 @@ public class QuoteTypingAggregationRepository {
   public List<QuoteTypingAggregation> aggregateByQuoteIds(List<Long> quoteIds) {
     Aggregation aggregation =
         Aggregation.newAggregation(
-            Aggregation.match(Criteria.where("outlier").is(false).and("quoteId").in(quoteIds)),
+            Aggregation.match(
+                Criteria.where("outlier")
+                    .is(false)
+                    .and("quoteId")
+                    .in(quoteIds)
+                    .and("servingType")
+                    .in(null, "RANDOM")),
             Aggregation.group("quoteId")
                 .first("language")
                 .as("language")
@@ -85,6 +91,8 @@ public class QuoteTypingAggregationRepository {
                     .is(false)
                     .and("quoteId")
                     .in(quoteIds)
+                    .and("servingType")
+                    .in(null, "RANDOM")
                     .and("completedAt")
                     .gte(from)
                     .lt(to)),

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/service/TypingRecordService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/service/TypingRecordService.java
@@ -1,5 +1,7 @@
 package com.typingpractice.typing_practice_be.typingrecord.service;
 
+import com.typingpractice.typing_practice_be.adaptiveserving.dto.AdaptiveServingEstimation;
+import com.typingpractice.typing_practice_be.adaptiveserving.service.AdaptiveServingRedisService;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
@@ -19,6 +21,7 @@ public class TypingRecordService {
   private final TypingRecordRepository typingRecordRepository;
   private final TypingRecordFallbackService fallbackService;
   private final QuoteRepository quoteRepository;
+  private final AdaptiveServingRedisService adaptiveServingRedisService;
 
   private final ApplicationEventPublisher eventPublisher;
 
@@ -29,6 +32,15 @@ public class TypingRecordService {
     float quoteDifficulty = quote.getDifficulty() != null ? quote.getDifficulty() : 0f;
     float quoteAvgCpm = quote.getTypingStats() != null ? quote.getTypingStats().getAvgCpm() : 0f;
     float quoteAvgAcc = quote.getTypingStats() != null ? quote.getTypingStats().getAvgAcc() : 0f;
+
+    float estimatedDifficulty = 0f;
+    float estimatedUncertainty = 0f;
+    if (memberId != null) {
+      AdaptiveServingEstimation estimation =
+          adaptiveServingRedisService.getEstimation(memberId, quote.getLanguage());
+      estimatedDifficulty = estimation.getMu();
+      estimatedUncertainty = estimation.getSigma();
+    }
 
     TypingRecord record =
         TypingRecord.create(
@@ -44,8 +56,8 @@ public class TypingRecordService {
             query.getTypos(),
             query.getTracking(),
             query.getServingType(),
-            0f, // estimatedDifficulty - 서버 계산으로 대체 예정
-            0f, // estimatedUncertainty - 서버 계산으로 대체 예정
+            estimatedDifficulty,
+            estimatedUncertainty,
             quoteDifficulty,
             quoteAvgCpm,
             quoteAvgAcc);

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/MemberTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/MemberTypingStatsBatchService.java
@@ -32,7 +32,7 @@ public class MemberTypingStatsBatchService {
   private final AdaptiveServingCalculator calculator;
   private final AdaptiveServingProperties properties;
 
-  private static final int CHUNK_SIZE = 500;
+  private static final int CHUNK_SIZE = 100;
 
   // 스케줄 배치: 전날 하루치 증분
   @Transactional


### PR DESCRIPTION
## 주요 내용
- GET /quotes/adaptive 엔드포인트 추가 (회원 전용 적응형 문장 서빙)
- mu/sigma 기반 난이도 구간별 문장 선택 + RANDOM 슬롯 혼합
- 문장 ID 캐시를 (id, difficulty) 쌍으로 통합
- QuoteTypingStats 배치에서 ADAPTIVE 기록 제외하여 동적 난이도 보정 오염 방지
- TypingRecord 저장 시 mu/sigma 스냅샷을 서버에서 직접 조회
- AdaptiveServingCalculator에 0 나누기 방어 추가
- 디버그 코드(System.out.println) 제거

## 세부 내용
### 적응형 문장 서빙 API
- AdaptiveServingController: GET /quotes/adaptive (language, count, excludeIds)
- AdaptiveQuoteRequest: 생성자 바인딩, count 기본값 50, @Range(50~100)
- AdaptiveQuoteListResponse: count + content 래핑
- AdaptiveQuoteResponse: QuoteResponse 상속 + servingType 태깅

### 문장 선택 로직 (AdaptiveQuoteService)
- 반폭 max(0.5σ, 3)으로 easy/fit/hard 구간 분류
- easy:fit:hard = 2:5:3 비율로 adaptive 문장 선택, 20% RANDOM 슬롯
- 구간별 풀 부족 시 RANDOM으로 보충
- excludeIds로 이미 친 문장 제외, count 미달 시 제외 목록 무시

### 문장 ID 캐시 통합
- QuoteIdWithDifficulty DTO 신규 생성
- QuoteRepository: findAllPublicIdsWithDifficulty() 추가
- QuoteIdCacheService: tier별 캐시 → (id, difficulty) 쌍 단일 캐시로 통합
- QuoteService: 새 캐시 형태에 맞게 수정

### 선택 편향 방지
- QuoteTypingAggregationRepository: aggregateByQuoteIds, aggregateByQuoteIdsBetween에 servingType in (null, "RANDOM") 필터 추가

### TypingRecord 스냅샷
- TypingRecordService: 회원이면 Redis에서 mu/sigma 조회하여 스냅샷 저장

### 안정성
- AdaptiveServingCalculator: sigma ≤ 0 시 기본값 대체, sigmaObs ≤ 0 시 업데이트 스킵
- TypingRecordController, AdaptiveServingRedisService: 디버그 println 제거