### PR TITLE
fix: 단어 모드 CPM 계산 및 입력 제한 개선

### DIFF
--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -44,6 +44,7 @@ export const updateHistory: UpdateEntry[] = [
             {ko: "단어 모드 결과 화면에 CPM/ACC 추이 그래프 및 키보드 히트맵 추가", ja: "単語モード結果画面にCPM/ACC推移グラフとキーボードヒートマップを追加", en: "Added CPM/ACC trend graph and keyboard heatmap to word mode results"},
         ],
         improvements: [
+            {ko: "단어 모드에서 글자 수가 부족할 때 다음 단어로 넘어가지 않도록 변경", ja: "単語モードで文字数が不足している場合、次の単語に進めないように変更", en: "Prevented moving to the next word when input is shorter than the word length"},
             {ko: "맞춤 난이도 모드에서 로그아웃 후 재진입 시 문장 로드 오류 수정", ja: "レベル別モードでログアウト後の再入時に文章読み込みエラーを修正", en: "Fixed sentence loading error when re-entering after logout in Adaptive mode"},
         ],
     },

--- a/tp-react/src/pages/WordMode/components/WordTyping/WordInput.jsx
+++ b/tp-react/src/pages/WordMode/components/WordTyping/WordInput.jsx
@@ -170,7 +170,7 @@ const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocus
             typos
         });
 
-        wordStartTimeRef.current = Date.now();
+        wordStartTimeRef.current = null;
         wordTyposRef.current = [];
         maxCheckedJamoRef.current = 0;
     };
@@ -198,7 +198,7 @@ const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocus
 
         if (!startTimeRef.current && newValue.length > 0) {
             startTimeRef.current = Date.now();
-            wordStartTimeRef.current = Date.now();
+            wordStartTimeRef.current = null;
         }
 
         const segments = newValue.split(' ');
@@ -240,6 +240,11 @@ const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocus
             maxCheckedJamoRef.current = 0;
         }
 
+        // 현재 단어 첫 입력 시 타이머 시작
+        if (currentSegment.length > 0 && wordStartTimeRef.current === null) {
+            wordStartTimeRef.current = Date.now();
+        }
+
         // 현재 단어 실시간 typo 감지
         runTypoDetection(currentSegment, newConfirmedCount);
 
@@ -258,6 +263,15 @@ const WordInput = forwardRef(({onFullInputChange, onCurrentGradesChange, onFocus
         if (e.key === 'Enter' || e.key === 'Escape') {
             e.preventDefault();
             return;
+        }
+        if (e.key === ' ') {
+            const segments = fullInput.split(' ');
+            const currentSegment = segments[segments.length - 1];
+            const currentWord = words[confirmedCountRef.current];
+            if (currentWord && currentSegment.length < currentWord.length) {
+                e.preventDefault();
+                return;
+            }
         }
         if (e.key === 'Backspace') {
             const segments = fullInput.split(' ');


### PR DESCRIPTION
## 주요 내용
- 단어별 CPM 타이머를 첫 입력 시점 기준으로 변경
- 글자 수가 부족할 때 스페이스바로 다음 단어 이동 차단

## 세부 내용
### WordInput
- wordStartTimeRef를 단어 확정 시 null로 리셋, 새 단어 첫 입력 시 Date.now()로 시작
- 기존: 이전 단어 확정 시점부터 측정 → 단어 간 간격이 짧으면 CPM 비정상 급등
- handleKeyDown에서 스페이스 입력 시 현재 입력 길이 < 단어 길이이면 차단

### updateHistory
- v1.7.1 개선사항 추가