### PR TITLE
feat: Word 패키지 초기 구현 — 도메인, 랜덤 서빙, 어드민 CRUD

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/AuthController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/AuthController.java
@@ -14,6 +14,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
+
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -23,24 +25,24 @@ public class AuthController {
   private final MemberService memberService;
   private final JwtTokenProvider jwtTokenProvider;
 
-  //  @PostMapping("/test")
-  //  public ApiResponse<LoginResponse> testLogin(@RequestBody TestLoginRequest request) {
-  //
-  //    LoginResult loginResult =
-  //        memberService.loginOrSignIn(
-  //            GoogleUserInfo.create(
-  //                request.getProviderId(),
-  //                "email",
-  //                "user_" + UUID.randomUUID().toString().substring(0, 8),
-  //                "picture"));
-  //
-  //    Member member = loginResult.getMember();
-  //
-  //    String token = jwtTokenProvider.createToken(member.getId(), member.getRole());
-  //    String refreshToken = authService.createRefreshToken(member);
-  //
-  //    return ApiResponse.ok(LoginResponse.from(loginResult, token, refreshToken));
-  //  }
+  @PostMapping("/test")
+  public ApiResponse<LoginResponse> testLogin(@RequestBody TestLoginRequest request) {
+
+    LoginResult loginResult =
+        memberService.loginOrSignIn(
+            GoogleUserInfo.create(
+                request.getProviderId(),
+                "email",
+                "user_" + UUID.randomUUID().toString().substring(0, 8),
+                "picture"));
+
+    Member member = loginResult.getMember();
+
+    String token = jwtTokenProvider.createToken(member.getId(), member.getRole());
+    String refreshToken = authService.createRefreshToken(member);
+
+    return ApiResponse.ok(LoginResponse.from(loginResult, token, refreshToken));
+  }
 
   @PostMapping("/google")
   public ApiResponse<LoginResponse> googleLogin(@RequestBody GoogleLoginRequest request) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -31,6 +31,10 @@ public enum ErrorCode {
   QUOTE_DUPLICATE(HttpStatus.CONFLICT, "동일한 문장이 이미 존재합니다."),
   QUOTE_SIMILAR(HttpStatus.CONFLICT, "유사한 문장이 이미 존재합니다."),
 
+  WORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 단어를 찾을 수 없습니다"),
+  WORD_LANGUAGE_MISMATCH(HttpStatus.BAD_REQUEST, "선택한 언어와 맞지 않는 문자가 포함되어 있습니다."),
+  WORD_DUPLICATE(HttpStatus.CONFLICT, "동일한 단어가 이미 존재합니다."),
+
   EMPTY_UPDATE_REQUEST(HttpStatus.BAD_REQUEST, "수정할 내용이 없습니다."),
 
   REPORT_NOT_FOUND(HttpStatus.NOT_FOUND, "신고 내역을 찾을 수 없습니다."),

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -48,16 +48,18 @@ public class SecurityConfig {
             auth ->
                 auth
                     // 인증 불필요
-                    // .requestMatchers("/swagger-ui/**", "/api-docs/**")
-                    // .permitAll()
-                    // .requestMatchers("/auth/test")
-                    // .permitAll()
+                    .requestMatchers("/swagger-ui/**", "/api-docs/**")
+                    .permitAll()
+                    .requestMatchers("/auth/test")
+                    .permitAll()
                     //
                     .requestMatchers("/auth/google")
                     .permitAll()
                     .requestMatchers("/auth/refresh")
                     .permitAll()
                     .requestMatchers(HttpMethod.GET, "/quotes")
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, "/words")
                     .permitAll()
                     .requestMatchers("/error")
                     .permitAll()

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/service/TypingRecordService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/service/TypingRecordService.java
@@ -3,6 +3,7 @@ package com.typingpractice.typing_practice_be.typingrecord.service;
 import com.typingpractice.typing_practice_be.adaptiveserving.dto.AdaptiveServingEstimation;
 import com.typingpractice.typing_practice_be.adaptiveserving.service.AdaptiveServingRedisService;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
 import com.typingpractice.typing_practice_be.typingrecord.domain.TypingRecord;
@@ -29,6 +30,8 @@ public class TypingRecordService {
     Quote quote =
         quoteRepository.findById(query.getQuoteId()).orElseThrow(QuoteNotFoundException::new);
 
+    QuoteLanguage language = quote.getLanguage();
+
     float quoteDifficulty = quote.getDifficulty() != null ? quote.getDifficulty() : 0f;
     float quoteAvgCpm = quote.getTypingStats() != null ? quote.getTypingStats().getAvgCpm() : 0f;
     float quoteAvgAcc = quote.getTypingStats() != null ? quote.getTypingStats().getAvgAcc() : 0f;
@@ -37,7 +40,7 @@ public class TypingRecordService {
     float estimatedUncertainty = 0f;
     if (memberId != null) {
       AdaptiveServingEstimation estimation =
-          adaptiveServingRedisService.getEstimation(memberId, quote.getLanguage());
+          adaptiveServingRedisService.getEstimation(memberId, language);
       estimatedDifficulty = estimation.getMu();
       estimatedUncertainty = estimation.getSigma();
     }
@@ -47,7 +50,7 @@ public class TypingRecordService {
             memberId,
             query.getAnonymousId(),
             quote.getId(),
-            quote.getLanguage(),
+            language,
             quote.getType(),
             query.getCpm(),
             query.getAccuracy(),

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/controller/AdminWordController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/controller/AdminWordController.java
@@ -1,0 +1,40 @@
+package com.typingpractice.typing_practice_be.word.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.word.domain.Word;
+import com.typingpractice.typing_practice_be.word.dto.WordCreateRequest;
+import com.typingpractice.typing_practice_be.word.dto.WordResponse;
+import com.typingpractice.typing_practice_be.word.dto.WordUpdateRequest;
+import com.typingpractice.typing_practice_be.word.service.WordService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/word")
+public class AdminWordController {
+  private final WordService wordService;
+
+  @PostMapping()
+  public ApiResponse<WordResponse> postWord(@RequestBody @Valid WordCreateRequest request) {
+    Word word = wordService.createWord(request.getWord(), request.getLanguage());
+
+    return ApiResponse.ok(WordResponse.from(word));
+  }
+
+  @PatchMapping("/{id}")
+  public ApiResponse<WordResponse> patchWord(
+      @PathVariable Long id, @RequestBody WordUpdateRequest request) {
+    Word word = wordService.updateWord(id, request.getWord());
+
+    return ApiResponse.ok(WordResponse.from(word));
+  }
+
+  @DeleteMapping("/{id}")
+  public ApiResponse<Void> deleteWord(@PathVariable Long id) {
+    wordService.deleteWord(id);
+
+    return ApiResponse.ok(null);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/controller/WordController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/controller/WordController.java
@@ -1,0 +1,28 @@
+package com.typingpractice.typing_practice_be.word.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.word.domain.Word;
+import com.typingpractice.typing_practice_be.word.dto.WordRequest;
+import com.typingpractice.typing_practice_be.word.dto.WordResponse;
+import com.typingpractice.typing_practice_be.word.service.WordService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/words")
+public class WordController {
+  private final WordService wordService;
+
+  @GetMapping()
+  public ApiResponse<List<WordResponse>> getRandomWords(
+      @ModelAttribute @Valid WordRequest request) {
+    List<Word> words = wordService.findRandomWords(request.getLanguage(), request.getCount());
+
+    List<WordResponse> response = words.stream().map(WordResponse::from).toList();
+
+    return ApiResponse.ok(response);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/domain/Word.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/domain/Word.java
@@ -1,0 +1,55 @@
+package com.typingpractice.typing_practice_be.word.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+
+@Entity
+@Getter
+@SQLRestriction("deleted = false")
+@SQLDelete(sql = "UPDATE word SET deleted = true, deleted_at = NOW() where word_id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_word",
+            columnNames = {"word", "language"}))
+public class Word extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "word_id")
+  private Long id;
+
+  private String word;
+
+  @Enumerated(EnumType.STRING)
+  private WordLanguage language;
+
+  private Float difficulty;
+
+  @Embedded private WordProfile profile;
+
+  public static Word create(String word, WordLanguage language) {
+    Word w = new Word();
+    w.word = word;
+    w.language = language;
+
+    return w;
+  }
+
+  public void updateWord(String word) {
+    this.word = word;
+  }
+
+  public void updateDifficulty(Float difficulty) {
+    this.difficulty = difficulty;
+  }
+
+  public void updateProfile(WordProfile profile) {
+    this.profile = profile;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/domain/WordLanguage.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/domain/WordLanguage.java
@@ -1,0 +1,6 @@
+package com.typingpractice.typing_practice_be.word.domain;
+
+public enum WordLanguage {
+  KOREAN,
+  ENGLISH
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/domain/WordProfile.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/domain/WordProfile.java
@@ -1,0 +1,28 @@
+package com.typingpractice.typing_practice_be.word.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WordProfile {
+  private int length;
+  private float difficultySeed;
+
+  // 한국어 전용
+  private Float jamoComplex;
+  private Float diphthongRate;
+  private Float shiftJamoRate;
+
+  // 영어 전용
+  private Float caseFlipRate;
+
+  public static WordProfile create() {
+    return new WordProfile();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/WordCreateRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/WordCreateRequest.java
@@ -1,0 +1,23 @@
+package com.typingpractice.typing_practice_be.word.dto;
+
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WordCreateRequest {
+  @Size(max = 20)
+  private String word;
+
+  private WordLanguage language;
+
+  public static WordCreateRequest create(String word, WordLanguage language) {
+    WordCreateRequest request = new WordCreateRequest();
+    request.word = word;
+    request.language = language;
+
+    return request;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/WordRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/WordRequest.java
@@ -1,0 +1,18 @@
+package com.typingpractice.typing_practice_be.word.dto;
+
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Range;
+
+@Getter
+public class WordRequest {
+  private final WordLanguage language;
+
+  @Range(min = 10, max = 100)
+  private final int count;
+
+  public WordRequest(WordLanguage language, Integer count) {
+    this.language = language;
+    this.count = count != null ? count : 25;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/WordResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/WordResponse.java
@@ -1,0 +1,20 @@
+package com.typingpractice.typing_practice_be.word.dto;
+
+import com.typingpractice.typing_practice_be.word.domain.Word;
+import lombok.Getter;
+
+@Getter
+public class WordResponse {
+  private Long wordId;
+  private String word;
+  private Float difficulty;
+
+  public static WordResponse from(Word word) {
+    WordResponse response = new WordResponse();
+    response.wordId = word.getId();
+    response.word = word.getWord();
+    response.difficulty = word.getDifficulty();
+
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/WordUpdateRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/WordUpdateRequest.java
@@ -1,0 +1,17 @@
+package com.typingpractice.typing_practice_be.word.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WordUpdateRequest {
+  private String word;
+
+  public static WordUpdateRequest create(String word) {
+    WordUpdateRequest request = new WordUpdateRequest();
+    request.word = word;
+
+    return request;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/exception/WordExceptionHandler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/exception/WordExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.typingpractice.typing_practice_be.word.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "com.typingpractice.typing_practice_be.word")
+public class WordExceptionHandler {
+  private ProblemDetail createProblemDetail(ErrorCode errorCode) {
+    ProblemDetail pd =
+        ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());
+
+    pd.setTitle("Word Domain Error");
+
+    return pd;
+  }
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ProblemDetail handleDuplicateWordException(DataIntegrityViolationException e) {
+
+    String message = e.getMessage();
+
+    if (message != null && message.contains("uq_word")) {
+      return createProblemDetail(ErrorCode.WORD_DUPLICATE);
+    }
+
+    return createProblemDetail(ErrorCode.DATA_INTEGRITY_VIOLATION);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/exception/WordLanguageMismatchException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/exception/WordLanguageMismatchException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.word.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class WordLanguageMismatchException extends BusinessException {
+  public WordLanguageMismatchException() {
+    super(ErrorCode.WORD_LANGUAGE_MISMATCH);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/exception/WordNotFoundException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/exception/WordNotFoundException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.word.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class WordNotFoundException extends BusinessException {
+  public WordNotFoundException() {
+    super(ErrorCode.WORD_NOT_FOUND);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/repository/WordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/repository/WordRepository.java
@@ -1,0 +1,44 @@
+package com.typingpractice.typing_practice_be.word.repository;
+
+import com.typingpractice.typing_practice_be.word.domain.Word;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class WordRepository {
+  private final EntityManager em;
+
+  public void save(Word word) {
+    em.persist(word);
+  }
+
+  public Optional<Word> findById(Long id) {
+    return Optional.ofNullable(em.find(Word.class, id));
+  }
+
+  public List<Word> findByIds(List<Long> ids, WordLanguage language) {
+    if (ids.isEmpty()) return List.of();
+
+    return em.createQuery(
+            "select w from Word w where w.id in :ids and w.language = :language", Word.class)
+        .setParameter("ids", ids)
+        .setParameter("language", language)
+        .getResultList();
+  }
+
+  public List<Long> findAllIds(WordLanguage language) {
+    return em.createQuery("select w.id from Word w where w.language = :language", Long.class)
+        .setParameter("language", language)
+        .getResultList();
+  }
+
+  public void deleteWord(Word w) {
+    em.remove(w);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordLanguageValidator.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordLanguageValidator.java
@@ -1,0 +1,23 @@
+package com.typingpractice.typing_practice_be.word.service;
+
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.exception.WordLanguageMismatchException;
+import org.springframework.stereotype.Component;
+
+import java.util.regex.Pattern;
+
+@Component
+public class WordLanguageValidator {
+  private static final Pattern ENGLISH_LETTER = Pattern.compile("[A-Za-z]");
+  private static final Pattern KOREAN_LETTER = Pattern.compile("[가-힣ㄱ-ㅎㅏ-ㅣ]");
+
+  public void validate(String word, WordLanguage language) {
+    if (language == WordLanguage.KOREAN && ENGLISH_LETTER.matcher(word).find()) {
+      throw new WordLanguageMismatchException();
+    }
+
+    if (language == WordLanguage.ENGLISH && KOREAN_LETTER.matcher(word).find()) {
+      throw new WordLanguageMismatchException();
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordService.java
@@ -1,0 +1,57 @@
+package com.typingpractice.typing_practice_be.word.service;
+
+import com.typingpractice.typing_practice_be.word.domain.Word;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.exception.WordNotFoundException;
+import com.typingpractice.typing_practice_be.word.repository.WordRepository;
+import java.util.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class WordService {
+  private final WordRepository wordRepository;
+  private final WordLanguageValidator validator;
+
+  public List<Word> findRandomWords(WordLanguage language, int count) {
+    List<Long> allIds = wordRepository.findAllIds(language);
+
+    List<Long> shuffled = new ArrayList<>(allIds);
+    Collections.shuffle(shuffled);
+
+    List<Long> selectedIds = shuffled.subList(0, Math.min(count, shuffled.size()));
+
+    List<Word> fetched = wordRepository.findByIds(selectedIds, language);
+    Collections.shuffle(fetched);
+
+    return fetched;
+  }
+
+  @Transactional
+  public Word createWord(String word, WordLanguage language) {
+    validator.validate(word, language);
+
+    Word w = Word.create(word, language);
+    wordRepository.save(w);
+
+    return w;
+  }
+
+  @Transactional
+  public Word updateWord(Long id, String word) {
+    Word w = wordRepository.findById(id).orElseThrow(WordNotFoundException::new);
+    w.updateWord(word);
+
+    return w;
+  }
+
+  @Transactional
+  public void deleteWord(Long id) {
+    Word w = wordRepository.findById(id).orElseThrow(WordNotFoundException::new);
+
+    wordRepository.deleteWord(w);
+  }
+}


### PR DESCRIPTION
## 주요 내용
- Word 도메인 및 패키지 구조 신규 생성
- GET /words 랜덤 서빙 API 구현 (비회원 포함)
- 어드민 단어 관리 API 구현 (POST/PATCH/DELETE /admin/word)
- 단어 언어 검증 및 중복 예외 처리

## 세부 내용
### 도메인
- Word 엔티티 (soft delete, UNIQUE(word, language))
- WordLanguage enum (KOREAN, ENGLISH)
- WordProfile (Embeddable — length, difficultySeed, 한국어/영어 전용 필드)

### 서빙 API
- WordController: GET /words (language, count @Range(10~100), 기본값 25)
- WordRequest: 생성자 바인딩 패턴
- WordService: 전체 ID 조회 → 셔플 → 선택 → DB fetch

### 어드민 API
- AdminWordController: POST/PATCH/DELETE /admin/word (ADMIN 전용)
- WordCreateRequest: @Size(max = 20) 길이 제한
- WordLanguageValidator: 한국어 단어에 영문 혼입, 영어 단어에 한글 혼입 방지

### 예외 처리
- WordExceptionHandler: DataIntegrityViolationException → WORD_DUPLICATE 응답
- WordNotFoundException, WordLanguageMismatchException
- ErrorCode에 WORD_NOT_FOUND, WORD_LANGUAGE_MISMATCH, WORD_DUPLICATE 추가

### 기존 변경
- SecurityConfig: GET /words permitAll 추가
- TypingRecordService: language 변수 추출 리팩토링