### PR TITLE
feat: Word 캐싱 서빙 — Redis Sorted Set 기반 난이도별 서빙

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/controller/WordController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/controller/WordController.java
@@ -19,7 +19,8 @@ public class WordController {
   @GetMapping()
   public ApiResponse<List<WordResponse>> getRandomWords(
       @ModelAttribute @Valid WordRequest request) {
-    List<Word> words = wordService.findRandomWords(request.getLanguage(), request.getCount());
+    List<Word> words =
+        wordService.findWords(request.getLanguage(), request.getDifficulty(), request.getCount());
 
     List<WordResponse> response = words.stream().map(WordResponse::from).toList();
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/domain/WordDifficultyTier.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/domain/WordDifficultyTier.java
@@ -1,0 +1,8 @@
+package com.typingpractice.typing_practice_be.word.domain;
+
+public enum WordDifficultyTier {
+  RANDOM,
+  EASY,
+  NORMAL,
+  HARD
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/WordRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/WordRequest.java
@@ -1,5 +1,6 @@
 package com.typingpractice.typing_practice_be.word.dto;
 
+import com.typingpractice.typing_practice_be.word.domain.WordDifficultyTier;
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
 import lombok.Getter;
 import org.hibernate.validator.constraints.Range;
@@ -7,12 +8,14 @@ import org.hibernate.validator.constraints.Range;
 @Getter
 public class WordRequest {
   private final WordLanguage language;
+  private final WordDifficultyTier difficulty;
 
   @Range(min = 10, max = 100)
   private final int count;
 
-  public WordRequest(WordLanguage language, Integer count) {
+  public WordRequest(WordLanguage language, WordDifficultyTier difficulty, Integer count) {
     this.language = language;
+    this.difficulty = difficulty != null ? difficulty : WordDifficultyTier.RANDOM;
     this.count = count != null ? count : 25;
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/repository/WordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/repository/WordRepository.java
@@ -32,12 +32,6 @@ public class WordRepository {
         .getResultList();
   }
 
-  public List<Long> findAllIds(WordLanguage language) {
-    return em.createQuery("select w.id from Word w where w.language = :language", Long.class)
-        .setParameter("language", language)
-        .getResultList();
-  }
-
   public void deleteWord(Word w) {
     em.remove(w);
   }
@@ -57,6 +51,22 @@ public class WordRepository {
         .setParameter("cursorId", cursorId)
         .setParameter("maxId", maxId)
         .setMaxResults(size)
+        .getResultList();
+  }
+
+  public List<Object[]> findAllIdsWithDifficulty(WordLanguage language) {
+    return em.createQuery(
+            "select w.id, w.difficulty from Word w where w.language = :language order by w.difficulty asc",
+            Object[].class)
+        .setParameter("language", language)
+        .getResultList();
+  }
+
+  public List<Long> findAllIdsSortedByDifficulty(WordLanguage language) {
+    return em.createQuery(
+            "select w.id from Word w where w.language = :language order by w.difficulty asc",
+            Long.class)
+        .setParameter("language", language)
         .getResultList();
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/scheduler/WordCacheScheduler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/scheduler/WordCacheScheduler.java
@@ -1,0 +1,21 @@
+package com.typingpractice.typing_practice_be.word.scheduler;
+
+import com.typingpractice.typing_practice_be.word.service.WordIdCacheService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class WordCacheScheduler {
+  private final WordIdCacheService wordIdCacheService;
+
+  @EventListener(ApplicationReadyEvent.class)
+  public void initOnStartup() {
+    log.info("[WordCacheScheduler] 앱 시작 후 단어 ID 캐시 초기화");
+    wordIdCacheService.buildAllCaches();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordIdCacheService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordIdCacheService.java
@@ -1,0 +1,119 @@
+package com.typingpractice.typing_practice_be.word.service;
+
+import com.typingpractice.typing_practice_be.word.domain.WordDifficultyTier;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.repository.WordRepository;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WordIdCacheService {
+  private final StringRedisTemplate redisTemplate;
+  private final WordRepository wordRepository;
+
+  private static final String KEY_PREFIX = "word:";
+
+  private String key(WordLanguage language) {
+    return KEY_PREFIX + language.name();
+  }
+
+  public void buildCache(WordLanguage language) {
+    List<Object[]> rows = wordRepository.findAllIdsWithDifficulty(language);
+    if (rows.isEmpty()) return;
+
+    String k = key(language);
+    redisTemplate.delete(k);
+
+    Set<ZSetOperations.TypedTuple<String>> tuples = new HashSet<>();
+    for (Object[] row : rows) {
+      Long id = (Long) row[0];
+      float difficulty = row[1] != null ? ((Number) row[1]).floatValue() : 0f;
+      tuples.add(ZSetOperations.TypedTuple.of(String.valueOf(id), (double) difficulty));
+    }
+
+    redisTemplate.opsForZSet().add(k, tuples);
+    log.info("[WordIdCache] 캐시 빌드 - language={}, size={}", language, tuples.size());
+  }
+
+  public void buildAllCaches() {
+    for (WordLanguage language : WordLanguage.values()) {
+      buildCache(language);
+    }
+  }
+
+  public void add(WordLanguage language, Long wordId, float difficulty) {
+    redisTemplate.opsForZSet().add(key(language), String.valueOf(wordId), difficulty);
+  }
+
+  public void remove(WordLanguage language, Long wordId) {
+    redisTemplate.opsForZSet().remove(key(language), String.valueOf(wordId));
+  }
+
+  public List<Long> getIdsByTier(WordLanguage language, WordDifficultyTier tier) {
+    String k = key(language);
+
+    try {
+      Long totalSize = redisTemplate.opsForZSet().size(k);
+      if (totalSize == null || totalSize == 0) {
+        return fallback(language, tier);
+      }
+
+      Set<String> members;
+      if (tier == WordDifficultyTier.RANDOM) {
+        members = redisTemplate.opsForZSet().range(k, 0, -1);
+      } else {
+        long easyEnd = totalSize / 3;
+        long normalEnd = totalSize * 2 / 3;
+
+        members =
+            switch (tier) {
+              case EASY -> redisTemplate.opsForZSet().range(k, 0, easyEnd - 1);
+              case NORMAL -> redisTemplate.opsForZSet().range(k, easyEnd, normalEnd - 1);
+              case HARD -> redisTemplate.opsForZSet().range(k, normalEnd, -1);
+              default -> redisTemplate.opsForZSet().range(k, 0, -1);
+            };
+      }
+
+      if (members == null || members.isEmpty()) {
+        return fallback(language, tier);
+      }
+
+      return members.stream().map(Long::parseLong).toList();
+
+    } catch (Exception e) {
+      log.warn("[WordIdCache] Redis 조회 실패, DB fallback: {}", e.getMessage());
+      return fallback(language, tier);
+    }
+  }
+
+  private List<Long> fallback(WordLanguage language, WordDifficultyTier tier) {
+    try {
+      buildCache(language);
+    } catch (Exception e) {
+      log.warn("[WordIdCache] 캐시 복구 실패: {}", e.getMessage());
+    }
+
+    List<Long> allIds = wordRepository.findAllIdsSortedByDifficulty(language);
+
+    if (tier == WordDifficultyTier.RANDOM) return allIds;
+
+    int size = allIds.size();
+    int easyEnd = size / 3;
+    int normalEnd = size * 2 / 3;
+
+    return switch (tier) {
+      case EASY -> allIds.subList(0, easyEnd);
+      case NORMAL -> allIds.subList(easyEnd, normalEnd);
+      case HARD -> allIds.subList(normalEnd, size);
+      default -> allIds;
+    };
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordService.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.word.service;
 
 import com.typingpractice.typing_practice_be.word.domain.Word;
+import com.typingpractice.typing_practice_be.word.domain.WordDifficultyTier;
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
 import com.typingpractice.typing_practice_be.word.domain.WordProfile;
 import com.typingpractice.typing_practice_be.word.exception.WordNotFoundException;
@@ -19,6 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class WordService {
+  private final WordIdCacheService wordIdCacheService;
   private final WordRepository wordRepository;
   private final WordLanguageValidator validator;
 
@@ -26,10 +28,10 @@ public class WordService {
   private final WordDifficultySeedCalculator seedCalculator;
   private final GlobalWordStatisticsService globalWordStatisticsService;
 
-  public List<Word> findRandomWords(WordLanguage language, int count) {
-    List<Long> allIds = wordRepository.findAllIds(language);
+  public List<Word> findWords(WordLanguage language, WordDifficultyTier tier, int count) {
+    List<Long> ids = wordIdCacheService.getIdsByTier(language, tier);
 
-    List<Long> shuffled = new ArrayList<>(allIds);
+    List<Long> shuffled = new ArrayList<>(ids);
     Collections.shuffle(shuffled);
 
     List<Long> selectedIds = shuffled.subList(0, Math.min(count, shuffled.size()));
@@ -56,6 +58,7 @@ public class WordService {
     w.updateDifficulty(seed);
 
     wordRepository.save(w);
+    wordIdCacheService.add(language, w.getId(), seed);
     return w;
   }
 
@@ -70,6 +73,7 @@ public class WordService {
   @Transactional
   public void deleteWord(Long id) {
     Word w = wordRepository.findById(id).orElseThrow(WordNotFoundException::new);
+    wordIdCacheService.remove(w.getLanguage(), w.getId());
 
     wordRepository.deleteWord(w);
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/service/GlobalWordStatisticsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/service/GlobalWordStatisticsBatchService.java
@@ -4,6 +4,7 @@ import com.typingpractice.typing_practice_be.word.domain.Word;
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
 import com.typingpractice.typing_practice_be.word.domain.WordProfile;
 import com.typingpractice.typing_practice_be.word.repository.WordRepository;
+import com.typingpractice.typing_practice_be.word.service.WordIdCacheService;
 import com.typingpractice.typing_practice_be.word.service.difficulty.WordDifficultySeedCalculator;
 import com.typingpractice.typing_practice_be.word.service.difficulty.WordProfileCalculator;
 import com.typingpractice.typing_practice_be.word.statistics.domain.GlobalWordStatistics;
@@ -22,6 +23,8 @@ import java.util.List;
 @Transactional(readOnly = true)
 public class GlobalWordStatisticsBatchService {
   private final GlobalWordStatisticsRepository statsRepository;
+  private final WordIdCacheService wordIdCacheService;
+
   private final WordRepository wordRepository;
   private final WordDifficultySeedCalculator seedCalculator;
   private final WordProfileCalculator profileCalculator;
@@ -79,6 +82,8 @@ public class GlobalWordStatisticsBatchService {
       totalUpdated += words.size();
       cursor = words.getLast().getId();
     }
+
+    wordIdCacheService.buildCache(lang);
 
     log.info("[Word:{}] seed 재계산 완료 - {}건 갱신", lang, totalUpdated);
   }


### PR DESCRIPTION
## 주요 내용
- Redis Sorted Set으로 단어 ID 캐싱 (score = difficulty, 자동 정렬)
- 난이도별 서빙 지원 (RANDOM/EASY/NORMAL/HARD, difficulty 점수순 33% 구간)
- 앱 시작 시 캐시 빌드 + Redis 장애 시 DB fallback 및 자동 복구
- 단어 등록/삭제 시 캐시 즉시 반영, 배치 seed 재계산 후 캐시 리빌드

## 세부 내용
### WordIdCacheService (Redis Sorted Set)
- ZADD로 단어 등록, ZREM으로 삭제, ZRANGE로 구간별 조회
- getIdsByTier: 전체 크기 기준 33% 구간으로 EASY/NORMAL/HARD 분류
- Redis 조회 실패 또는 빈 결과 시 DB fallback + 캐시 복구 시도

### WordCacheScheduler
- 앱 시작 시 ApplicationReadyEvent로 전체 캐시 빌드

### API 변경
- GET /words에 difficulty 파라미터 추가 (기본값 RANDOM)
- WordRequest: difficulty(WordDifficultyTier), count, language
- WordDifficultyTier enum 신규 (RANDOM, EASY, NORMAL, HARD)

### 기존 변경
- WordService: findWords()로 변경, 캐시 기반 조회
- WordService: createWord()에 캐시 add, deleteWord()에 캐시 remove
- GlobalWordStatisticsBatchService: seed 재계산 후 캐시 리빌드