### PR TITLE
feat: 회원 단어 모드 타이핑 통계 조회 API 추가 (누적 / 일별)

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberWordStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberWordStatisticsController.java
@@ -1,15 +1,15 @@
 package com.typingpractice.typing_practice_be.statistics.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.statistics.dto.MemberDailyWordStatsRequest;
 import com.typingpractice.typing_practice_be.statistics.service.MemberWordStatisticsService;
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
-import com.typingpractice.typing_practice_be.wordtypingrecord.dto.MemberWordTypingStatsResponse;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberDailyWordStatsResponse;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberWordTypingStatsResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/members/me/word-stats")
@@ -26,5 +26,15 @@ public class MemberWordStatisticsController {
       @RequestParam WordLanguage language) {
     Long memberId = getMemberId();
     return ApiResponse.ok(memberWordStatisticsService.getTypingStats(memberId, language));
+  }
+
+  @GetMapping("/daily")
+  public ApiResponse<MemberDailyWordStatsResponse> getDailyStats(
+      @ModelAttribute @Valid MemberDailyWordStatsRequest request) {
+    Long memberId = getMemberId();
+
+    return ApiResponse.ok(
+        memberWordStatisticsService.getDailyStats(
+            memberId, request.getLanguage(), request.getDays()));
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberWordStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberWordStatisticsController.java
@@ -1,0 +1,30 @@
+package com.typingpractice.typing_practice_be.statistics.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.statistics.service.MemberWordStatisticsService;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.MemberWordTypingStatsResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/members/me/word-stats")
+@RequiredArgsConstructor
+public class MemberWordStatisticsController {
+  private final MemberWordStatisticsService memberWordStatisticsService;
+
+  private Long getMemberId() {
+    return (Long) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+  }
+
+  @GetMapping("/typing")
+  public ApiResponse<MemberWordTypingStatsResponse> getTypingStats(
+      @RequestParam WordLanguage language) {
+    Long memberId = getMemberId();
+    return ApiResponse.ok(memberWordStatisticsService.getTypingStats(memberId, language));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/dto/MemberDailyWordStatsRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/dto/MemberDailyWordStatsRequest.java
@@ -1,0 +1,23 @@
+package com.typingpractice.typing_practice_be.statistics.dto;
+
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class MemberDailyWordStatsRequest {
+  @Min(value = 7, message = "days는 최소 7입니다.")
+  @Max(value = 90, message = "days는 최대 90입니다.")
+  private final int days;
+
+  @NotNull private final WordLanguage language;
+
+  public MemberDailyWordStatsRequest(Integer days, WordLanguage language) {
+    this.days = days != null ? days : 7;
+    this.language = language;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberWordStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberWordStatisticsService.java
@@ -1,0 +1,75 @@
+package com.typingpractice.typing_practice_be.statistics.service;
+
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.MemberWordTypingStatsResponse;
+import com.typingpractice.typing_practice_be.wordtypingrecord.repository.WordTypingRecordRepository;
+import com.typingpractice.typing_practice_be.wordtypingrecord.repository.aggregation.MemberWordTypingAggregationRepository;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberWordTypingStats;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.MemberWordTypingAggregation;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.TodayWordTypingSnapshot;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.repository.MemberDailyWordStatsRepository;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.repository.MemberWordTypingStatsRepository;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.service.TodayWordTypingStatsRedisService;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberWordStatisticsService {
+  // mongo
+  private final WordTypingRecordRepository wordTypingRecordRepository;
+  private final MemberWordTypingAggregationRepository memberWordTypingAggregationRepository;
+
+  // pg
+  private final MemberWordTypingStatsRepository memberWordTypingStatsRepository;
+  private final MemberDailyWordStatsRepository memberDailyWordStatsRepository;
+
+  // redis
+  private final TodayWordTypingStatsRedisService todayWordTypingStatsRedisService;
+
+  private boolean isYesterdayBatchPending(Long memberId, WordLanguage language) {
+    LocalDate yesterday = LocalDate.now(TimeUtils.KST).minusDays(1);
+
+    // DailyStats 가 있으면 배치 처리 완료
+    if (memberDailyWordStatsRepository
+        .findByMemberIdAndDateAndLanguage(memberId, yesterday, language)
+        .isPresent()) {
+      return false;
+    }
+
+    LocalDateTime from = TimeUtils.startOfDayKstToUtc(yesterday);
+    LocalDateTime to = TimeUtils.endOfDayKstToUtc(yesterday);
+    // 어제 타이핑 기록이 있으면 배치 미완료 없으면 대상 아님
+    return wordTypingRecordRepository.existsByMemberIdBetween(memberId, from, to);
+  }
+
+  public MemberWordTypingStatsResponse getTypingStats(Long memberId, WordLanguage language) {
+    MemberWordTypingStats pg =
+        memberWordTypingStatsRepository.findByMemberIdAndLanguage(memberId, language).orElse(null);
+
+    TodayWordTypingSnapshot today = todayWordTypingStatsRedisService.getTyping(memberId, language);
+
+    MemberWordTypingAggregation yesterday = null;
+    if (isYesterdayBatchPending(memberId, language)) {
+      LocalDate yesterdayDate = LocalDate.now(TimeUtils.KST).minusDays(1);
+      LocalDateTime from = TimeUtils.startOfDayKstToUtc(yesterdayDate);
+      LocalDateTime to = TimeUtils.endOfDayKstToUtc(yesterdayDate);
+
+      List<MemberWordTypingAggregation> agg =
+          memberWordTypingAggregationRepository.aggregateByMemberIdsAndLanguageBetween(
+              List.of(memberId), language, from, to);
+
+      if (!agg.isEmpty()) {
+        yesterday = agg.getFirst();
+      }
+    }
+
+    return MemberWordTypingStatsResponse.of(pg, yesterday, today);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberWordStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberWordStatisticsService.java
@@ -2,10 +2,14 @@ package com.typingpractice.typing_practice_be.statistics.service;
 
 import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
-import com.typingpractice.typing_practice_be.wordtypingrecord.dto.MemberWordTypingStatsResponse;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberDailyWordStatsResponse;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberWordTypingStatsResponse;
 import com.typingpractice.typing_practice_be.wordtypingrecord.repository.WordTypingRecordRepository;
+import com.typingpractice.typing_practice_be.wordtypingrecord.repository.aggregation.MemberDailyWordAggregationRepository;
 import com.typingpractice.typing_practice_be.wordtypingrecord.repository.aggregation.MemberWordTypingAggregationRepository;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberDailyWordStats;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberWordTypingStats;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.MemberDailyWordAggregation;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.MemberWordTypingAggregation;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.TodayWordTypingSnapshot;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.repository.MemberDailyWordStatsRepository;
@@ -25,6 +29,7 @@ public class MemberWordStatisticsService {
   // mongo
   private final WordTypingRecordRepository wordTypingRecordRepository;
   private final MemberWordTypingAggregationRepository memberWordTypingAggregationRepository;
+  private final MemberDailyWordAggregationRepository memberDailyWordAggregationRepository;
 
   // pg
   private final MemberWordTypingStatsRepository memberWordTypingStatsRepository;
@@ -71,5 +76,32 @@ public class MemberWordStatisticsService {
     }
 
     return MemberWordTypingStatsResponse.of(pg, yesterday, today);
+  }
+
+  public MemberDailyWordStatsResponse getDailyStats(
+      Long memberId, WordLanguage language, int days) {
+    LocalDate todayKst = LocalDate.now(TimeUtils.KST);
+
+    List<MemberDailyWordStats> pgList =
+        memberDailyWordStatsRepository.findRecentByMemberIdAndLanguage(memberId, language, days);
+
+    TodayWordTypingSnapshot today = todayWordTypingStatsRedisService.getTyping(memberId, language);
+
+    MemberDailyWordAggregation yesterdayAgg = null;
+    if (isYesterdayBatchPending(memberId, language)) {
+      LocalDate yesterday = todayKst.minusDays(1);
+      LocalDateTime yesterdayFrom = TimeUtils.startOfDayKstToUtc(yesterday);
+      LocalDateTime yesterdayTo = TimeUtils.endOfDayKstToUtc(yesterday);
+
+      List<MemberDailyWordAggregation> agg =
+          memberDailyWordAggregationRepository.aggregateByMemberIdsAndLanguageBetween(
+              List.of(memberId), language, yesterdayFrom, yesterdayTo);
+
+      if (!agg.isEmpty()) {
+        yesterdayAgg = agg.getFirst();
+      }
+    }
+
+    return MemberDailyWordStatsResponse.of(days, pgList, yesterdayAgg, today, todayKst);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/controller/WordTypingRecordController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/controller/WordTypingRecordController.java
@@ -1,7 +1,7 @@
 package com.typingpractice.typing_practice_be.wordtypingrecord.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
-import com.typingpractice.typing_practice_be.wordtypingrecord.dto.WordTypingRecordRequest;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.request.WordTypingRecordRequest;
 import com.typingpractice.typing_practice_be.wordtypingrecord.query.WordTypingRecordQuery;
 import com.typingpractice.typing_practice_be.wordtypingrecord.service.WordTypingRecordService;
 import jakarta.validation.Valid;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/MemberWordTypingStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/MemberWordTypingStatsResponse.java
@@ -1,0 +1,88 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.dto;
+
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberWordTypingStats;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.MemberWordTypingAggregation;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.TodayWordTypingSnapshot;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class MemberWordTypingStatsResponse {
+  private int totalAttempts;
+  private int totalWordsAttempted;
+  private float avgWpm;
+  private float avgAcc;
+  private float bestWpm;
+  private float totalPracticeTimeMin;
+
+  public static MemberWordTypingStatsResponse create(
+      int totalAttempts,
+      int totalWordsAttempted,
+      float avgWpm,
+      float avgAcc,
+      float bestWpm,
+      float totalPracticeTimeMin) {
+    MemberWordTypingStatsResponse response = new MemberWordTypingStatsResponse();
+    response.totalAttempts = totalAttempts;
+    response.totalWordsAttempted = totalWordsAttempted;
+    response.avgWpm = avgWpm;
+    response.avgAcc = avgAcc;
+    response.bestWpm = bestWpm;
+    response.totalPracticeTimeMin = totalPracticeTimeMin;
+    return response;
+  }
+
+  public static MemberWordTypingStatsResponse empty() {
+    return new MemberWordTypingStatsResponse();
+  }
+
+  public static MemberWordTypingStatsResponse of(
+      MemberWordTypingStats pg,
+      MemberWordTypingAggregation yesterday,
+      TodayWordTypingSnapshot today) {
+    int totalAttempts = 0;
+    int totalWordsAttempted = 0;
+    float sumWpm = 0f;
+    float sumAcc = 0f;
+    float bestWpm = 0f;
+    float totalPracticeTimeMin = 0f;
+
+    if (pg != null) {
+      totalAttempts += pg.getTotalAttempts();
+      totalWordsAttempted += pg.getTotalWordsAttempted();
+      sumWpm += pg.getAvgWpm() * pg.getTotalAttempts();
+      sumAcc += pg.getAvgAcc() * pg.getTotalAttempts();
+      bestWpm = pg.getBestWpm();
+      totalPracticeTimeMin += pg.getTotalPracticeTimeMin();
+    }
+
+    if (yesterday != null) {
+      totalAttempts += yesterday.getTotalAttempts();
+      totalWordsAttempted += yesterday.getTotalWordsAttempted();
+      sumWpm += yesterday.getAvgWpm() * yesterday.getTotalAttempts();
+      sumAcc += yesterday.getAvgAcc() * yesterday.getTotalAttempts();
+      bestWpm = Math.max(bestWpm, yesterday.getBestWpm());
+      totalPracticeTimeMin += yesterday.getTotalPracticeTimeMin();
+    }
+
+    if (today.getTotalAttempts() > 0) {
+      totalAttempts += today.getTotalAttempts();
+      totalWordsAttempted += today.getTotalWordsAttempted();
+      sumWpm += today.getAvgWpm() * today.getTotalAttempts();
+      sumAcc += today.getAvgAcc() * today.getTotalAttempts();
+      bestWpm = Math.max(bestWpm, today.getBestWpm());
+      totalPracticeTimeMin += today.getTotalPracticeTimeMin();
+    }
+
+    if (totalAttempts == 0) return empty();
+
+    return create(
+        totalAttempts,
+        totalWordsAttempted,
+        sumWpm / totalAttempts,
+        sumAcc / totalAttempts,
+        bestWpm,
+        totalPracticeTimeMin);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/request/WordDetailRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/request/WordDetailRequest.java
@@ -1,4 +1,4 @@
-package com.typingpractice.typing_practice_be.wordtypingrecord.dto;
+package com.typingpractice.typing_practice_be.wordtypingrecord.dto.request;
 
 import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordDetail;
 import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordTypo;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/request/WordTypingRecordRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/request/WordTypingRecordRequest.java
@@ -1,4 +1,4 @@
-package com.typingpractice.typing_practice_be.wordtypingrecord.dto;
+package com.typingpractice.typing_practice_be.wordtypingrecord.dto.request;
 
 import com.typingpractice.typing_practice_be.word.domain.WordDifficultyTier;
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/request/WordTypoRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/request/WordTypoRequest.java
@@ -1,4 +1,4 @@
-package com.typingpractice.typing_practice_be.wordtypingrecord.dto;
+package com.typingpractice.typing_practice_be.wordtypingrecord.dto.request;
 
 import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordTypo;
 import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordTypoType;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/response/MemberDailyWordStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/response/MemberDailyWordStatsResponse.java
@@ -1,0 +1,106 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.dto.response;
+
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberDailyWordStats;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.MemberDailyWordAggregation;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.TodayWordTypingSnapshot;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberDailyWordStatsResponse {
+  private int days;
+  private List<DayEntry> content;
+
+  public static MemberDailyWordStatsResponse create(int days, List<DayEntry> content) {
+    MemberDailyWordStatsResponse response = new MemberDailyWordStatsResponse();
+    response.days = days;
+    response.content = content;
+    return response;
+  }
+
+  public static MemberDailyWordStatsResponse of(
+      int days,
+      List<MemberDailyWordStats> pgList,
+      MemberDailyWordAggregation yesterday,
+      TodayWordTypingSnapshot today,
+      LocalDate todayDate) {
+    List<DayEntry> content = new ArrayList<>();
+
+    for (MemberDailyWordStats stats : pgList) {
+      content.add(DayEntry.from(stats));
+    }
+
+    if (yesterday != null) {
+      content.add(DayEntry.from(yesterday));
+    }
+
+    if (today.getTotalAttempts() > 0) {
+      content.add(DayEntry.fromToday(today, todayDate));
+    }
+
+    if (content.size() > days) {
+      content = content.subList(content.size() - days, content.size());
+    }
+
+    return create(days, content);
+  }
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class DayEntry {
+    private LocalDate date;
+    private int attempts;
+    private int wordsAttempted;
+    private float avgWpm;
+    private float avgAcc;
+    private float bestWpm;
+    private float practiceTimeMin;
+
+    /** from mongo */
+    public static DayEntry from(MemberDailyWordAggregation agg) {
+      DayEntry entry = new DayEntry();
+      entry.date = agg.getDateAsLocalDate();
+      entry.attempts = agg.getAttempts();
+      entry.wordsAttempted = agg.getWordsAttempted();
+      entry.avgWpm = agg.getAvgWpm();
+      entry.avgAcc = agg.getAvgAcc();
+      entry.bestWpm = agg.getBestWpm();
+      entry.practiceTimeMin = agg.getPracticeTimeMin();
+      return entry;
+    }
+
+    /** from Postgres */
+    public static DayEntry from(MemberDailyWordStats stats) {
+      DayEntry entry = new DayEntry();
+      entry.date = stats.getDate();
+      entry.attempts = stats.getAttempts();
+      entry.wordsAttempted = stats.getWordsAttempted();
+      entry.avgWpm = stats.getAvgWpm();
+      entry.avgAcc = stats.getAvgAcc();
+      entry.bestWpm = stats.getBestWpm();
+      entry.practiceTimeMin = stats.getPracticeTimeMin();
+      return entry;
+    }
+
+    /** from redis */
+    public static DayEntry fromToday(TodayWordTypingSnapshot today, LocalDate date) {
+      DayEntry entry = new DayEntry();
+      entry.date = date;
+      entry.attempts = today.getTotalAttempts();
+      entry.wordsAttempted = today.getTotalWordsAttempted();
+      entry.avgWpm = today.getAvgWpm();
+      entry.avgAcc = today.getAvgAcc();
+      entry.bestWpm = today.getBestWpm();
+      entry.practiceTimeMin = today.getTotalPracticeTimeMin();
+      return entry;
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/response/MemberWordTypingStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/response/MemberWordTypingStatsResponse.java
@@ -1,4 +1,4 @@
-package com.typingpractice.typing_practice_be.wordtypingrecord.dto;
+package com.typingpractice.typing_practice_be.wordtypingrecord.dto.response;
 
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberWordTypingStats;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.MemberWordTypingAggregation;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/query/WordTypingRecordQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/query/WordTypingRecordQuery.java
@@ -3,8 +3,8 @@ package com.typingpractice.typing_practice_be.wordtypingrecord.query;
 import com.typingpractice.typing_practice_be.word.domain.WordDifficultyTier;
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
 import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordDetail;
-import com.typingpractice.typing_practice_be.wordtypingrecord.dto.WordDetailRequest;
-import com.typingpractice.typing_practice_be.wordtypingrecord.dto.WordTypingRecordRequest;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.request.WordDetailRequest;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.request.WordTypingRecordRequest;
 import lombok.Getter;
 import lombok.ToString;
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/repository/WordTypingRecordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/repository/WordTypingRecordRepository.java
@@ -1,15 +1,15 @@
 package com.typingpractice.typing_practice_be.wordtypingrecord.repository;
 
 import com.typingpractice.typing_practice_be.wordtypingrecord.domain.WordTypingRecord;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.bson.Document;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -49,5 +49,14 @@ public class WordTypingRecordRepository {
         .stream()
         .map(doc -> ((Number) doc.get("memberId")).longValue())
         .toList();
+  }
+
+  public boolean existsByMemberIdBetween(Long memberId, LocalDateTime from, LocalDateTime to) {
+    long count =
+        mongoTemplate.count(
+            Query.query(
+                Criteria.where("memberId").is(memberId).and("completedAt").gte(from).lt(to)),
+            "wordTypingRecord");
+    return count > 0;
   }
 }


### PR DESCRIPTION
## 주요 내용
- 회원 단어 모드 누적/일별 타이핑 통계 조회 엔드포인트 추가
- PostgreSQL 확정값 + MongoDB 어제 집계 + Redis 오늘 스냅샷의 3-way 병합으로 응답 구성
- 04시 배치 전후 공백 구간에서도 누락 없는 통계 반환
- wordtypingrecord DTO 구조를 request/response 하위로 정리

## 세부 내용
### 엔드포인트 (신규)
- GET /members/me/word-stats/typing?language=KOREAN
  - 누적 통계 반환 (MemberWordTypingStatsResponse)
- GET /members/me/word-stats/daily?language=KOREAN&days=7
  - 일별 통계 반환 (MemberDailyWordStatsResponse)
  - days 범위 7~90, 기본값 7
- 인증 회원만 접근 가능

### 3-way 병합 로직
- pg: PostgreSQL의 MemberWordTypingStats / MemberDailyWordStats
- today: Redis Today 스냅샷 (미스 시 MongoDB fallback)
- yesterday: isYesterdayBatchPending일 때만 MongoDB 집계
  - MemberDailyWordStats에 어제 데이터가 없고 MongoDB에 어제 기록이 존재하면 배치 미완료로 판정
- 3소스의 totalAttempts 가중평균으로 avgWpm / avgAcc 계산, bestWpm은 max
- 일별 응답은 리스트 크기가 days 초과 시 뒤에서부터 잘라 반환

### 서비스
- MemberWordStatisticsService 신설
  - getTypingStats: 누적 통계 3-way 병합
  - getDailyStats: 일별 통계 3-way 병합 (오늘 날짜 기준)
  - isYesterdayBatchPending: 어제 배치 완료 여부 판정

### 요청/응답 DTO
- MemberDailyWordStatsRequest: days (Min 7, Max 90), language (NotNull)
- MemberWordTypingStatsResponse: totalAttempts, totalWordsAttempted, avgWpm, avgAcc, bestWpm, totalPracticeTimeMin
- MemberDailyWordStatsResponse: days + DayEntry 리스트 (date, attempts, wordsAttempted, avgWpm, avgAcc, bestWpm, practiceTimeMin)
  - from(MemberDailyWordAggregation) / from(MemberDailyWordStats) / fromToday(TodayWordTypingSnapshot)

### Repository 확장
- WordTypingRecordRepository.existsByMemberIdBetween: MongoDB count로 어제 기록 존재 여부 판정 (배치 미완료 감지용)

### 리팩토링
- wordtypingrecord/dto/ 경로 정리
  - request/: WordDetailRequest, WordTypingRecordRequest, WordTypoRequest
  - response/: MemberWordTypingStatsResponse, MemberDailyWordStatsResponse
- 관련 파일 import 경로 갱신 (WordTypingRecordController, WordTypingRecordQuery)