### PR TITLE
feat: 맞춤 난이도 모드 추가 (적응형 문장 서빙 프론트엔드 대응)

### DIFF
--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -41,7 +41,7 @@ export const updateHistory: UpdateEntry[] = [
         showPopup: true,
         hidden: false,
         features: [
-            {ko: "도전 모드 추가 — 실력에 맞는 문장을 자동으로 제공", ja: "チャレンジモード追加 — 実力に合った文章を自動提供", en: "Added Challenge mode — sentences matched to your skill level"},
+            {ko: "맞춤 난이도 모드 추가 — 실력에 맞는 문장을 자동으로 제공", ja: "レベル別モード追加 — 実力に合った文章を自動提供", en: "Added Adaptive mode — sentences matched to your skill level"},
         ],
     },
     {

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -67,7 +67,7 @@ const translations = {
     // 문장 소스
     allSentences: l('전체 문장', 'すべての文章', 'All'),
     mySentencesOnly: l('내 문장만', 'マイ文章のみ', 'Mine'),
-    adaptiveSentences: l('도전 모드', 'チャレンジ', 'Challenge'),
+    adaptiveSentences: l('맞춤 난이도', 'レベル別', 'Adaptive'),
     mySentencesLoginRequired: l('내 문장을 사용하려면 로그인이 필요합니다.', 'マイ文章を使用するにはログインが必要です。', 'Login required to use your sentences.'),
 
     // 문장 로딩/비어있음


### PR DESCRIPTION
## 주요 내용
- 사용자 실력에 맞는 문장을 자동으로 제공하는 맞춤 난이도 모드 추가
- 비로그인 시 로그인 유도 → 로그인 후 자동 전환
- 팝업 표시 중 다음 배치 프리페치

## 세부 내용
### API 레이어
- quoteApi: ServingType 타입 및 getAdaptiveQuotes() 함수 추가
- typingRecordApi: servingType 필드 추가 (ADAPTIVE/RANDOM)
- statsApi: getTypingProfile() 함수 및 TypingProfile 인터페이스 추가

### QuoteContext
- 'adaptive' 소스 타입 추가, excludeIdsRef로 중복 문장 방지
- adaptive 응답 구조 대응 (배열 / content 래퍼 양쪽)
- localStorage로 quoteSource 유지 (새로고침 시 복원)
- isInitialized 대기 후 로드하여 인증 전 요청 방지
- prefetchAdaptiveQuotes() — 팝업 표시 중 다음 배치 백그라운드 로드
- 기존 문장에 servingType: 'RANDOM' 설정

### UI
- QuoteSourceSelector에 맞춤 난이도 버튼 추가
- 비로그인 시 sessionStorage에 'adaptive' 저장 후 로그인 유도
- Input.jsx에서 servingType 전달 및 팝업 시 프리페치 호출

### 기타
- config.const: Storage_Quote_Source 추가
- i18n: adaptiveSentences 키 추가 (맞춤 난이도/レベル別/Adaptive)
- updateHistory: v1.6.0 추가, v1.5.0 showPopup false