### PR TITLE
refactor: Word 캐싱 최적화 및 단어 검증 강화

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
   QUOTE_SIMILAR(HttpStatus.CONFLICT, "유사한 문장이 이미 존재합니다."),
 
   WORD_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 단어를 찾을 수 없습니다"),
+  WORD_INVALID_CHARACTER(HttpStatus.BAD_REQUEST, "단어에 숫자는 포함될 수 없습니다."),
   WORD_LANGUAGE_MISMATCH(HttpStatus.BAD_REQUEST, "선택한 언어와 맞지 않는 문자가 포함되어 있습니다."),
   WORD_DUPLICATE(HttpStatus.CONFLICT, "동일한 단어가 이미 존재합니다."),
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/exception/WordInvalidCharacterException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/exception/WordInvalidCharacterException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.word.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class WordInvalidCharacterException extends BusinessException {
+  public WordInvalidCharacterException() {
+    super(ErrorCode.WORD_INVALID_CHARACTER);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordIdCacheService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordIdCacheService.java
@@ -57,7 +57,7 @@ public class WordIdCacheService {
     redisTemplate.opsForZSet().remove(key(language), String.valueOf(wordId));
   }
 
-  public List<Long> getIdsByTier(WordLanguage language, WordDifficultyTier tier) {
+  public List<Long> getIdsByTier(WordLanguage language, WordDifficultyTier tier, int count) {
     String k = key(language);
 
     try {
@@ -66,21 +66,24 @@ public class WordIdCacheService {
         return fallback(language, tier);
       }
 
-      Set<String> members;
       if (tier == WordDifficultyTier.RANDOM) {
-        members = redisTemplate.opsForZSet().range(k, 0, -1);
-      } else {
-        long easyEnd = totalSize / 3;
-        long normalEnd = totalSize * 2 / 3;
-
-        members =
-            switch (tier) {
-              case EASY -> redisTemplate.opsForZSet().range(k, 0, easyEnd - 1);
-              case NORMAL -> redisTemplate.opsForZSet().range(k, easyEnd, normalEnd - 1);
-              case HARD -> redisTemplate.opsForZSet().range(k, normalEnd, -1);
-              default -> redisTemplate.opsForZSet().range(k, 0, -1);
-            };
+        Set<String> members = redisTemplate.opsForZSet().distinctRandomMembers(k, count);
+        if (members == null || members.isEmpty()) {
+          return fallback(language, tier);
+        }
+        return members.stream().map(Long::parseLong).toList();
       }
+
+      long easyEnd = totalSize / 3;
+      long normalEnd = totalSize * 2 / 3;
+
+      Set<String> members =
+          switch (tier) {
+            case EASY -> redisTemplate.opsForZSet().range(k, 0, easyEnd - 1);
+            case NORMAL -> redisTemplate.opsForZSet().range(k, easyEnd, normalEnd - 1);
+            case HARD -> redisTemplate.opsForZSet().range(k, normalEnd, -1);
+            default -> redisTemplate.opsForZSet().range(k, 0, -1);
+          };
 
       if (members == null || members.isEmpty()) {
         return fallback(language, tier);

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordLanguageValidator.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordLanguageValidator.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.word.service;
 
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.exception.WordInvalidCharacterException;
 import com.typingpractice.typing_practice_be.word.exception.WordLanguageMismatchException;
 import org.springframework.stereotype.Component;
 
@@ -8,10 +9,15 @@ import java.util.regex.Pattern;
 
 @Component
 public class WordLanguageValidator {
+  private static final Pattern DIGIT = Pattern.compile("[0-9]");
   private static final Pattern ENGLISH_LETTER = Pattern.compile("[A-Za-z]");
   private static final Pattern KOREAN_LETTER = Pattern.compile("[가-힣ㄱ-ㅎㅏ-ㅣ]");
 
   public void validate(String word, WordLanguage language) {
+    if (DIGIT.matcher(word).find()) {
+      throw new WordInvalidCharacterException();
+    }
+
     if (language == WordLanguage.KOREAN && ENGLISH_LETTER.matcher(word).find()) {
       throw new WordLanguageMismatchException();
     }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordService.java
@@ -29,14 +29,15 @@ public class WordService {
   private final GlobalWordStatisticsService globalWordStatisticsService;
 
   public List<Word> findWords(WordLanguage language, WordDifficultyTier tier, int count) {
-    List<Long> ids = wordIdCacheService.getIdsByTier(language, tier);
+    List<Long> ids = wordIdCacheService.getIdsByTier(language, tier, count);
 
-    List<Long> shuffled = new ArrayList<>(ids);
-    Collections.shuffle(shuffled);
+    if (tier != WordDifficultyTier.RANDOM) {
+      List<Long> shuffled = new ArrayList<>(ids);
+      Collections.shuffle(shuffled);
+      ids = shuffled.subList(0, Math.min(count, shuffled.size()));
+    }
 
-    List<Long> selectedIds = shuffled.subList(0, Math.min(count, shuffled.size()));
-
-    List<Word> fetched = wordRepository.findByIds(selectedIds, language);
+    List<Word> fetched = wordRepository.findByIds(ids, language);
     Collections.shuffle(fetched);
 
     return fetched;


### PR DESCRIPTION
## 변경사항

### RANDOM 모드 Redis 최적화
- RANDOM 모드에서 전체 ID를 가져온 뒤 Java에서 셔플하는 대신, Redis `ZRANDMEMBER`로 직접 N개 랜덤 조회
- `getIdsByTier`에 count 파라미터 추가
- EASY/NORMAL/HARD는 기존 ZRANGE 구간 조회 유지

### 단어 등록 검증 강화
- 단어에 숫자가 포함되면 등록 거부 (`WORD_INVALID_CHARACTER`)
- DIGIT 정규식 오류 수정 (`[0-9]]` → `[0-9]`)
- WordInvalidCharacterException 신규 생성

## 커밋 이력
- `4fa16a1` refactor: RANDOM 모드에서 Redis ZRANDMEMBER 사용으로 최적화
- `1835623` fix: 단어 등록 시 숫자 포함 검증 추가