### PR TITLE
feat: 회원 단어 통계 refresh 엔드포인트 추가 + Quote refresh 쿨다운 정리

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberWordStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberWordStatisticsController.java
@@ -37,4 +37,11 @@ public class MemberWordStatisticsController {
         memberWordStatisticsService.getDailyStats(
             memberId, request.getLanguage(), request.getDays()));
   }
+
+  @PostMapping("/refresh")
+  public ApiResponse<MemberWordTypingStatsResponse> refreshStats(
+      @RequestParam WordLanguage language) {
+    Long memberId = getMemberId();
+    return ApiResponse.ok(memberWordStatisticsService.refreshStats(memberId, language));
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberQuoteStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberQuoteStatisticsService.java
@@ -48,7 +48,7 @@ public class MemberQuoteStatisticsService {
   private final TodayTypingStatsRedisService todayTypingStatsRedisService;
   private final StringRedisTemplate redisTemplate;
 
-  private static final String COOLDOWN_KEY_PREFIX = "cooldown:refresh:";
+  private static final String COOLDOWN_KEY_PREFIX = "cooldown:quote-refresh:";
   private static final Duration COOLDOWN_DURATION = Duration.ofMinutes(1);
 
   private boolean isYesterdayBatchPending(Long memberId, QuoteLanguage language) {
@@ -193,7 +193,7 @@ public class MemberQuoteStatisticsService {
 
   private void checkCooldown(Long memberId) {
     String key = COOLDOWN_KEY_PREFIX + memberId;
-    if (redisTemplate.hasKey(key)) {
+    if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
       throw new RefreshCooldownException();
     }
   }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberWordStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberWordStatisticsService.java
@@ -1,6 +1,7 @@
 package com.typingpractice.typing_practice_be.statistics.service;
 
 import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.statistics.exception.RefreshCooldownException;
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
 import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberDailyWordStatsResponse;
 import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberWordTypingStatsResponse;
@@ -15,10 +16,13 @@ import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.Tod
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.repository.MemberDailyWordStatsRepository;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.repository.MemberWordTypingStatsRepository;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.service.TodayWordTypingStatsRedisService;
+
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,6 +41,11 @@ public class MemberWordStatisticsService {
 
   // redis
   private final TodayWordTypingStatsRedisService todayWordTypingStatsRedisService;
+
+  // refresh
+  private final StringRedisTemplate redisTemplate;
+  private static final String COOLDOWN_KEY_PREFIX = "cooldown:word-refresh:";
+  private static final Duration COOLDOWN_DURATION = Duration.ofMinutes(1);
 
   private boolean isYesterdayBatchPending(Long memberId, WordLanguage language) {
     LocalDate yesterday = LocalDate.now(TimeUtils.KST).minusDays(1);
@@ -103,5 +112,27 @@ public class MemberWordStatisticsService {
     }
 
     return MemberDailyWordStatsResponse.of(days, pgList, yesterdayAgg, today, todayKst);
+  }
+
+  public MemberWordTypingStatsResponse refreshStats(Long memberId, WordLanguage language) {
+    checkCooldown(memberId);
+
+    todayWordTypingStatsRedisService.invalidateAll(memberId);
+
+    setCooldown(memberId);
+
+    return getTypingStats(memberId, language);
+  }
+
+  private void checkCooldown(Long memberId) {
+    String key = COOLDOWN_KEY_PREFIX + memberId;
+    if (Boolean.TRUE.equals(redisTemplate.hasKey(key))) {
+      throw new RefreshCooldownException();
+    }
+  }
+
+  private void setCooldown(Long memberId) {
+    String key = COOLDOWN_KEY_PREFIX + memberId;
+    redisTemplate.opsForValue().set(key, "1", COOLDOWN_DURATION);
   }
 }


### PR DESCRIPTION
## 주요 내용
- 단어 모드 회원 통계 강제 갱신 엔드포인트 추가
- Redis Today 캐시 무효화 후 재조회하여 최신 상태 응답
- 1분 쿨다운으로 MongoDB fallback 과다 호출 방지
- Quote/Word 쿨다운 키 네이밍 대칭화 및 hasKey NPE 방어

## 세부 내용
### 엔드포인트 (신규)
- POST /members/me/word-stats/refresh?language=KOREAN
- 인증 회원만 접근 가능
- MemberWordTypingStatsResponse 반환 (누적 통계)

### Word refresh 서비스
- MemberWordStatisticsService.refreshStats
  - 쿨다운 체크 → invalidateAll(memberId) → 쿨다운 설정 → getTypingStats 반환
  - 쿨다운 미해제 상태면 RefreshCooldownException 발생
- 쿨다운 키: cooldown:word-refresh:{memberId}, TTL 1분
- StringRedisTemplate.hasKey 체크에 Boolean.TRUE.equals(...) 적용

### Quote/Word 쿨다운 키 분리 이유
- 쿨다운의 본질적 목적은 refresh 시 MongoDB fallback 스캔의 과다 호출 방지
- Quote와 Word는 각자 독립된 MongoDB 컬렉션(typingRecord / wordTypingRecord)을 스캔하므로 쿨다운도 분리가 합리적
- 사용자 UX 측면에서도 Quote refresh 직후 Word refresh 차단은 어색

### Quote refresh 개선
- COOLDOWN_KEY_PREFIX: cooldown:refresh: → cooldown:quote-refresh:
  - Word의 cooldown:word-refresh:와 네이밍 대칭
  - Redis 키 디버깅 시 소속 명확
- checkCooldown의 hasKey 체크를 Boolean.TRUE.equals(...)로 변경
  - 파이프라인/트랜잭션 모드에서 null 반환 시 NPE 방어
  - null은 "쿨다운 상태 불명" → 통과로 처리 (안전한 기본값)

### 마이그레이션
- 기존 cooldown:refresh:* 키는 TTL 1분 이내 자동 만료되므로 별도 작업 불필요