### PR TITLE
feat: Word 난이도 산정 및 배치 시스템 구현

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminStatisticsController.java
@@ -8,6 +8,7 @@ import com.typingpractice.typing_practice_be.typingrecord.statistics.service.bat
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.batch.MemberTypingStatsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.batch.MemberTypoStatsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.batch.QuoteTypingStatsBatchService;
+import com.typingpractice.typing_practice_be.word.statistics.service.GlobalWordStatisticsBatchService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -22,6 +23,8 @@ public class AdminStatisticsController {
   private final MemberDailyStatsBatchService memberDailyStatsBatchService;
   private final MemberTypoStatsBatchService memberTypoStatsBatchService;
   private final DifficultyBatchService difficultyBatchService;
+
+  private final GlobalWordStatisticsBatchService globalWordStatisticsBatchService;
 
   @PostMapping("/global-quote/recalculate")
   public ApiResponse<Void> recalculate() {
@@ -63,6 +66,12 @@ public class AdminStatisticsController {
   @PostMapping("/member-typo/recalculate")
   public ApiResponse<Void> recalculateMemberTypoStats() {
     memberTypoStatsBatchService.runManualRecalculation();
+    return ApiResponse.ok(null);
+  }
+
+  @PostMapping("/global-word/recalculate")
+  public ApiResponse<Void> recalculateGlobalWordStats() {
+    globalWordStatisticsBatchService.runManualRecalculation();
     return ApiResponse.ok(null);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
@@ -7,6 +7,7 @@ import com.typingpractice.typing_practice_be.typingrecord.statistics.service.bat
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.batch.MemberTypingStatsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.batch.MemberTypoStatsBatchService;
 import com.typingpractice.typing_practice_be.typingrecord.statistics.service.batch.QuoteTypingStatsBatchService;
+import com.typingpractice.typing_practice_be.word.statistics.service.GlobalWordStatisticsBatchService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -23,6 +24,8 @@ public class StatisticsScheduler {
   private final MemberTypoStatsBatchService memberTypoStatsBatchService;
   private final DifficultyBatchService difficultyBatchService;
 
+  private final GlobalWordStatisticsBatchService globalWordStatisticsBatchService;
+
   @Scheduled(cron = "0 0 3 * * *", zone = TimeUtils.KST_ZONE)
   public void runDailyBatch() {
     log.info("전역 통계 배치 시작");
@@ -33,5 +36,12 @@ public class StatisticsScheduler {
     memberDailyStatsBatchService.runScheduledBatch(); // 개인 일간 통계
     memberTypoStatsBatchService.runScheduledBatch(); // 개인 오타 통계
     log.info("전역 통계 배치 완료");
+  }
+
+  @Scheduled(cron = "0 0 4 * * *", zone = TimeUtils.KST_ZONE)
+  public void runWordDailyBatch() {
+    log.info("단어 전역 통계 배치 시작");
+    globalWordStatisticsBatchService.runScheduledBatch();
+    log.info("단어 전역 통계 배치 완료");
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/domain/Word.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/domain/Word.java
@@ -45,6 +45,13 @@ public class Word extends BaseEntity {
     this.word = word;
   }
 
+  public void updateDifficultySeed(float seed) {
+    if (this.profile != null) {
+      this.profile.setDifficultySeed(seed);
+    }
+    this.difficulty = seed;
+  }
+
   public void updateDifficulty(Float difficulty) {
     this.difficulty = difficulty;
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/repository/WordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/repository/WordRepository.java
@@ -41,4 +41,22 @@ public class WordRepository {
   public void deleteWord(Word w) {
     em.remove(w);
   }
+
+  public Long findMaxIdByLanguage(WordLanguage language) {
+    return em.createQuery("select max(w.id) from Word w where w.language = :language", Long.class)
+        .setParameter("language", language)
+        .getSingleResult();
+  }
+
+  public List<Word> findPageByLanguageAndIdRange(
+      WordLanguage language, Long cursorId, Long maxId, int size) {
+    return em.createQuery(
+            "select w from Word w where w.language = :language and w.id > :cursorId and w.id <= :maxId order by w.id ASC",
+            Word.class)
+        .setParameter("language", language)
+        .setParameter("cursorId", cursorId)
+        .setParameter("maxId", maxId)
+        .setMaxResults(size)
+        .getResultList();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordService.java
@@ -2,9 +2,15 @@ package com.typingpractice.typing_practice_be.word.service;
 
 import com.typingpractice.typing_practice_be.word.domain.Word;
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.domain.WordProfile;
 import com.typingpractice.typing_practice_be.word.exception.WordNotFoundException;
 import com.typingpractice.typing_practice_be.word.repository.WordRepository;
 import java.util.*;
+
+import com.typingpractice.typing_practice_be.word.service.difficulty.WordDifficultySeedCalculator;
+import com.typingpractice.typing_practice_be.word.service.difficulty.WordProfileCalculator;
+import com.typingpractice.typing_practice_be.word.statistics.domain.GlobalWordStatistics;
+import com.typingpractice.typing_practice_be.word.statistics.service.GlobalWordStatisticsService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -15,6 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class WordService {
   private final WordRepository wordRepository;
   private final WordLanguageValidator validator;
+
+  private final WordProfileCalculator profileCalculator;
+  private final WordDifficultySeedCalculator seedCalculator;
+  private final GlobalWordStatisticsService globalWordStatisticsService;
 
   public List<Word> findRandomWords(WordLanguage language, int count) {
     List<Long> allIds = wordRepository.findAllIds(language);
@@ -35,8 +45,17 @@ public class WordService {
     validator.validate(word, language);
 
     Word w = Word.create(word, language);
-    wordRepository.save(w);
 
+    // 난이도 계산
+    WordProfile profile = profileCalculator.calculate(word, language);
+    GlobalWordStatistics stats = globalWordStatisticsService.findByLanguage(language);
+    float seed = seedCalculator.calculate(profile, stats, language);
+    profile.setDifficultySeed(seed);
+
+    w.updateProfile(profile);
+    w.updateDifficulty(seed);
+
+    wordRepository.save(w);
     return w;
   }
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/difficulty/WordDifficultySeedCalculator.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/difficulty/WordDifficultySeedCalculator.java
@@ -1,0 +1,50 @@
+package com.typingpractice.typing_practice_be.word.service.difficulty;
+
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.domain.WordProfile;
+import com.typingpractice.typing_practice_be.word.statistics.domain.GlobalWordStatistics;
+import org.springframework.stereotype.Component;
+
+@Component
+public class WordDifficultySeedCalculator {
+  // 한국어 가중치
+  private static final float W_LEN_KO = 0.30f;
+  private static final float W_JAMO = 0.30f;
+  private static final float W_DIPHTHONG = 0.20f;
+  private static final float W_SHIFT_JAMO = 0.20f;
+
+  // 영어 가중치
+  private static final float W_LEN_EN = 0.60f;
+  private static final float W_CASE = 0.40f;
+
+  public float calculate(WordProfile profile, GlobalWordStatistics stats, WordLanguage language) {
+    float sum = 0f;
+
+    if (language == WordLanguage.KOREAN) {
+      sum += W_LEN_KO * zScore(profile.getLength(), stats.getLenMean(), stats.getLenStd());
+      sum += W_JAMO * zScore(profile.getJamoComplex(), stats.getJamoMean(), stats.getJamoStd());
+      sum +=
+          W_DIPHTHONG
+              * zScore(
+                  profile.getDiphthongRate(), stats.getDiphthongMean(), stats.getDiphthongStd());
+      sum +=
+          W_SHIFT_JAMO
+              * zScore(
+                  profile.getShiftJamoRate(), stats.getShiftJamoMean(), stats.getShiftJamoStd());
+    } else {
+      sum += W_LEN_EN * zScore(profile.getLength(), stats.getLenMean(), stats.getLenStd());
+      sum += W_CASE * zScore(profile.getCaseFlipRate(), stats.getCaseMean(), stats.getCaseStd());
+    }
+
+    return Math.round(100 * sum);
+  }
+
+  private float zScore(float value, float mean, float std) {
+    if (std == 0f) return 0f;
+    return clip((value - mean) / std);
+  }
+
+  private float clip(float value) {
+    return Math.max(0f, Math.min(1f, (value + 2f) / 4f));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/difficulty/WordProfileCalculator.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/difficulty/WordProfileCalculator.java
@@ -1,0 +1,103 @@
+package com.typingpractice.typing_practice_be.word.service.difficulty;
+
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.domain.WordProfile;
+import org.springframework.stereotype.Component;
+
+import java.util.Set;
+
+@Component
+public class WordProfileCalculator {
+  private static final Set<Character> DIPHTHONGS = Set.of('ㅘ', 'ㅙ', 'ㅚ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅢ');
+  private static final Set<Character> SHIFT_INITIALS = Set.of('ㄲ', 'ㄸ', 'ㅃ', 'ㅆ', 'ㅉ');
+  private static final Set<Character> SHIFT_VOWELS = Set.of('ㅒ', 'ㅖ');
+  private static final Set<Character> SHIFT_FINALS = Set.of('ㄲ', 'ㄸ', 'ㅃ', 'ㅆ', 'ㅉ');
+  private static final Set<Character> DOUBLE_FINALS =
+      Set.of('ㄳ', 'ㄵ', 'ㄶ', 'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅄ');
+
+  private static final char[] INITIALS = {
+    'ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+  };
+  private static final char[] MEDIALS = {
+    'ㅏ', 'ㅐ', 'ㅑ', 'ㅒ', 'ㅓ', 'ㅔ', 'ㅕ', 'ㅖ', 'ㅗ', 'ㅘ', 'ㅙ', 'ㅚ', 'ㅛ', 'ㅜ', 'ㅝ', 'ㅞ', 'ㅟ', 'ㅠ', 'ㅡ',
+    'ㅢ', 'ㅣ'
+  };
+  private static final char[] FINALS = {
+    0, 'ㄱ', 'ㄲ', 'ㄳ', 'ㄴ', 'ㄵ', 'ㄶ', 'ㄷ', 'ㄹ', 'ㄺ', 'ㄻ', 'ㄼ', 'ㄽ', 'ㄾ', 'ㄿ', 'ㅀ', 'ㅁ', 'ㅂ', 'ㅄ',
+    'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'
+  };
+
+  public WordProfile calculate(String word, WordLanguage language) {
+    WordProfile profile = WordProfile.create();
+    profile.setLength(word.length());
+
+    if (language == WordLanguage.KOREAN) {
+      calculateKoreanFeatures(word, profile);
+    } else {
+      calculateEnglishFeatures(word, profile);
+    }
+
+    return profile;
+  }
+
+  private void calculateKoreanFeatures(String word, WordProfile profile) {
+    int koChars = 0;
+    float jamoComplexSum = 0;
+    int diphthongCount = 0;
+    int shiftJamoCount = 0;
+
+    for (char c : word.toCharArray()) {
+      if (c >= '가' && c <= '힣') {
+        koChars++;
+        int code = c - '가';
+        int initialIndex = code / (21 * 28);
+        int medialIndex = (code % (21 * 28)) / 28;
+        int finalIndex = code % 28;
+
+        char initial = INITIALS[initialIndex];
+        char medial = MEDIALS[medialIndex];
+        char finalChar = finalIndex > 0 ? FINALS[finalIndex] : 0;
+
+        if (finalIndex == 0) {
+          // 무받침
+        } else if (DOUBLE_FINALS.contains(finalChar)) {
+          jamoComplexSum += 1.5f;
+        } else {
+          jamoComplexSum += 1.0f;
+        }
+
+        if (DIPHTHONGS.contains(medial)) diphthongCount++;
+        if (SHIFT_INITIALS.contains(initial)
+            || SHIFT_VOWELS.contains(medial)
+            || SHIFT_FINALS.contains(finalChar)) {
+          shiftJamoCount++;
+        }
+      }
+    }
+
+    if (koChars > 0) {
+      profile.setJamoComplex((jamoComplexSum / koChars) / 1.5f);
+      profile.setDiphthongRate((float) diphthongCount / koChars);
+      profile.setShiftJamoRate((float) shiftJamoCount / koChars);
+    } else {
+      profile.setJamoComplex(0f);
+      profile.setDiphthongRate(0f);
+      profile.setShiftJamoRate(0f);
+    }
+  }
+
+  private void calculateEnglishFeatures(String word, WordProfile profile) {
+    int flipCount = 0;
+    char[] chars = word.toCharArray();
+
+    for (int i = 1; i < chars.length; i++) {
+      if (Character.isLetter(chars[i]) && Character.isLetter(chars[i - 1])) {
+        if (Character.isUpperCase(chars[i]) != Character.isUpperCase(chars[i - 1])) {
+          flipCount++;
+        }
+      }
+    }
+
+    profile.setCaseFlipRate(chars.length > 0 ? (float) flipCount / chars.length : 0f);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/domain/GlobalWordStatistics.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/domain/GlobalWordStatistics.java
@@ -1,0 +1,84 @@
+package com.typingpractice.typing_practice_be.word.statistics.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.statistics.dto.WordProfileAggregation;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GlobalWordStatistics extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "global_word_statistics_id")
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  private WordLanguage language;
+
+  // 공통
+  private float lenMean;
+  private float lenStd;
+
+  // 한국어 전용
+  private Float jamoMean;
+  private Float jamoStd;
+  private Float diphthongMean;
+  private Float diphthongStd;
+  private Float shiftJamoMean;
+  private Float shiftJamoStd;
+
+  // 영어 전용
+  private Float caseMean;
+  private Float caseStd;
+
+  public static GlobalWordStatistics createKoreanDefault() {
+    GlobalWordStatistics stats = new GlobalWordStatistics();
+    stats.language = WordLanguage.KOREAN;
+    stats.lenMean = 3f;
+    stats.lenStd = 1.5f;
+    stats.jamoMean = 0.5f;
+    stats.jamoStd = 0.2f;
+    stats.diphthongMean = 0.08f;
+    stats.diphthongStd = 0.05f;
+    stats.shiftJamoMean = 0.05f;
+    stats.shiftJamoStd = 0.03f;
+    return stats;
+  }
+
+  public static GlobalWordStatistics createEnglishDefault() {
+    GlobalWordStatistics stats = new GlobalWordStatistics();
+    stats.language = WordLanguage.ENGLISH;
+    stats.lenMean = 6f;
+    stats.lenStd = 2.5f;
+    stats.caseMean = 0.05f;
+    stats.caseStd = 0.03f;
+    return stats;
+  }
+
+  public static GlobalWordStatistics createFromAggregation(
+      WordLanguage language, WordProfileAggregation agg) {
+    GlobalWordStatistics stats = new GlobalWordStatistics();
+    stats.language = language;
+    stats.lenMean = agg.getLenMean();
+    stats.lenStd = agg.getLenStd();
+
+    if (language == WordLanguage.KOREAN) {
+      stats.jamoMean = agg.getJamoMean();
+      stats.jamoStd = agg.getJamoStd();
+      stats.diphthongMean = agg.getDiphthongMean();
+      stats.diphthongStd = agg.getDiphthongStd();
+      stats.shiftJamoMean = agg.getShiftJamoMean();
+      stats.shiftJamoStd = agg.getShiftJamoStd();
+    } else {
+      stats.caseMean = agg.getCaseMean();
+      stats.caseStd = agg.getCaseStd();
+    }
+
+    return stats;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/dto/WordProfileAggregation.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/dto/WordProfileAggregation.java
@@ -1,0 +1,48 @@
+package com.typingpractice.typing_practice_be.word.statistics.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class WordProfileAggregation {
+  private float lenMean;
+  private float lenStd;
+
+  // 한국어
+  private Float jamoMean;
+  private Float jamoStd;
+  private Float diphthongMean;
+  private Float diphthongStd;
+  private Float shiftJamoMean;
+  private Float shiftJamoStd;
+
+  // 영어
+  private Float caseMean;
+  private Float caseStd;
+
+  public static WordProfileAggregation from(Object[] row) {
+    WordProfileAggregation agg = new WordProfileAggregation();
+    agg.lenMean = toFloat(row[0]);
+    agg.lenStd = toFloat(row[1]);
+    agg.jamoMean = toFloatOrNull(row[2]);
+    agg.jamoStd = toFloatOrNull(row[3]);
+    agg.diphthongMean = toFloatOrNull(row[4]);
+    agg.diphthongStd = toFloatOrNull(row[5]);
+    agg.shiftJamoMean = toFloatOrNull(row[6]);
+    agg.shiftJamoStd = toFloatOrNull(row[7]);
+    agg.caseMean = toFloatOrNull(row[8]);
+    agg.caseStd = toFloatOrNull(row[9]);
+    return agg;
+  }
+
+  private static float toFloat(Object value) {
+    if (value == null) return 0f;
+    return ((Number) value).floatValue();
+  }
+
+  private static Float toFloatOrNull(Object value) {
+    if (value == null) return null;
+    return ((Number) value).floatValue();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/repository/GlobalWordStatisticsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/repository/GlobalWordStatisticsRepository.java
@@ -1,0 +1,45 @@
+package com.typingpractice.typing_practice_be.word.statistics.repository;
+
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.statistics.domain.GlobalWordStatistics;
+import com.typingpractice.typing_practice_be.word.statistics.dto.WordProfileAggregation;
+import jakarta.persistence.EntityManager;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class GlobalWordStatisticsRepository {
+  private final EntityManager em;
+
+  public void save(GlobalWordStatistics stats) {
+    em.persist(stats);
+  }
+
+  public Optional<GlobalWordStatistics> findByLanguage(WordLanguage language) {
+    return em.createQuery(
+            "select g from GlobalWordStatistics g where g.language = :language",
+            GlobalWordStatistics.class)
+        .setParameter("language", language)
+        .getResultStream()
+        .findFirst();
+  }
+
+  public WordProfileAggregation aggregateByLanguage(WordLanguage language) {
+    Object[] row =
+        (Object[])
+            em.createQuery(
+                    "select "
+                        + "avg(w.profile.length), cast(stddev(w.profile.length) as float), "
+                        + "avg(w.profile.jamoComplex), cast(stddev(w.profile.jamoComplex) as float), "
+                        + "avg(w.profile.diphthongRate), cast(stddev(w.profile.diphthongRate) as float), "
+                        + "avg(w.profile.shiftJamoRate), cast(stddev(w.profile.shiftJamoRate) as float), "
+                        + "avg(w.profile.caseFlipRate), cast(stddev(w.profile.caseFlipRate) as float) "
+                        + "from Word w where w.language = :language")
+                .setParameter("language", language)
+                .getSingleResult();
+
+    return WordProfileAggregation.from(row);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/service/GlobalWordStatisticsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/service/GlobalWordStatisticsBatchService.java
@@ -1,0 +1,85 @@
+package com.typingpractice.typing_practice_be.word.statistics.service;
+
+import com.typingpractice.typing_practice_be.word.domain.Word;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.domain.WordProfile;
+import com.typingpractice.typing_practice_be.word.repository.WordRepository;
+import com.typingpractice.typing_practice_be.word.service.difficulty.WordDifficultySeedCalculator;
+import com.typingpractice.typing_practice_be.word.service.difficulty.WordProfileCalculator;
+import com.typingpractice.typing_practice_be.word.statistics.domain.GlobalWordStatistics;
+import com.typingpractice.typing_practice_be.word.statistics.dto.WordProfileAggregation;
+import com.typingpractice.typing_practice_be.word.statistics.repository.GlobalWordStatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class GlobalWordStatisticsBatchService {
+  private final GlobalWordStatisticsRepository statsRepository;
+  private final WordRepository wordRepository;
+  private final WordDifficultySeedCalculator seedCalculator;
+  private final WordProfileCalculator profileCalculator;
+
+  private static final int PAGE_SIZE = 500;
+
+  @Transactional
+  public void runScheduledBatch() {
+    for (WordLanguage lang : WordLanguage.values()) {
+      GlobalWordStatistics next = recalculateStats(lang);
+
+      recalculateAllSeeds(lang, next);
+    }
+  }
+
+  @Transactional
+  public void runManualRecalculation() {
+    for (WordLanguage lang : WordLanguage.values()) {
+      GlobalWordStatistics next = recalculateStats(lang);
+      log.info("[Word:{}] 수동 트리거 -> seed 재계산 시작", lang);
+      recalculateAllSeeds(lang, next);
+    }
+  }
+
+  private GlobalWordStatistics recalculateStats(WordLanguage lang) {
+    WordProfileAggregation agg = statsRepository.aggregateByLanguage(lang);
+    GlobalWordStatistics next = GlobalWordStatistics.createFromAggregation(lang, agg);
+    statsRepository.save(next);
+    log.info("[Word:{}] 전역 통계 재계산 완료 - lenMean={}", lang, next.getLenMean());
+    return next;
+  }
+
+  private void recalculateAllSeeds(WordLanguage lang, GlobalWordStatistics stats) {
+    Long maxId = wordRepository.findMaxIdByLanguage(lang);
+    if (maxId == null) return;
+
+    Long cursor = 0L;
+    int totalUpdated = 0;
+
+    while (true) {
+      List<Word> words =
+          wordRepository.findPageByLanguageAndIdRange(lang, cursor, maxId, PAGE_SIZE);
+      if (words.isEmpty()) break;
+
+      for (Word word : words) {
+        if (word.getProfile() == null) {
+          WordProfile profile = profileCalculator.calculate(word.getWord(), word.getLanguage());
+          word.updateProfile(profile);
+        }
+
+        float seed = seedCalculator.calculate(word.getProfile(), stats, lang);
+        word.updateDifficultySeed(seed);
+      }
+
+      totalUpdated += words.size();
+      cursor = words.getLast().getId();
+    }
+
+    log.info("[Word:{}] seed 재계산 완료 - {}건 갱신", lang, totalUpdated);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/service/GlobalWordStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/service/GlobalWordStatisticsService.java
@@ -1,0 +1,29 @@
+package com.typingpractice.typing_practice_be.word.statistics.service;
+
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.statistics.domain.GlobalWordStatistics;
+import com.typingpractice.typing_practice_be.word.statistics.repository.GlobalWordStatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class GlobalWordStatisticsService {
+  private final GlobalWordStatisticsRepository repository;
+
+  @Transactional
+  public GlobalWordStatistics findByLanguage(WordLanguage language) {
+    return repository
+        .findByLanguage(language)
+        .orElseGet(
+            () -> {
+              GlobalWordStatistics stats =
+                  language == WordLanguage.KOREAN
+                      ? GlobalWordStatistics.createKoreanDefault()
+                      : GlobalWordStatistics.createEnglishDefault();
+              repository.save(stats);
+              return stats;
+            });
+  }
+}


### PR DESCRIPTION
## 주요 내용
- WordProfileCalculator: 단어 입력 변수 계산
- WordDifficultySeedCalculator: z점수 가중합 기반 난이도 산출
- GlobalWordStatistics: 전역 평균/표준편차 관리
- GlobalWordStatisticsBatchService: 전역 통계 재계산 + seed 재계산
- 04시 스케줄 배치 및 어드민 수동 트리거 등록

## 세부 내용
### 난이도 산정
- 한국어 가중치: length(0.3), jamoComplex(0.3), diphthongRate(0.2), shiftJamoRate(0.2)
- 영어 가중치: length(0.6), caseFlipRate(0.4)
- 단어 등록 시 즉시 프로필 계산 + seed 산출

### 배치
- 04시 스케줄 배치: 전역 통계 재계산 + 전체 seed 재계산 (매 실행)
- 어드민 수동 트리거: POST /admin/stats/global-word/recalculate
- 커서 기반 페이징으로 대량 단어 처리

### 신규 파일
- WordProfileCalculator, WordDifficultySeedCalculator
- GlobalWordStatistics, GlobalWordStatisticsRepository, GlobalWordStatisticsService
- GlobalWordStatisticsBatchService
- WordProfileAggregation DTO