### PR TITLE
feat: WordTypingRecord — 단어 모드 타이핑 기록 저장 API

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -65,6 +65,8 @@ public class SecurityConfig {
                     .permitAll()
                     .requestMatchers(HttpMethod.POST, "/typing-records")
                     .permitAll()
+                    .requestMatchers(HttpMethod.POST, "/word-typing-records")
+                    .permitAll()
                     .requestMatchers("/actuator/prometheus")
                     .permitAll()
                     // 관리자 전용

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/controller/WordTypingRecordController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/controller/WordTypingRecordController.java
@@ -1,0 +1,37 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.WordTypingRecordRequest;
+import com.typingpractice.typing_practice_be.wordtypingrecord.query.WordTypingRecordQuery;
+import com.typingpractice.typing_practice_be.wordtypingrecord.service.WordTypingRecordService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class WordTypingRecordController {
+  private final WordTypingRecordService wordTypingRecordService;
+
+  private Long getMemberIdOrNull() {
+    try {
+      return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    } catch (Exception e) {
+      return null;
+    }
+  }
+
+  @PostMapping("/word-typing-records")
+  public ApiResponse<Void> save(@RequestBody @Valid WordTypingRecordRequest request) {
+    Long memberId = getMemberIdOrNull();
+
+    WordTypingRecordQuery query = WordTypingRecordQuery.from(request);
+
+    wordTypingRecordService.save(memberId, query);
+
+    return ApiResponse.ok(null);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/domain/WordDetail.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/domain/WordDetail.java
@@ -1,0 +1,38 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WordDetail {
+  private int wordIndex;
+  private Long wordId;
+  private String word;
+  private String typed;
+  private boolean correct;
+  private long timeMs;
+  private List<WordTypo> typos;
+
+  public static WordDetail create(
+      int wordIndex,
+      Long wordId,
+      String word,
+      String typed,
+      boolean correct,
+      long timeMs,
+      List<WordTypo> typos) {
+    WordDetail detail = new WordDetail();
+    detail.wordIndex = wordIndex;
+    detail.wordId = wordId;
+    detail.word = word;
+    detail.typed = typed;
+    detail.correct = correct;
+    detail.timeMs = timeMs;
+    detail.typos = typos;
+    return detail;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/domain/WordTypingRecord.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/domain/WordTypingRecord.java
@@ -1,0 +1,80 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.typingpractice.typing_practice_be.word.domain.WordDifficultyTier;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Document(collection = "wordTypingRecord")
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WordTypingRecord {
+  private static final float WPM_UPPER_LIMIT = 300f;
+  private static final float ACCURACY_LOWER_LIMIT = 0.5f;
+
+  @Id private String id;
+
+  private Long memberId;
+  private String anonymousId;
+
+  private WordLanguage language;
+  private WordDifficultyTier difficulty;
+  private int wordCount;
+
+  private float wpm;
+  private float accuracy;
+  private int correctWordCount;
+  private int incorrectWordCount;
+  private long elapsedTimeMs;
+
+  private boolean outlier;
+  private LocalDateTime completedAt;
+
+  private List<Long> wordIds;
+  private List<WordDetail> wordDetails;
+
+  public static WordTypingRecord create(
+      Long memberId,
+      String anonymousId,
+      WordLanguage language,
+      WordDifficultyTier difficulty,
+      int wordCount,
+      float wpm,
+      float accuracy,
+      int correctWordCount,
+      int incorrectWordCount,
+      long elapsedTimeMs,
+      List<Long> wordIds,
+      List<WordDetail> wordDetails) {
+    WordTypingRecord record = new WordTypingRecord();
+    record.memberId = memberId;
+    record.anonymousId = anonymousId;
+    record.language = language;
+    record.difficulty = difficulty;
+    record.wordCount = wordCount;
+    record.wpm = wpm;
+    record.accuracy = accuracy;
+    record.correctWordCount = correctWordCount;
+    record.incorrectWordCount = incorrectWordCount;
+    record.elapsedTimeMs = elapsedTimeMs;
+    record.outlier = wpm > WPM_UPPER_LIMIT || accuracy < ACCURACY_LOWER_LIMIT;
+    record.completedAt = LocalDateTime.now();
+    record.wordIds = wordIds;
+    record.wordDetails = wordDetails;
+    return record;
+  }
+
+  @JsonIgnore
+  public boolean isLoggedIn() {
+    return memberId != null;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/domain/WordTypo.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/domain/WordTypo.java
@@ -1,0 +1,23 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class WordTypo {
+  private String expected;
+  private String actual;
+  private int position;
+  private WordTypoType type;
+
+  public static WordTypo create(String expected, String actual, int position, WordTypoType type) {
+    WordTypo typo = new WordTypo();
+    typo.expected = expected;
+    typo.actual = actual;
+    typo.position = position;
+    typo.type = type;
+    return typo;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/domain/WordTypoType.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/domain/WordTypoType.java
@@ -1,0 +1,8 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.domain;
+
+public enum WordTypoType {
+  INITIAL,
+  MEDIAL,
+  FINAL,
+  LETTER
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/WordDetailRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/WordDetailRequest.java
@@ -1,0 +1,31 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.dto;
+
+import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordDetail;
+import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordTypo;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class WordDetailRequest {
+  @NotNull private Integer wordIndex;
+  @NotNull private Long wordId;
+  @NotNull private String word;
+  private String typed;
+  private boolean correct;
+  private long timeMs;
+
+  @Valid private List<WordTypoRequest> typos;
+
+  public WordDetail toWordDetail() {
+    List<WordTypo> wordTypos =
+        (typos == null || typos.isEmpty())
+            ? List.of()
+            : typos.stream().map(WordTypoRequest::toWordTypo).toList();
+
+    return WordDetail.create(
+        wordIndex, wordId, word, typed != null ? typed : "", correct, timeMs, wordTypos);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/WordTypingRecordRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/WordTypingRecordRequest.java
@@ -1,0 +1,35 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.dto;
+
+import com.typingpractice.typing_practice_be.word.domain.WordDifficultyTier;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+public class WordTypingRecordRequest {
+  @NotNull private WordLanguage language;
+  @NotNull private WordDifficultyTier difficulty;
+  @NotNull @Positive private Integer wordCount;
+
+  private String anonymousId;
+
+  @NotNull @PositiveOrZero private Float wpm;
+
+  @NotNull
+  @DecimalMin("0.0")
+  @DecimalMax("1.0")
+  private Float accuracy;
+
+  @NotNull @PositiveOrZero private Integer correctWordCount;
+  @NotNull @PositiveOrZero private Integer incorrectWordCount;
+  @NotNull @PositiveOrZero private Long elapsedTimeMs;
+
+  private List<Long> wordIds;
+
+  @Valid private List<WordDetailRequest> wordDetails;
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/WordTypoRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/WordTypoRequest.java
@@ -1,0 +1,18 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.dto;
+
+import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordTypo;
+import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordTypoType;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class WordTypoRequest {
+  @NotNull private String expected;
+  @NotNull private String actual;
+  private int position;
+  @NotNull private WordTypoType type;
+
+  public WordTypo toWordTypo() {
+    return WordTypo.create(expected, actual, position, type);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/query/WordTypingRecordQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/query/WordTypingRecordQuery.java
@@ -1,0 +1,74 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.query;
+
+import com.typingpractice.typing_practice_be.word.domain.WordDifficultyTier;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordDetail;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.WordDetailRequest;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.WordTypingRecordRequest;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+public class WordTypingRecordQuery {
+  private final String anonymousId;
+  private final WordLanguage language;
+  private final WordDifficultyTier difficulty;
+  private final int wordCount;
+  private final float wpm;
+  private final float accuracy;
+  private final int correctWordCount;
+  private final int incorrectWordCount;
+  private final long elapsedTimeMs;
+  private final List<Long> wordIds;
+  private final List<WordDetail> wordDetails;
+
+  private WordTypingRecordQuery(
+      String anonymousId,
+      WordLanguage language,
+      WordDifficultyTier difficulty,
+      int wordCount,
+      float wpm,
+      float accuracy,
+      int correctWordCount,
+      int incorrectWordCount,
+      long elapsedTimeMs,
+      List<Long> wordIds,
+      List<WordDetail> wordDetails) {
+    this.anonymousId = anonymousId;
+    this.language = language;
+    this.difficulty = difficulty;
+    this.wordCount = wordCount;
+    this.wpm = wpm;
+    this.accuracy = accuracy;
+    this.correctWordCount = correctWordCount;
+    this.incorrectWordCount = incorrectWordCount;
+    this.elapsedTimeMs = elapsedTimeMs;
+    this.wordIds = wordIds;
+    this.wordDetails = wordDetails;
+  }
+
+  public static WordTypingRecordQuery from(WordTypingRecordRequest request) {
+    List<WordDetail> wordDetails =
+        (request.getWordDetails() == null || request.getWordDetails().isEmpty())
+            ? List.of()
+            : request.getWordDetails().stream().map(WordDetailRequest::toWordDetail).toList();
+
+    List<Long> wordIds = request.getWordIds() != null ? request.getWordIds() : List.of();
+
+    return new WordTypingRecordQuery(
+        request.getAnonymousId(),
+        request.getLanguage(),
+        request.getDifficulty(),
+        request.getWordCount(),
+        request.getWpm(),
+        request.getAccuracy(),
+        request.getCorrectWordCount(),
+        request.getIncorrectWordCount(),
+        request.getElapsedTimeMs(),
+        wordIds,
+        wordDetails);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/repository/WordTypingRecordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/repository/WordTypingRecordRepository.java
@@ -1,0 +1,16 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.repository;
+
+import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordTypingRecord;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class WordTypingRecordRepository {
+  private final MongoTemplate mongoTemplate;
+
+  public WordTypingRecord save(WordTypingRecord record) {
+    return mongoTemplate.save(record);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/service/WordTypingRecordFallbackService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/service/WordTypingRecordFallbackService.java
@@ -1,0 +1,100 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordTypingRecord;
+import com.typingpractice.typing_practice_be.wordtypingrecord.repository.WordTypingRecordRepository;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class WordTypingRecordFallbackService {
+  private final WordTypingRecordRepository repository;
+  private final ObjectMapper objectMapper;
+  private final Path fallbackFilePath;
+  private final AtomicBoolean flushing = new AtomicBoolean(false);
+
+  public WordTypingRecordFallbackService(
+      WordTypingRecordRepository repository,
+      @Value(
+              "${fallback.word-typing-record.path:/data/fallback/fallback-word-typing-records.jsonl}")
+          String path) {
+    this.repository = repository;
+    this.fallbackFilePath = Paths.get(path);
+    this.objectMapper = new ObjectMapper();
+    this.objectMapper.registerModule(new JavaTimeModule());
+  }
+
+  public void writeToFile(WordTypingRecord record) {
+    try {
+      Files.createDirectories(fallbackFilePath.getParent());
+      String json = objectMapper.writeValueAsString(record);
+      Files.writeString(
+          fallbackFilePath, json + "\n", StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+      if (record.getMemberId() != null) {
+        log.warn(
+            "[WordFallback] 로컬 파일에 저장: memberId={}, language={}",
+            record.getMemberId(),
+            record.getLanguage());
+      } else {
+        log.warn(
+            "[WordFallback] 로컬 파일에 저장: anonymousId={}, language={}",
+            record.getAnonymousId(),
+            record.getLanguage());
+      }
+    } catch (IOException e) {
+      log.error("[WordFallback] 파일 쓰기 실패 - 기록 유실: {}", record.toString());
+    }
+  }
+
+  public boolean hasBacklog() {
+    return Files.exists(fallbackFilePath);
+  }
+
+  public void flushIfNeeded() {
+    if (!hasBacklog()) return;
+    if (!flushing.compareAndSet(false, true)) return;
+
+    try {
+      List<String> lines = Files.readAllLines(fallbackFilePath);
+      List<String> failedLines = new ArrayList<>();
+      int successCount = 0;
+
+      for (String line : lines) {
+        if (line.isBlank()) continue;
+        try {
+          WordTypingRecord record = objectMapper.readValue(line, WordTypingRecord.class);
+          repository.save(record);
+          successCount++;
+        } catch (Exception e) {
+          log.error("[WordFallback] flush 중 레코드 저장 실패: {}", e.getMessage());
+          failedLines.add(line);
+        }
+      }
+
+      if (failedLines.isEmpty()) {
+        Files.deleteIfExists(fallbackFilePath);
+      } else {
+        Files.writeString(fallbackFilePath, String.join("\n", failedLines) + "\n");
+        log.warn("[WordFallback] {}건 flush 실패 - 파일에 유지", failedLines.size());
+      }
+
+      log.info("[WordFallback] flush 완료 - {}건 복구", successCount);
+
+    } catch (IOException e) {
+      log.error("[WordFallback] flush 실패: {}", e.getMessage());
+    } finally {
+      flushing.set(false);
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/service/WordTypingRecordService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/service/WordTypingRecordService.java
@@ -1,0 +1,48 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.service;
+
+import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordTypingRecord;
+import com.typingpractice.typing_practice_be.wordtypingrecord.query.WordTypingRecordQuery;
+import com.typingpractice.typing_practice_be.wordtypingrecord.repository.WordTypingRecordRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class WordTypingRecordService {
+  private final WordTypingRecordRepository repository;
+  private final WordTypingRecordFallbackService fallbackService;
+
+  public WordTypingRecord save(Long memberId, WordTypingRecordQuery query) {
+    WordTypingRecord record =
+        WordTypingRecord.create(
+            memberId,
+            query.getAnonymousId(),
+            query.getLanguage(),
+            query.getDifficulty(),
+            query.getWordCount(),
+            query.getWpm(),
+            query.getAccuracy(),
+            query.getCorrectWordCount(),
+            query.getIncorrectWordCount(),
+            query.getElapsedTimeMs(),
+            query.getWordIds(),
+            query.getWordDetails());
+
+    WordTypingRecord saved;
+    try {
+      saved = repository.save(record);
+    } catch (Exception e) {
+      log.warn("[WordTypingRecord] MongoDB 저장 실패 -> fallback: {}", e.getMessage());
+      fallbackService.writeToFile(record);
+      return record;
+    }
+
+    fallbackService.flushIfNeeded();
+
+    // TODO: Step 5, 6에서 이벤트 발행 추가
+
+    return saved;
+  }
+}


### PR DESCRIPTION
## 주요 내용
- POST /word-typing-records 엔드포인트 신규 (비회원 포함 permitAll)
- MongoDB `wordTypingRecord` 컬렉션에 세션 단위 기록 저장
- outlier 판정 기준: wpm > 300 또는 accuracy < 0.5
- MongoDB 저장 실패 시 JSONL 파일 fallback + 다음 요청 시 flush

## 세부 내용
### 도메인 (wordtypingrecord 독립 패키지)
- WordTypingRecord: 세션 단위 기록 (language, difficulty, wpm, accuracy, wordIds, wordDetails)
- WordDetail: 단어별 결과 (wordIndex, wordId, word, typed, correct, timeMs, typos)
- WordTypo, WordTypoType: 단어 전용 오타 (TypingRecord의 Typo와 독립)

### DTO 및 Query
- WordTypingRecordRequest, WordDetailRequest, WordTypoRequest (@Valid 중첩 검증)
- WordTypingRecordQuery: Request → Service 전달용 변환 객체

### Service
- WordTypingRecordService: 저장 + fallback 처리
- WordTypingRecordFallbackService: JSONL 파일 쓰기/읽기, flush 중복 실행 방지
- 이벤트 발행은 Step 5/6 작업 시 함께 추가 예정

### 기존 변경
- SecurityConfig: POST /word-typing-records permitAll 추가