### PR TITLE
feat: 도전 모드 추가 (적응형 문장 서빙 프론트엔드 대응)

### DIFF
--- a/tp-react/src/Context/QuoteContext.tsx
+++ b/tp-react/src/Context/QuoteContext.tsx
@@ -2,18 +2,20 @@ import {createContext, ReactNode, useCallback, useContext, useEffect, useRef, us
 import {useScore} from "./ScoreContext";
 import {useAuth} from "./AuthContext";
 import {useError} from "./ErrorContext";
-import {getQuotes} from "../utils/quoteApi";
+import {getQuotes, getAdaptiveQuotes} from "../utils/quoteApi";
+import type {ServingType} from "../utils/quoteApi";
 import {defaultQuotes} from "../data/default-quotes.const.ts";
-import {Session_Post_Login_Quote_Source} from "../const/config.const";
+import {Session_Post_Login_Quote_Source, Storage_Quote_Source} from "../const/config.const";
 import {t} from "../utils/i18n";
 
 interface Quote {
     quoteId?: number;
     sentence: string;
     author?: string;
+    servingType?: ServingType;
 }
 
-type QuoteSourceType = 'all' | 'my';
+type QuoteSourceType = 'all' | 'my' | 'adaptive';
 
 interface QuoteContextType {
     sentence: string;
@@ -26,6 +28,7 @@ interface QuoteContextType {
     isLoading: boolean;
     isEmpty: boolean;
     isOffline: boolean;
+    prefetchAdaptiveQuotes: () => void;
 }
 
 export const QuoteContext = createContext<QuoteContextType | null>(null);
@@ -39,9 +42,11 @@ export const useQuote = (): QuoteContextType => {
 };
 
 const QUOTES_PER_PAGE = 100;
+const ADAPTIVE_COUNT = 50;
 const QUOTE_SOURCE = {
     ALL: 'all' as const,
     MY: 'my' as const,
+    ADAPTIVE: 'adaptive' as const,
 };
 
 const generateSeed = () => Math.floor(Math.random() * 1_999_999_999) - 999_999_999;
@@ -61,15 +66,22 @@ interface QuoteContextProviderProps {
 
 export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
     const {setInputCheck} = useScore();
-    const {user} = useAuth();
+    const {user, isInitialized} = useAuth();
     const {showError} = useError();
 
     const seedRef = useRef<number>(generateSeed());
     const currentPageRef = useRef<number>(1);
     const hasNextRef = useRef<boolean>(true);
     const isLoadingRef = useRef<boolean>(false);
+    const excludeIdsRef = useRef<number[]>([]);
 
-    const [quoteSource, setQuoteSource] = useState<QuoteSourceType>(QUOTE_SOURCE.ALL);
+    const getInitialQuoteSource = (): QuoteSourceType => {
+        const stored = localStorage.getItem(Storage_Quote_Source);
+        if (stored === 'all' || stored === 'my' || stored === 'adaptive') return stored;
+        return QUOTE_SOURCE.ALL;
+    };
+
+    const [quoteSource, setQuoteSource] = useState<QuoteSourceType>(getInitialQuoteSource);
     const [quotes, setQuotes] = useState<Quote[]>([]);
     const [quotesIndex, setQuotesIndex] = useState<number>(0);
     const [sentence, setSentence] = useState<string>("");
@@ -86,6 +98,7 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
         setAuthor("");
         currentPageRef.current = 1;
         hasNextRef.current = true;
+        excludeIdsRef.current = [];
         setIsEmpty(false);
     }, []);
 
@@ -116,34 +129,65 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
         setIsLoading(true);
 
         try {
-            const response = await getQuotes({
-                page,
-                count: QUOTES_PER_PAGE,
-                seed: seedRef.current,
-                onlyMyQuotes: source === QUOTE_SOURCE.MY,
-            });
-            const data = response.data.data;
-            const content = data.content || [];
+            if (source === QUOTE_SOURCE.ADAPTIVE) {
+                const response = await getAdaptiveQuotes('KOREAN', ADAPTIVE_COUNT, excludeIdsRef.current);
+                const rawContent = response.data.data;
+                const contentArray = Array.isArray(rawContent) ? rawContent : (rawContent as any).content || [];
+                const content = contentArray.map((q: any) => ({
+                    ...q,
+                    servingType: q.servingType || 'ADAPTIVE',
+                }));
 
-            if (reset) {
-                if (content.length === 0 && source === QUOTE_SOURCE.ALL) {
-                    // 서버 응답은 왔지만 공개 문장이 없는 경우 로컬 문장 사용
-                    loadFallbackQuotes();
-                    return;
+                if (reset) {
+                    setQuotes(content);
+                    setQuotesIndex(0);
+                } else {
+                    setQuotes(prev => [...prev, ...content]);
                 }
-                setQuotes(content);
-                setQuotesIndex(0);
+
+                // excludeIds에 새로 받은 ID 추가
+                const newIds = content.map((q: any) => q.quoteId || q.id).filter(Boolean);
+                excludeIdsRef.current = [...excludeIdsRef.current, ...newIds];
+
+                hasNextRef.current = true; // 항상 더 요청 가능
+                setIsEmpty(reset && content.length === 0);
+                setIsOffline(false);
+
+                if (reset && content.length > 0) {
+                    setCurrentQuote(content[0]);
+                }
             } else {
-                setQuotes(prev => [...prev, ...content]);
-            }
+                const response = await getQuotes({
+                    page,
+                    count: QUOTES_PER_PAGE,
+                    seed: seedRef.current,
+                    onlyMyQuotes: source === QUOTE_SOURCE.MY,
+                });
+                const data = response.data.data;
+                const content = (data.content || []).map((q: any) => ({
+                    ...q,
+                    servingType: 'RANDOM' as ServingType,
+                }));
 
-            hasNextRef.current = data.hasNext ?? false;
-            currentPageRef.current = page;
-            setIsEmpty(reset && content.length === 0);
-            setIsOffline(false);
+                if (reset) {
+                    if (content.length === 0 && source === QUOTE_SOURCE.ALL) {
+                        loadFallbackQuotes();
+                        return;
+                    }
+                    setQuotes(content);
+                    setQuotesIndex(0);
+                } else {
+                    setQuotes(prev => [...prev, ...content]);
+                }
 
-            if (reset && content.length > 0) {
-                setCurrentQuote(content[0]);
+                hasNextRef.current = data.hasNext ?? false;
+                currentPageRef.current = page;
+                setIsEmpty(reset && content.length === 0);
+                setIsOffline(false);
+
+                if (reset && content.length > 0) {
+                    setCurrentQuote(content[0]);
+                }
             }
         } catch (error) {
             console.error('문장 로드 실패:', error);
@@ -164,23 +208,28 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
     }, [quoteSource, setCurrentQuote, showError, loadFallbackQuotes]);
 
     useEffect(() => {
-        if (!user && quoteSource === QUOTE_SOURCE.MY) {
+        if (!isInitialized) return;
+        if (!user && (quoteSource === QUOTE_SOURCE.MY || quoteSource === QUOTE_SOURCE.ADAPTIVE)) {
             setQuoteSource(QUOTE_SOURCE.ALL);
         }
         // 로그인 후 저장된 소스 전환 적용
         if (user) {
             const pendingSource = sessionStorage.getItem(Session_Post_Login_Quote_Source);
-            if (pendingSource === 'my') {
+            if (pendingSource === 'my' || pendingSource === 'adaptive') {
                 sessionStorage.removeItem(Session_Post_Login_Quote_Source);
-                setQuoteSource(QUOTE_SOURCE.MY);
+                setQuoteSource(pendingSource as QuoteSourceType);
             }
         }
-    }, [user, quoteSource]);
+    }, [user, isInitialized, quoteSource]);
 
     useEffect(() => {
+        // 로그인 필요한 소스는 인증 초기화 후 로드
+        if ((quoteSource === QUOTE_SOURCE.MY || quoteSource === QUOTE_SOURCE.ADAPTIVE) && !isInitialized) return;
+
         resetState();
         loadQuotes(1, true, quoteSource);
-    }, [quoteSource]); // eslint-disable-line react-hooks/exhaustive-deps
+        localStorage.setItem(Storage_Quote_Source, quoteSource);
+    }, [quoteSource, isInitialized]); // eslint-disable-line react-hooks/exhaustive-deps
 
     useEffect(() => {
         if (quotes.length === 0) return;
@@ -191,7 +240,10 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
         }
 
         if (quotesIndex >= quotes.length) {
-            if (hasNextRef.current && !isLoadingRef.current) {
+            if (quoteSource === QUOTE_SOURCE.ADAPTIVE) {
+                // 적응형: 항상 새 문장 요청
+                loadQuotes(1, false, quoteSource);
+            } else if (hasNextRef.current && !isLoadingRef.current) {
                 loadQuotes(currentPageRef.current + 1, false, quoteSource);
             } else {
                 if (isOffline) {
@@ -214,12 +266,17 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
     const currentQuote = quotes[quotesIndex] || null;
 
     const changeQuoteSource = useCallback((source: QuoteSourceType): boolean => {
-        if (source === QUOTE_SOURCE.MY && !user) {
+        if ((source === QUOTE_SOURCE.MY || source === QUOTE_SOURCE.ADAPTIVE) && !user) {
             return false;
         }
         setQuoteSource(source);
         return true;
     }, [user]);
+
+    const prefetchAdaptiveQuotes = useCallback(() => {
+        if (quoteSource !== QUOTE_SOURCE.ADAPTIVE) return;
+        loadQuotes(1, false, QUOTE_SOURCE.ADAPTIVE);
+    }, [quoteSource, loadQuotes]);
 
     return (
         <QuoteContext.Provider
@@ -234,6 +291,7 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
                 isLoading,
                 isEmpty,
                 isOffline,
+                prefetchAdaptiveQuotes,
             }}
         >
             {children}

--- a/tp-react/src/const/config.const.ts
+++ b/tp-react/src/const/config.const.ts
@@ -22,6 +22,7 @@ export const MAX_AUTHOR_LENGTH = 20 as const;
 export const Storage_Word_Difficulty = "Typing-Practice-wordDifficulty" as const;
 export const Storage_Word_Count = "Typing-Practice-wordCount" as const;
 export const Storage_Last_Mode = "Typing-Practice-lastMode" as const;
+export const Storage_Quote_Source = "Typing-Practice-quoteSource" as const;
 
 // 로그인 유도
 export const Session_Typing_Count = "Typing-Practice-sessionTypingCount" as const;

--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -36,9 +36,18 @@ export function localize(item: LocalizedText): string {
 
 export const updateHistory: UpdateEntry[] = [
     {
+        version: "1.6.0",
+        date: "2026-04-14",
+        showPopup: true,
+        hidden: false,
+        features: [
+            {ko: "도전 모드 추가 — 실력에 맞는 문장을 자동으로 제공", ja: "チャレンジモード追加 — 実力に合った文章を自動提供", en: "Added Challenge mode — sentences matched to your skill level"},
+        ],
+    },
+    {
         version: "1.5.0",
         date: "2026-04-12",
-        showPopup: true,
+        showPopup: false,
         hidden: false,
         features: [
             {ko: "기록 페이지 디자인 전면 개편", ja: "記録ページのデザインを全面改修", en: "Complete redesign of the Records page"},

--- a/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
+++ b/tp-react/src/pages/Home/components/Quote/Input/Input.jsx
@@ -39,7 +39,7 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
         setPopupAccList,
         setPopupTypos,
     } = useScore();
-    const {sentence, currentQuote, setQuotesIndex} = useQuote(); // 예문, 예문의 인덱스
+    const {sentence, currentQuote, setQuotesIndex, prefetchAdaptiveQuotes} = useQuote();
     const {resultPeriod, fontSize, isCompactMode} = useSetting();
     const [input, setInput] = useState(""); // 사용자 입력값
     const speedInterval = useRef(null); // setInterval 을 참조하기 위함
@@ -258,6 +258,7 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
                 setPopupCpmList(recentCpmList);
                 setPopupAccList(recentAccList);
                 setShowPopup(true);
+                prefetchAdaptiveQuotes();
             }
 
             return {
@@ -284,6 +285,7 @@ const Input = ({onInputChange: onInputChangeCallback}) => {
                 charLength: sentence.length,
                 resetCount: resetCountRef.current,
                 typos: typosRef.current,
+                servingType: currentQuote?.servingType || 'RANDOM',
                 anonymousId: user ? null : getAnonymousId(),
             }).catch((error) => console.error('타이핑 기록 저장 실패:', error));
         }

--- a/tp-react/src/pages/Home/components/Quote/QuoteSourceSelector/QuoteSourceSelector.jsx
+++ b/tp-react/src/pages/Home/components/Quote/QuoteSourceSelector/QuoteSourceSelector.jsx
@@ -20,6 +20,14 @@ const QuoteSourceSelector = () => {
         }
     };
 
+    const handleAdaptiveClick = () => {
+        const success = changeQuoteSource('adaptive');
+        if (!success) {
+            sessionStorage.setItem(Session_Post_Login_Quote_Source, 'adaptive');
+            triggerLogin();
+        }
+    };
+
     return (
         <div className="quote-source-selector">
             <button
@@ -33,6 +41,12 @@ const QuoteSourceSelector = () => {
                 onClick={handleMyClick}
             >
                 {t('mySentencesOnly')}
+            </button>
+            <button
+                className={`quote-source-btn ${quoteSource === 'adaptive' ? 'active' : ''}`}
+                onClick={handleAdaptiveClick}
+            >
+                {t('adaptiveSentences')}
             </button>
         </div>
     );

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -67,6 +67,7 @@ const translations = {
     // 문장 소스
     allSentences: l('전체 문장', 'すべての文章', 'All'),
     mySentencesOnly: l('내 문장만', 'マイ文章のみ', 'Mine'),
+    adaptiveSentences: l('도전 모드', 'チャレンジ', 'Challenge'),
     mySentencesLoginRequired: l('내 문장을 사용하려면 로그인이 필요합니다.', 'マイ文章を使用するにはログインが必要です。', 'Login required to use your sentences.'),
 
     // 문장 로딩/비어있음

--- a/tp-react/src/utils/quoteApi.ts
+++ b/tp-react/src/utils/quoteApi.ts
@@ -2,6 +2,8 @@ import apiClient from './apiClient';
 import {ApiResponse, PageResponse} from '../types/api.types';
 
 // 문장 타입
+export type ServingType = 'ADAPTIVE' | 'RANDOM';
+
 interface Quote {
     id: number;
     sentence: string;
@@ -10,6 +12,7 @@ interface Quote {
     status: 'PENDING' | 'ACTIVE';
     createdAt: string;
     updatedAt: string;
+    servingType?: ServingType;
 }
 
 // 파라미터 타입
@@ -46,6 +49,19 @@ export const getQuotes = async (params: GetQuotesParams = {}) => {
 
     const queryString = queryParams.toString();
     return apiClient.get<ApiResponse<PageResponse<Quote>>>(`/quotes${queryString ? `?${queryString}` : ''}`);
+};
+
+/**
+ * 적응형 문장 조회 (회원 전용)
+ */
+export const getAdaptiveQuotes = async (language: string, count: number, excludeIds?: number[]) => {
+    const queryParams = new URLSearchParams();
+    queryParams.append('language', language);
+    queryParams.append('count', String(count));
+    if (excludeIds && excludeIds.length > 0) {
+        queryParams.append('excludeIds', excludeIds.join(','));
+    }
+    return apiClient.get<ApiResponse<Quote[]>>(`/quotes/adaptive?${queryParams.toString()}`);
 };
 
 /**

--- a/tp-react/src/utils/statsApi.ts
+++ b/tp-react/src/utils/statsApi.ts
@@ -103,3 +103,17 @@ export const refreshStats = async (language: Language) => {
         `/members/me/stats/refresh?language=${language}`
     );
 };
+
+/**
+ * 타이핑 프로필 조회 (적응형 서빙 기반 실력 추정)
+ */
+export interface TypingProfile {
+    mu: number;
+    sigma: number;
+}
+
+export const getTypingProfile = async (language: Language) => {
+    return apiClient.get<ApiResponse<TypingProfile>>(
+        `/members/me/typing-profile?language=${language}`
+    );
+};

--- a/tp-react/src/utils/typingRecordApi.ts
+++ b/tp-react/src/utils/typingRecordApi.ts
@@ -1,5 +1,6 @@
 import apiClient from './apiClient';
 import {buildTracking, TrackingInfo} from './tracking';
+import {ServingType} from './quoteApi';
 
 export type TypoType = 'INITIAL' | 'MEDIAL' | 'FINAL' | 'LETTER';
 
@@ -17,6 +18,7 @@ interface TypingRecordRequest {
     charLength: number;
     resetCount: number;
     typos: TypoEntry[];
+    servingType: ServingType;
     anonymousId?: string | null;
     tracking?: TrackingInfo;
 }


### PR DESCRIPTION
## 주요 내용
- 사용자 실력에 맞는 문장을 자동으로 제공하는 도전 모드 추가
- 비로그인 시 로그인 유도 → 로그인 후 자동 전환
- 팝업 표시 중 다음 배치 프리페치

## 세부 내용
### API 레이어
- quoteApi: ServingType 타입 및 getAdaptiveQuotes() 함수 추가
- typingRecordApi: servingType 필드 추가 (ADAPTIVE/RANDOM)
- statsApi: getTypingProfile() 함수 및 TypingProfile 인터페이스 추가

### QuoteContext
- 'adaptive' 소스 타입 추가, excludeIdsRef로 중복 문장 방지
- adaptive 응답 구조 대응 (배열 / content 래퍼 양쪽)
- localStorage로 quoteSource 유지 (새로고침 시 복원)
- isInitialized 대기 후 로드하여 인증 전 요청 방지
- prefetchAdaptiveQuotes() — 팝업 표시 중 다음 배치 백그라운드 로드
- 기존 문장에 servingType: 'RANDOM' 설정

### UI
- QuoteSourceSelector에 도전 모드 버튼 추가
- 비로그인 시 sessionStorage에 'adaptive' 저장 후 로그인 유도
- Input.jsx에서 servingType 전달 및 팝업 시 프리페치 호출

### 기타
- config.const: Storage_Quote_Source 추가
- i18n: adaptiveSentences 키 추가 (도전 모드/チャレンジ/Challenge)
- updateHistory: v1.6.0 추가, v1.5.0 showPopup false