### PR TITLE
feat: 단어 모드 세션 결과 그래프/히트맵 추가 및 리팩토링

### DIFF
--- a/tp-react/src/Context/QuoteContext.tsx
+++ b/tp-react/src/Context/QuoteContext.tsx
@@ -5,7 +5,7 @@ import {useError} from "./ErrorContext";
 import {getQuotes, getAdaptiveQuotes} from "../utils/quoteApi";
 import type {ServingType} from "../utils/quoteApi";
 import {defaultQuotes} from "../data/default-quotes.const.ts";
-import {Session_Post_Login_Quote_Source, Storage_Quote_Source} from "../const/config.const";
+import {Session_Post_Login_Quote_Source, Storage_Quote_Source, LANGUAGE} from "../const/config.const";
 import {t} from "../utils/i18n";
 
 interface Quote {
@@ -122,72 +122,91 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
         }
     }, [setCurrentQuote]);
 
-    const loadQuotes = useCallback(async (page = 1, reset = false, source = quoteSource) => {
+    const loadAdaptiveQuotes = useCallback(async (reset = false) => {
         if (isLoadingRef.current) return;
 
         isLoadingRef.current = true;
         setIsLoading(true);
 
         try {
-            if (source === QUOTE_SOURCE.ADAPTIVE) {
-                const response = await getAdaptiveQuotes('KOREAN', ADAPTIVE_COUNT, excludeIdsRef.current);
-                const rawContent = response.data.data;
-                const contentArray = Array.isArray(rawContent) ? rawContent : (rawContent as any).content || [];
-                const content = contentArray.map((q: any) => ({
-                    ...q,
-                    servingType: q.servingType || 'ADAPTIVE',
-                }));
+            const response = await getAdaptiveQuotes(LANGUAGE.KOREAN, ADAPTIVE_COUNT, excludeIdsRef.current);
+            const rawContent = response.data.data;
+            const contentArray = Array.isArray(rawContent) ? rawContent : (rawContent as any).content || [];
+            const content = contentArray.map((q: any) => ({
+                ...q,
+                servingType: q.servingType || 'ADAPTIVE',
+            }));
 
-                if (reset) {
-                    setQuotes(content);
-                    setQuotesIndex(0);
-                } else {
-                    setQuotes(prev => [...prev, ...content]);
-                }
-
-                // excludeIds에 새로 받은 ID 추가
-                const newIds = content.map((q: any) => q.quoteId || q.id).filter(Boolean);
-                excludeIdsRef.current = [...excludeIdsRef.current, ...newIds];
-
-                hasNextRef.current = true; // 항상 더 요청 가능
-                setIsEmpty(reset && content.length === 0);
-                setIsOffline(false);
-
-                if (reset && content.length > 0) {
-                    setCurrentQuote(content[0]);
-                }
+            if (reset) {
+                setQuotes(content);
+                setQuotesIndex(0);
             } else {
-                const response = await getQuotes({
-                    page,
-                    count: QUOTES_PER_PAGE,
-                    seed: seedRef.current,
-                    onlyMyQuotes: source === QUOTE_SOURCE.MY,
-                });
-                const data = response.data.data;
-                const content = (data.content || []).map((q: any) => ({
-                    ...q,
-                    servingType: 'RANDOM' as ServingType,
-                }));
+                setQuotes(prev => [...prev, ...content]);
+            }
 
-                if (reset) {
-                    if (content.length === 0 && source === QUOTE_SOURCE.ALL) {
-                        loadFallbackQuotes();
-                        return;
-                    }
-                    setQuotes(content);
-                    setQuotesIndex(0);
-                } else {
-                    setQuotes(prev => [...prev, ...content]);
+            // excludeIds 관리
+            const newIds = content.map((q: any) => q.quoteId || q.id).filter(Boolean);
+            const randomCount = content.filter((q: any) => q.servingType === 'RANDOM').length;
+            if (randomCount >= Math.ceil(ADAPTIVE_COUNT / 2)) {
+                excludeIdsRef.current = [];
+            } else {
+                excludeIdsRef.current = [...excludeIdsRef.current, ...newIds];
+            }
+
+            hasNextRef.current = content.length > 0;
+            setIsEmpty(reset && content.length === 0);
+            setIsOffline(false);
+
+            if (reset && content.length > 0) {
+                setCurrentQuote(content[0]);
+            }
+        } catch (error) {
+            console.error('적응형 문장 로드 실패:', error);
+            showError(t('sentenceLoadFailed'));
+            if (reset) setIsEmpty(true);
+        } finally {
+            isLoadingRef.current = false;
+            setIsLoading(false);
+        }
+    }, [setCurrentQuote, showError]);
+
+    const loadPagedQuotes = useCallback(async (page = 1, reset = false, source = quoteSource) => {
+        if (isLoadingRef.current) return;
+
+        isLoadingRef.current = true;
+        setIsLoading(true);
+
+        try {
+            const response = await getQuotes({
+                page,
+                count: QUOTES_PER_PAGE,
+                seed: seedRef.current,
+                onlyMyQuotes: source === QUOTE_SOURCE.MY,
+            });
+            const data = response.data.data;
+            const content = (data.content || []).map((q: any) => ({
+                ...q,
+                servingType: 'RANDOM' as ServingType,
+            }));
+
+            if (reset) {
+                if (content.length === 0 && source === QUOTE_SOURCE.ALL) {
+                    loadFallbackQuotes();
+                    return;
                 }
+                setQuotes(content);
+                setQuotesIndex(0);
+            } else {
+                setQuotes(prev => [...prev, ...content]);
+            }
 
-                hasNextRef.current = data.hasNext ?? false;
-                currentPageRef.current = page;
-                setIsEmpty(reset && content.length === 0);
-                setIsOffline(false);
+            hasNextRef.current = data.hasNext ?? false;
+            currentPageRef.current = page;
+            setIsEmpty(reset && content.length === 0);
+            setIsOffline(false);
 
-                if (reset && content.length > 0) {
-                    setCurrentQuote(content[0]);
-                }
+            if (reset && content.length > 0) {
+                setCurrentQuote(content[0]);
             }
         } catch (error) {
             console.error('문장 로드 실패:', error);
@@ -197,9 +216,7 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
                 loadFallbackQuotes();
             } else {
                 showError(t('sentenceLoadFailed'));
-                if (reset) {
-                    setIsEmpty(true);
-                }
+                if (reset) setIsEmpty(true);
             }
         } finally {
             isLoadingRef.current = false;
@@ -225,9 +242,15 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
     useEffect(() => {
         // 로그인 필요한 소스는 인증 초기화 후 로드
         if ((quoteSource === QUOTE_SOURCE.MY || quoteSource === QUOTE_SOURCE.ADAPTIVE) && !isInitialized) return;
+        // 비로그인 상태에서 로그인 필요한 소스는 로드하지 않음 (다른 effect에서 'all'로 전환됨)
+        if ((quoteSource === QUOTE_SOURCE.MY || quoteSource === QUOTE_SOURCE.ADAPTIVE) && !user) return;
 
         resetState();
-        loadQuotes(1, true, quoteSource);
+        if (quoteSource === QUOTE_SOURCE.ADAPTIVE) {
+            loadAdaptiveQuotes(true);
+        } else {
+            loadPagedQuotes(1, true, quoteSource);
+        }
         localStorage.setItem(Storage_Quote_Source, quoteSource);
     }, [quoteSource, isInitialized]); // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -241,10 +264,11 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
 
         if (quotesIndex >= quotes.length) {
             if (quoteSource === QUOTE_SOURCE.ADAPTIVE) {
-                // 적응형: 항상 새 문장 요청
-                loadQuotes(1, false, quoteSource);
+                if (hasNextRef.current && !isLoadingRef.current) {
+                    loadAdaptiveQuotes(false);
+                }
             } else if (hasNextRef.current && !isLoadingRef.current) {
-                loadQuotes(currentPageRef.current + 1, false, quoteSource);
+                loadPagedQuotes(currentPageRef.current + 1, false, quoteSource);
             } else {
                 if (isOffline) {
                     const shuffled = shuffleArray(quotes);
@@ -254,7 +278,7 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
                 } else {
                     seedRef.current = generateSeed();
                     resetState();
-                    loadQuotes(1, true, quoteSource);
+                    loadPagedQuotes(1, true, quoteSource);
                 }
             }
             return;
@@ -275,8 +299,8 @@ export const QuoteContextProvider = ({children}: QuoteContextProviderProps) => {
 
     const prefetchAdaptiveQuotes = useCallback(() => {
         if (quoteSource !== QUOTE_SOURCE.ADAPTIVE) return;
-        loadQuotes(1, false, QUOTE_SOURCE.ADAPTIVE);
-    }, [quoteSource, loadQuotes]);
+        loadAdaptiveQuotes(false);
+    }, [quoteSource, loadAdaptiveQuotes]);
 
     return (
         <QuoteContext.Provider

--- a/tp-react/src/const/config.const.ts
+++ b/tp-react/src/const/config.const.ts
@@ -24,6 +24,13 @@ export const Storage_Word_Count = "Typing-Practice-wordCount" as const;
 export const Storage_Last_Mode = "Typing-Practice-lastMode" as const;
 export const Storage_Quote_Source = "Typing-Practice-quoteSource" as const;
 
+// 언어
+export type Language = 'KOREAN' | 'ENGLISH';
+export const LANGUAGE = {
+    KOREAN: 'KOREAN' as const,
+    ENGLISH: 'ENGLISH' as const,
+};
+
 // 로그인 유도
 export const Session_Typing_Count = "Typing-Practice-sessionTypingCount" as const;
 export const LOGIN_PROMPT_THRESHOLD = 3 as const;

--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -36,9 +36,21 @@ export function localize(item: LocalizedText): string {
 
 export const updateHistory: UpdateEntry[] = [
     {
-        version: "1.6.0",
+        version: "1.7.1",
         date: "2026-04-14",
         showPopup: true,
+        hidden: false,
+        features: [
+            {ko: "단어 모드 결과 화면에 CPM/ACC 추이 그래프 및 키보드 히트맵 추가", ja: "単語モード結果画面にCPM/ACC推移グラフとキーボードヒートマップを追加", en: "Added CPM/ACC trend graph and keyboard heatmap to word mode results"},
+        ],
+        improvements: [
+            {ko: "맞춤 난이도 모드에서 로그아웃 후 재진입 시 문장 로드 오류 수정", ja: "レベル別モードでログアウト後の再入時に文章読み込みエラーを修正", en: "Fixed sentence loading error when re-entering after logout in Adaptive mode"},
+        ],
+    },
+    {
+        version: "1.6.0",
+        date: "2026-04-14",
+        showPopup: false,
         hidden: false,
         features: [
             {ko: "맞춤 난이도 모드 추가 — 실력에 맞는 문장을 자동으로 제공", ja: "レベル別モード追加 — 実力に合った文章を自動提供", en: "Added Adaptive mode — sentences matched to your skill level"},

--- a/tp-react/src/pages/WordMode/components/WordResult/WordResult.css
+++ b/tp-react/src/pages/WordMode/components/WordResult/WordResult.css
@@ -1,7 +1,7 @@
 .word-result {
     display: flex;
     flex-direction: column;
-    width: 22rem;
+    width: 52rem;
     margin: 0 auto;
     padding: 2rem;
     border-radius: 1rem;
@@ -59,6 +59,25 @@
 .word-result-detail-value {
     font-weight: 500;
     color: var(--color-text);
+}
+
+/* 세션 차트 + 히트맵 */
+.word-result-session {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 1.5rem;
+    margin-bottom: 1.5rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-border);
+}
+
+.word-result-section-title {
+    font-size: 0.6875rem;
+    font-weight: 600;
+    color: var(--color-text-muted);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
 }
 
 /* 하단 */

--- a/tp-react/src/pages/WordMode/components/WordResult/WordResult.jsx
+++ b/tp-react/src/pages/WordMode/components/WordResult/WordResult.jsx
@@ -1,27 +1,58 @@
 import {useEffect, useRef, useCallback} from "react";
 import {useTheme} from "@/Context/ThemeContext.tsx";
+import {useAuth} from "@/Context/AuthContext.tsx";
 import {useWord} from "../../context/WordContext";
 import {fetchWords} from "@/utils/wordService";
 import {koreanSeparator} from "@/utils/koreanSeparator.ts";
+import {getAnonymousId} from "@/utils/tracking.ts";
 import {t} from "@/utils/i18n.ts";
 import {VscDebugRestart} from "react-icons/vsc";
+import SessionChart from "@/pages/Home/components/AverageScorePopUp/SessionChart";
+import KeyboardHeatmap from "@/pages/Stats/components/KeyboardHeatmap";
 import "./WordResult.css";
-
-const difficultyLabels = {
-    RANDOM: () => t('random'),
-    EASY: () => t('easy'),
-    NORMAL: () => t('normal'),
-    HARD: () => t('hard'),
-};
 
 const WordResult = () => {
     const {isDark} = useTheme();
+    const {user} = useAuth();
     const {state, dispatch, startTimeRef} = useWord();
-    const {wpm, accuracy, correctWordCount, words, difficulty, wordCount, elapsedMs} = state;
+    const {wpm, accuracy, correctWordCount, words, difficulty, wordCount, elapsedMs, wordCpms, wordAccs, typos, wordDetails} = state;
     const retryBtnRef = useRef(null);
 
     const totalWords = words.length;
     const elapsedSec = elapsedMs / 1000;
+
+    // 서버 전송용 WordTypingRecord 출력
+    useEffect(() => {
+        if (state.phase !== 'result') return;
+
+        // flat typos → wordDetails[].typos 로 재구성
+        const record = {
+            mode: 'WORD',
+            language: 'KOREAN',
+            difficulty,
+            wordCount,
+            timestamp: new Date().toISOString(),
+            memberId: null,
+            anonymousId: user ? null : getAnonymousId(),
+            wpm,
+            accuracy: accuracy / 100,
+            correctWordCount,
+            incorrectWordCount: totalWords - correctWordCount,
+            elapsedTimeMs: elapsedMs,
+            wordIds: null,
+            wordDetails: wordDetails.map((wd, i) => ({
+                wordIndex: i,
+                word: wd.word,
+                typed: wd.typed,
+                correct: wd.correct,
+                timeMs: wd.timeMs,
+                typos: typos
+                    .filter(t => t.wordIndex === i)
+                    .map(({wordIndex, ...rest}) => rest),
+            })),
+        };
+        console.log('[WordTypingRecord]', JSON.stringify(record, null, 2));
+    }, [state.phase]); // eslint-disable-line react-hooks/exhaustive-deps
 
     // CPM 계산: 자모 분리 기준 타수 + 스페이스(단어 수 - 1) / 소요 시간(분)
     const totalJamo = words.reduce((sum, word) => {
@@ -35,9 +66,14 @@ const WordResult = () => {
         dispatch({type: 'RETRY', words: newWords});
     }, [difficulty, wordCount, dispatch, startTimeRef]);
 
-    // Tab → Enter로 retry (자동 포커스 없음)
+    // Tab → retry 버튼으로 직접 포커스, Enter → retry 실행
     useEffect(() => {
         const handleKeyDown = (e) => {
+            if (e.key === 'Tab') {
+                e.preventDefault();
+                retryBtnRef.current?.focus();
+                return;
+            }
             if (e.key === 'Enter' && document.activeElement === retryBtnRef.current) {
                 e.preventDefault();
                 handleRetry();
@@ -77,6 +113,20 @@ const WordResult = () => {
                     <span className="word-result-detail-value">{elapsedSec.toFixed(1)}s</span>
                 </div>
             </div>
+
+            {/* 세션 차트 + 히트맵 */}
+            {wordCpms.length > 0 && (
+                <div className="word-result-session">
+                    <div>
+                        <div className="word-result-section-title">{t('sessionTrend')}</div>
+                        <SessionChart cpmList={wordCpms} accList={wordAccs}/>
+                    </div>
+                    <div>
+                        <div className="word-result-section-title">{t('keyboardHeatmap')}</div>
+                        <KeyboardHeatmap externalTypos={typos} compact/>
+                    </div>
+                </div>
+            )}
 
             {/* 하단 */}
             <div className="word-result-bottom">

--- a/tp-react/src/pages/WordMode/components/WordTyping/WordInput.jsx
+++ b/tp-react/src/pages/WordMode/components/WordTyping/WordInput.jsx
@@ -1,23 +1,27 @@
-import {useEffect, useRef, useState, useCallback, forwardRef, useImperativeHandle} from "react";
+import {forwardRef, useCallback, useEffect, useImperativeHandle, useRef, useState} from "react";
 import {useWord} from "../../context/WordContext";
 import {koreanSeparator} from "@/utils/koreanSeparator.ts";
+import {createFlatTypoEntry, isLanguageSwitchMistake} from "@/utils/typoUtils.ts";
 import {areJamoEqual} from "@/pages/Home/components/Quote/Input/InputUtils";
 import {incrementSessionTypingCount} from "@/utils/sessionUtils.ts";
 import "./WordInput.css";
 
 const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocusChange}, ref) => {
-    const {state, dispatch, startTimeRef} = useWord();
+    const {state, dispatch, startTimeRef, wordStartTimeRef} = useWord();
     const {words, phase} = state;
 
     const [fullInput, setFullInput] = useState("");
     const textareaRef = useRef(null);
-    const goBackBlockedRef = useRef(false); // 현재 단어에 2글자 이상 입력 시 이전 단어 복귀 차단
+    const goBackBlockedRef = useRef(false);
 
-    // 부모에서 focus() 호출 가능하도록 ref 노출
     useImperativeHandle(ref, () => ({
         focus: () => textareaRef.current?.focus(),
     }));
     const confirmedCountRef = useRef(0);
+
+    // 실시간 typo 수집용 refs
+    const wordTyposRef = useRef([]);
+    const maxCheckedJamoRef = useRef(0);
 
     // phase 또는 words 변경 시 초기화
     useEffect(() => {
@@ -25,6 +29,8 @@ const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocus
             setFullInput("");
             confirmedCountRef.current = 0;
             goBackBlockedRef.current = false;
+            wordTyposRef.current = [];
+            maxCheckedJamoRef.current = 0;
             onFullInputChange?.("");
             onCurrentGradesChange?.([]);
             setTimeout(() => textareaRef.current?.focus(), 50);
@@ -36,19 +42,15 @@ const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocus
         const grades = [];
         for (let i = 0; i < Math.max(input.length, word.length); i++) {
             if (i >= input.length) {
-                grades.push('none'); // 미입력
+                grades.push('none');
             } else if (i >= word.length) {
-                grades.push('incorrect'); // 초과
+                grades.push('incorrect');
             } else {
                 const inputSep = koreanSeparator(input[i]);
                 const wordSep = koreanSeparator(word[i]);
                 if (inputSep.length >= wordSep.length) {
-                    const isCorrect = areJamoEqual(
-                        inputSep.slice(0, wordSep.length),
-                        wordSep
-                    );
+                    const isCorrect = areJamoEqual(inputSep.slice(0, wordSep.length), wordSep);
                     if (isCorrect && inputSep.length > wordSep.length) {
-                        // 초과 자모 확인
                         const nextIdx = i + 1;
                         if (nextIdx < word.length) {
                             const nextWordSep = koreanSeparator(word[nextIdx]);
@@ -74,119 +76,189 @@ const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocus
     const computeFullGrades = useCallback((input) => {
         const segments = input.split(' ');
         const allGrades = [];
-
         for (let segIdx = 0; segIdx < segments.length; segIdx++) {
             const segment = segments[segIdx];
             const word = words[segIdx] || '';
-
-            if (segment.length === 0 && segIdx === segments.length - 1) {
-                // 마지막 빈 세그먼트 (스페이스 직후)
-                break;
-            }
-
+            if (segment.length === 0 && segIdx === segments.length - 1) break;
             const wordGrades = gradeWord(segment, word);
-            allGrades.push(...wordGrades);
-
-            // 단어 사이 스페이스
-            if (segIdx < segments.length - 1) {
-                allGrades.push('correct');
+            // 확정된 단어는 미완성('none')을 오답 처리
+            const isConfirmed = segIdx < segments.length - 1;
+            if (isConfirmed) {
+                allGrades.push(...wordGrades.map(g => g === 'none' ? 'incorrect' : g));
+            } else {
+                allGrades.push(...wordGrades);
             }
+            if (isConfirmed) allGrades.push('correct');
         }
-
         return allGrades;
     }, [words, gradeWord]);
 
-    const finishTyping = useCallback((lastWordInput) => {
-        const grades = gradeWord(lastWordInput, words[words.length - 1]);
+    // 현재 단어 실시간 typo 감지 (일반 함수)
+    const runTypoDetection = (inputSegment, wordIdx) => {
+        const word = words[wordIdx];
+        if (!word) return;
+        const separatedWord = word.split('').map(ch => koreanSeparator(ch));
+        const flatWord = separatedWord.flat();
+        const flatInput = inputSegment.split('').map(ch => koreanSeparator(ch)).flat();
+        const newLen = flatInput.length;
+
+        if (newLen > maxCheckedJamoRef.current) {
+            for (let i = maxCheckedJamoRef.current; i < newLen; i++) {
+                const exp = flatWord[i];
+                const act = flatInput[i];
+                if (exp !== undefined && act !== undefined && exp !== act && !isLanguageSwitchMistake(act)) {
+                    wordTyposRef.current.push(createFlatTypoEntry(i, exp, act, separatedWord, word));
+                }
+            }
+            maxCheckedJamoRef.current = newLen;
+        }
+    };
+
+    // 단어 확정 시 typo 수집 + stats 계산 공통 로직
+    const collectWordData = (wordText, word, wordIdx) => {
+        const grades = gradeWord(wordText, word);
+        const finalGrades = grades.map(g => g === 'none' ? 'incorrect' : g);
+        const wordTimeMs = wordStartTimeRef.current ? Date.now() - wordStartTimeRef.current : 0;
+        const jamoCount = word.split('').reduce((sum, ch) => sum + koreanSeparator(ch).length, 0);
+        const cpm = wordTimeMs > 0 ? Math.round(jamoCount / (wordTimeMs / 1000) * 60) : 0;
+        const correctCount = finalGrades.slice(0, word.length).filter(g => g === 'correct').length;
+        const acc = word.length > 0 ? Math.round(correctCount / word.length * 100) : 0;
+
+        // fallback: 실시간 감지에서 놓친 typo 보완 + 부족 자모
+        const separatedWord = word.split('').map(ch => koreanSeparator(ch));
+        const flatWord = separatedWord.flat();
+        const flatInput = wordText.split('').map(ch => koreanSeparator(ch)).flat();
+        const existingKeys = new Set(wordTyposRef.current.map(t => `${t.position}-${t.type}`));
+        for (let i = 0; i < flatWord.length; i++) {
+            const exp = flatWord[i];
+            const act = flatInput[i];
+            if (act !== undefined) {
+                if (exp !== act && !isLanguageSwitchMistake(act)) {
+                    const entry = createFlatTypoEntry(i, exp, act, separatedWord, word);
+                    const key = `${entry.position}-${entry.type}`;
+                    if (!existingKeys.has(key)) {
+                        wordTyposRef.current.push({...entry, wordIndex: wordIdx});
+                        existingKeys.add(key);
+                    }
+                }
+            } else {
+                // 부족한 자모 (expected: 자모, actual: "")
+                const entry = createFlatTypoEntry(i, exp, '', separatedWord, word);
+                const key = `${entry.position}-${entry.type}`;
+                if (!existingKeys.has(key)) {
+                    wordTyposRef.current.push({...entry, wordIndex: wordIdx});
+                    existingKeys.add(key);
+                }
+            }
+        }
+
+        const typos = wordTyposRef.current.map(t => ({...t, wordIndex: wordIdx}));
+        return {finalGrades, wordTimeMs, cpm, acc, typos};
+    };
+
+    // 단어 확정 시 dispatch
+    const confirmWord = (wordText, wordIdx) => {
+        const {finalGrades, wordTimeMs, cpm, acc, typos} = collectWordData(wordText, words[wordIdx], wordIdx);
+
+        dispatch({
+            type: 'CONFIRM_WORD',
+            input: wordText,
+            charGrades: finalGrades,
+            timeMs: wordTimeMs,
+            cpm,
+            acc,
+            typos
+        });
+
+        wordStartTimeRef.current = Date.now();
+        wordTyposRef.current = [];
+        maxCheckedJamoRef.current = 0;
+    };
+
+    const finishTyping = (lastWordInput) => {
+        const lastWordIdx = words.length - 1;
+        const {finalGrades, wordTimeMs, cpm, acc, typos} = collectWordData(lastWordInput, words[lastWordIdx], lastWordIdx);
         const elapsedMs = startTimeRef.current ? Date.now() - startTimeRef.current : 0;
+
         dispatch({
             type: 'FINISH',
             input: lastWordInput,
-            charGrades: grades,
-            timeMs: 0,
+            charGrades: finalGrades,
+            timeMs: wordTimeMs,
             elapsedMs,
+            cpm,
+            acc,
+            typos,
         });
-
-        // 세션 타이핑 카운트 증가
         incrementSessionTypingCount();
-    }, [dispatch, gradeWord, words, startTimeRef]);
+    };
 
     const handleInput = (e) => {
         const newValue = e.target.value;
 
-        // 타이머 시작
         if (!startTimeRef.current && newValue.length > 0) {
             startTimeRef.current = Date.now();
+            wordStartTimeRef.current = Date.now();
         }
 
-        // 스페이스로 분할하여 단어 세그먼트 파악
         const segments = newValue.split(' ');
         const newConfirmedCount = segments.length - 1;
         const oldConfirmedCount = confirmedCountRef.current;
 
-        // 마지막 단어 이후 스페이스 → 완료 처리
+        // 마지막 단어 이후 스페이스 → 완료
         if (newConfirmedCount >= words.length) {
             const lastWordInput = segments[words.length - 1] || '';
-
-            // 마지막 단어 이전까지의 모든 미확정 단어 확정
             for (let i = oldConfirmedCount; i < words.length - 1; i++) {
-                const wordText = segments[i];
-                const grades = gradeWord(wordText, words[i]);
-                dispatch({type: 'CONFIRM_WORD', input: wordText, charGrades: grades, timeMs: 0});
+                confirmWord(segments[i], i);
             }
-
             finishTyping(lastWordInput);
             return;
         }
 
         setFullInput(newValue);
 
-        // 현재 단어 글자수가 2 이상이면 복귀 차단 플래그 활성화
         const currentSegment = segments[segments.length - 1];
         if (currentSegment.length >= 2) {
             goBackBlockedRef.current = true;
         }
 
-        // 새로 확정된 단어 처리 (스페이스 수 증가)
+        // 새로 확정된 단어
         if (newConfirmedCount > oldConfirmedCount) {
             for (let i = oldConfirmedCount; i < newConfirmedCount; i++) {
-                const wordText = segments[i];
-                const grades = gradeWord(wordText, words[i]);
-                dispatch({type: 'CONFIRM_WORD', input: wordText, charGrades: grades, timeMs: 0});
+                confirmWord(segments[i], i);
             }
             confirmedCountRef.current = newConfirmedCount;
-            goBackBlockedRef.current = false; // 새 단어 시작, 플래그 리셋
+            goBackBlockedRef.current = false;
         }
-        // 이전 단어로 복귀 (스페이스 수 감소 = 백스페이스로 스페이스 삭제)
+        // 이전 단어로 복귀
         else if (newConfirmedCount < oldConfirmedCount) {
             for (let i = oldConfirmedCount; i > newConfirmedCount; i--) {
                 dispatch({type: 'GO_BACK_WORD'});
             }
             confirmedCountRef.current = newConfirmedCount;
+            wordTyposRef.current = [];
+            maxCheckedJamoRef.current = 0;
         }
 
-        // 현재 단어 채점 + 전체 채점
+        // 현재 단어 실시간 typo 감지
+        runTypoDetection(currentSegment, newConfirmedCount);
+
         const fullGrades = computeFullGrades(newValue);
         onCurrentGradesChange?.(fullGrades);
         onFullInputChange?.(newValue);
     };
 
     const handleKeyDown = (e) => {
-        // Tab → retry 버튼으로 포커스
         if (e.key === 'Tab') {
             e.preventDefault();
             const retryBtn = document.querySelector('.word-retry-btn');
             if (retryBtn) retryBtn.focus();
             return;
         }
-
-        // Enter, Escape — 완전 차단
         if (e.key === 'Enter' || e.key === 'Escape') {
             e.preventDefault();
             return;
         }
-
-        // Backspace — 플래그 활성화 시 이전 단어 복귀 차단
         if (e.key === 'Backspace') {
             const segments = fullInput.split(' ');
             const currentSegment = segments[segments.length - 1];

--- a/tp-react/src/pages/WordMode/context/WordContext.tsx
+++ b/tp-react/src/pages/WordMode/context/WordContext.tsx
@@ -1,6 +1,7 @@
 import {createContext, ReactNode, useContext, useReducer, useRef} from "react";
 import {Difficulty, WordCount, WORD_COUNTS} from "@/utils/wordService";
 import {Storage_Word_Difficulty, Storage_Word_Count} from "@/const/config.const";
+import type {TypoEntry} from "@/utils/typingRecordApi";
 
 // === Types ===
 
@@ -28,6 +29,12 @@ interface WordState {
     wordGrades: CharGrade[];      // 단어별 판정
     charGrades: CharGrade[][];    // 단어별 글자별 판정 (확정된 단어)
 
+    // 세션 데이터 (서버 전송 대비)
+    typos: TypoEntry[];           // 전체 typo 누적 (히트맵용)
+    wordCpms: number[];           // 단어별 CPM
+    wordAccs: number[];           // 단어별 정확도 %
+    wordTimesMs: number[];        // 단어별 소요 시간
+
     // 결과
     wpm: number;
     accuracy: number;
@@ -40,9 +47,9 @@ type WordAction =
     | { type: 'SET_DIFFICULTY'; difficulty: Difficulty }
     | { type: 'SET_WORD_COUNT'; wordCount: WordCount }
     | { type: 'START_TYPING'; words: string[] }
-    | { type: 'CONFIRM_WORD'; input: string; charGrades: CharGrade[]; timeMs: number }
+    | { type: 'CONFIRM_WORD'; input: string; charGrades: CharGrade[]; timeMs: number; cpm: number; acc: number; typos: TypoEntry[] }
     | { type: 'GO_BACK_WORD' }
-    | { type: 'FINISH'; input: string; charGrades: CharGrade[]; timeMs: number; elapsedMs: number }
+    | { type: 'FINISH'; input: string; charGrades: CharGrade[]; timeMs: number; elapsedMs: number; cpm: number; acc: number; typos: TypoEntry[] }
     | { type: 'RETRY'; words: string[] }
     | { type: 'RESET' };
 
@@ -81,6 +88,10 @@ const createInitialState = (): WordState => ({
     wordInputs: [],
     wordGrades: [],
     charGrades: [],
+    typos: [],
+    wordCpms: [],
+    wordAccs: [],
+    wordTimesMs: [],
     wpm: 0,
     accuracy: 0,
     correctWordCount: 0,
@@ -96,27 +107,25 @@ function calculateResult(state: WordState): Pick<WordState, 'wpm' | 'accuracy' |
     const elapsedSec = elapsedMs / 1000;
     const wpm = elapsedSec > 0 ? Math.round(correctWordCount / (elapsedSec / 60)) : 0;
 
-    // 글자 기준 정확도
-    let totalChars = 0;
-    let correctChars = 0;
+    // 글자 기준 정확도 (문장 모드와 동일: correct / (correct + incorrect))
+    let totalCorrect = 0;
+    let totalIncorrect = 0;
     for (let i = 0; i < words.length; i++) {
         const word = words[i];
         const wordCharGrades = state.charGrades[i] || [];
-        // 원본 단어 길이 기준
         for (let j = 0; j < word.length; j++) {
-            totalChars++;
-            if (wordCharGrades[j] === 'correct') {
-                correctChars++;
-            }
+            if (wordCharGrades[j] === 'correct') totalCorrect++;
+            else if (wordCharGrades[j] === 'incorrect') totalIncorrect++;
         }
     }
-    const accuracy = totalChars > 0 ? Math.round((correctChars / totalChars) * 100) : 0;
+    const checked = totalCorrect + totalIncorrect;
+    const accuracy = checked > 0 ? Math.round((totalCorrect / checked) * 100) : 0;
 
     const wordDetails: WordDetail[] = words.map((word, i) => ({
         word,
         typed: wordInputs[i] || '',
         correct: wordGrades[i] === 'correct',
-        timeMs: 0, // Phase 1에서는 개별 단어 시간 미수집
+        timeMs: state.wordTimesMs[i] || 0,
     }));
 
     return {wpm, accuracy, correctWordCount, wordDetails, elapsedMs};
@@ -141,6 +150,10 @@ function wordReducer(state: WordState, action: WordAction): WordState {
                 wordInputs: new Array(action.words.length).fill(''),
                 wordGrades: new Array(action.words.length).fill('none'),
                 charGrades: new Array(action.words.length).fill([]),
+                typos: [],
+                wordCpms: [],
+                wordAccs: [],
+                wordTimesMs: [],
                 wpm: 0,
                 accuracy: 0,
                 correctWordCount: 0,
@@ -170,6 +183,10 @@ function wordReducer(state: WordState, action: WordAction): WordState {
                 wordGrades: newWordGrades,
                 charGrades: newCharGrades,
                 currentWordIndex: currentWordIndex + 1,
+                typos: [...state.typos, ...action.typos],
+                wordCpms: [...state.wordCpms, action.cpm],
+                wordAccs: [...state.wordAccs, action.acc],
+                wordTimesMs: [...state.wordTimesMs, action.timeMs],
             };
         }
 
@@ -211,6 +228,10 @@ function wordReducer(state: WordState, action: WordAction): WordState {
                 charGrades: newCharGrades,
                 currentWordIndex: currentWordIndex + 1,
                 elapsedMs: action.elapsedMs,
+                typos: [...state.typos, ...action.typos],
+                wordCpms: [...state.wordCpms, action.cpm],
+                wordAccs: [...state.wordAccs, action.acc],
+                wordTimesMs: [...state.wordTimesMs, action.timeMs],
             };
 
             const result = calculateResult(updatedState);
@@ -231,6 +252,10 @@ function wordReducer(state: WordState, action: WordAction): WordState {
                 wordInputs: new Array(action.words.length).fill(''),
                 wordGrades: new Array(action.words.length).fill('none'),
                 charGrades: new Array(action.words.length).fill([]),
+                typos: [],
+                wordCpms: [],
+                wordAccs: [],
+                wordTimesMs: [],
                 wpm: 0,
                 accuracy: 0,
                 correctWordCount: 0,

--- a/tp-react/src/utils/quoteApi.ts
+++ b/tp-react/src/utils/quoteApi.ts
@@ -1,5 +1,6 @@
 import apiClient from './apiClient';
 import {ApiResponse, PageResponse} from '../types/api.types';
+import {LANGUAGE} from '@/const/config.const';
 
 // 문장 타입
 export type ServingType = 'ADAPTIVE' | 'RANDOM';
@@ -68,7 +69,7 @@ export const getAdaptiveQuotes = async (language: string, count: number, exclude
  * 공개 문장 업로드
  */
 const uploadPublicQuote = async (sentence: string, author?: string) => {
-    const body: { sentence: string; author?: string; language: string } = {sentence, language: 'KOREAN'};
+    const body: { sentence: string; author?: string; language: string } = {sentence, language: LANGUAGE.KOREAN};
     if (author) {
         body.author = author;
     }
@@ -79,7 +80,7 @@ const uploadPublicQuote = async (sentence: string, author?: string) => {
  * 비공개 문장 업로드
  */
 const uploadPrivateQuote = async (sentence: string, author?: string) => {
-    const body: { sentence: string; author?: string; language: string } = {sentence, language: 'KOREAN'};
+    const body: { sentence: string; author?: string; language: string } = {sentence, language: LANGUAGE.KOREAN};
     if (author) {
         body.author = author;
     }

--- a/tp-react/src/utils/statsApi.ts
+++ b/tp-react/src/utils/statsApi.ts
@@ -1,5 +1,6 @@
 import apiClient from './apiClient';
 import {ApiResponse} from '../types/api.types';
+import {Language} from '@/const/config.const';
 
 // 종합 통계 응답
 export interface TypingStatsResponse {
@@ -57,7 +58,6 @@ export interface TypoDetailStatsResponse {
     content: TypoDetailEntry[];
 }
 
-type Language = 'KOREAN' | 'ENGLISH';
 
 /**
  * 종합 타이핑 통계 조회

--- a/tp-react/src/utils/typingRecordApi.ts
+++ b/tp-react/src/utils/typingRecordApi.ts
@@ -9,6 +9,7 @@ export interface TypoEntry {
     actual: string;
     position: number;
     type: TypoType;
+    wordIndex?: number;
 }
 
 interface TypingRecordRequest {


### PR DESCRIPTION
## 주요 내용
- 단어 모드 결과 화면에 CPM/ACC 추이 그래프 및 키보드 에러 히트맵 추가
- 단어 모드 타이핑 typo 수집 및 단어별 CPM/ACC/시간 측정
- 맞춤 난이도 코드 리뷰 피드백 반영

## 세부 내용
### 단어 모드 세션 결과
- SessionChart, KeyboardHeatmap 재사용하여 결과 화면에 2열 그리드 배치
- WordTypingRecord 구조로 console.log 출력 (서버 전송 대비)

### 단어 모드 typo 수집
- 실시간 flat jamo 비교 (Quote processInput과 동일 패턴) + 확정 시점 fallback 보완
- 부족 자모 typo 기록 (expected: 자모, actual: "")
- TypoEntry에 wordIndex 필드 추가, 전송 시 wordDetails[].typos로 재구성

### 단어 모드 정확도/채점 개선
- 정확도 계산을 문장 모드와 동일 기준으로 통일 (correct / (correct + incorrect))
- 확정 시 미완성 글자('none') → 오답('incorrect') 변환
- WordContext에 wordCpms, wordAccs, wordTimesMs state 추가

### 리팩토링
- loadQuotes를 loadAdaptiveQuotes/loadPagedQuotes로 분리
- Language 타입 및 LANGUAGE 상수를 config.const에 정의, 하드코딩 제거
- excludeIds 관리: RANDOM 비율 절반 이상 시 초기화
- 빈 응답 시 hasNextRef=false로 무한 요청 방지
- 비로그인 상태에서 adaptive 로드 차단 (로그아웃 후 재진입 오류 수정)

### 기타
- updateHistory v1.7.1 추가
- WordResult 미사용 변수(wordTimesMs, difficultyLabels) 제거
- WordInput 중복 로직을 collectWordData 헬퍼로 추출