### PR TITLE
feat: 회원 단어 오타 통계 도메인 및 집계 인프라 추가

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/repository/aggregation/MemberWordTypoAggregationRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/repository/aggregation/MemberWordTypoAggregationRepository.java
@@ -1,0 +1,89 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.repository.aggregation;
+
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.MemberWordTypoAggregation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.aggregation.Aggregation;
+import org.springframework.data.mongodb.core.aggregation.ConditionalOperators;
+import org.springframework.data.mongodb.core.aggregation.Fields;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberWordTypoAggregationRepository {
+  private final MongoTemplate mongoTemplate;
+
+  public List<MemberWordTypoAggregation> aggregateByMemberIdsBetween(
+      List<Long> memberIds, LocalDateTime from, LocalDateTime to) {
+    Aggregation aggregation =
+        buildAggregation(
+            Criteria.where("memberId")
+                .in(memberIds)
+                .and("completedAt")
+                .gte(from)
+                .lt(to)
+                .and("outlier")
+                .is(false));
+
+    return mongoTemplate
+        .aggregate(aggregation, "wordTypingRecord", MemberWordTypoAggregation.class)
+        .getMappedResults();
+  }
+
+  public List<MemberWordTypoAggregation> aggregateByMemberIds(List<Long> memberIds) {
+    Aggregation aggregation =
+        buildAggregation(Criteria.where("memberId").in(memberIds).and("outlier").is(false));
+
+    return mongoTemplate
+        .aggregate(aggregation, "wordTypingRecord", MemberWordTypoAggregation.class)
+        .getMappedResults();
+  }
+
+  private Aggregation buildAggregation(Criteria matchCriteria) {
+    return Aggregation.newAggregation(
+        Aggregation.match(matchCriteria),
+        Aggregation.unwind("wordDetails"),
+        Aggregation.unwind("wordDetails.typos"),
+        Aggregation.group(
+                Fields.fields("memberId")
+                    .and("language")
+                    .and("expected", "wordDetails.typos.expected")
+                    .and("actual", "wordDetails.typos.actual"))
+            .count()
+            .as("count")
+            .sum(
+                ConditionalOperators.when(Criteria.where("wordDetails.typos.type").is("INITIAL"))
+                    .then(1)
+                    .otherwise(0))
+            .as("initialCount")
+            .sum(
+                ConditionalOperators.when(Criteria.where("wordDetails.typos.type").is("MEDIAL"))
+                    .then(1)
+                    .otherwise(0))
+            .as("medialCount")
+            .sum(
+                ConditionalOperators.when(Criteria.where("wordDetails.typos.type").is("FINAL"))
+                    .then(1)
+                    .otherwise(0))
+            .as("finalCount")
+            .sum(
+                ConditionalOperators.when(Criteria.where("wordDetails.typos.type").is("LETTER"))
+                    .then(1)
+                    .otherwise(0))
+            .as("letterCount"),
+        Aggregation.project()
+            .and("_id.memberId")
+            .as("memberId")
+            .and("_id.language")
+            .as("language")
+            .and("_id.expected")
+            .as("expected")
+            .and("_id.actual")
+            .as("actual")
+            .andInclude("count", "initialCount", "medialCount", "finalCount", "letterCount"));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/domain/MemberWordTypoDetailStats.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/domain/MemberWordTypoDetailStats.java
@@ -1,0 +1,79 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_member_word_typo_detail_stats",
+            columnNames = {"member_id", "language", "expected", "actual"}))
+public class MemberWordTypoDetailStats extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "member_word_typo_detail_stats_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @Enumerated(EnumType.STRING)
+  private WordLanguage language;
+
+  private String expected;
+  private String actual;
+  private int typoCount;
+  private int initialCount;
+  private int medialCount;
+  private int finalCount;
+  private int letterCount;
+
+  public static MemberWordTypoDetailStats create(
+      Member member,
+      WordLanguage language,
+      String expected,
+      String actual,
+      int count,
+      int initialCount,
+      int medialCount,
+      int finalCount,
+      int letterCount) {
+    MemberWordTypoDetailStats stats = new MemberWordTypoDetailStats();
+    stats.member = member;
+    stats.language = language;
+    stats.expected = expected;
+    stats.actual = actual;
+    stats.typoCount = count;
+    stats.initialCount = initialCount;
+    stats.medialCount = medialCount;
+    stats.finalCount = finalCount;
+    stats.letterCount = letterCount;
+    return stats;
+  }
+
+  public void merge(int count, int initialCount, int medialCount, int finalCount, int letterCount) {
+    this.typoCount += count;
+    this.initialCount += initialCount;
+    this.medialCount += medialCount;
+    this.finalCount += finalCount;
+    this.letterCount += letterCount;
+  }
+
+  public void overwrite(
+      int count, int initialCount, int medialCount, int finalCount, int letterCount) {
+    this.typoCount = count;
+    this.initialCount = initialCount;
+    this.medialCount = medialCount;
+    this.finalCount = finalCount;
+    this.letterCount = letterCount;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/domain/MemberWordTypoStats.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/domain/MemberWordTypoStats.java
@@ -1,0 +1,52 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+    uniqueConstraints =
+        @UniqueConstraint(
+            name = "uq_member_word_typo_stats",
+            columnNames = {"member_id", "language", "expected"}))
+public class MemberWordTypoStats extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "member_word_typo_stats_id")
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id")
+  private Member member;
+
+  @Enumerated(EnumType.STRING)
+  private WordLanguage language;
+
+  private String expected;
+  private int typoCount;
+
+  public static MemberWordTypoStats create(
+      Member member, WordLanguage language, String expected, int count) {
+    MemberWordTypoStats stats = new MemberWordTypoStats();
+    stats.member = member;
+    stats.language = language;
+    stats.expected = expected;
+    stats.typoCount = count;
+    return stats;
+  }
+
+  public void merge(int count) {
+    this.typoCount += count;
+  }
+
+  public void overwrite(int count) {
+    this.typoCount = count;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/dto/MemberWordTypoAggregation.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/dto/MemberWordTypoAggregation.java
@@ -1,0 +1,19 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto;
+
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MemberWordTypoAggregation {
+  private Long memberId;
+  private WordLanguage language;
+  private String expected;
+  private String actual;
+  private int count;
+  private int initialCount;
+  private int medialCount;
+  private int finalCount;
+  private int letterCount;
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/repository/MemberWordTypoDetailStatsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/repository/MemberWordTypoDetailStatsRepository.java
@@ -1,0 +1,56 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.statistics.repository;
+
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberWordTypoDetailStats;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberWordTypoDetailStatsRepository {
+  private final EntityManager em;
+
+  public void save(MemberWordTypoDetailStats stats) {
+    em.persist(stats);
+  }
+
+  public Optional<MemberWordTypoDetailStats> findByMemberIdAndLanguageAndExpectedAndActual(
+      Long memberId, WordLanguage language, String expected, String actual) {
+    return em.createQuery(
+            "select s from MemberWordTypoDetailStats s "
+                + "where s.member.id = :memberId "
+                + "and s.language = :language "
+                + "and s.expected = :expected "
+                + "and s.actual = :actual",
+            MemberWordTypoDetailStats.class)
+        .setParameter("memberId", memberId)
+        .setParameter("language", language)
+        .setParameter("expected", expected)
+        .setParameter("actual", actual)
+        .getResultStream()
+        .findFirst();
+  }
+
+  public List<MemberWordTypoDetailStats> findByMemberIdAndLanguageAndExpected(
+      Long memberId, WordLanguage language, String expected) {
+    return em.createQuery(
+            "select s from MemberWordTypoDetailStats s "
+                + "where s.member.id = :memberId "
+                + "and s.language = :language "
+                + "and s.expected = :expected "
+                + "order by s.typoCount desc",
+            MemberWordTypoDetailStats.class)
+        .setParameter("memberId", memberId)
+        .setParameter("language", language)
+        .setParameter("expected", expected)
+        .getResultList();
+  }
+
+  public void deleteAllInBatch() {
+    em.createQuery("delete from MemberWordTypoDetailStats").executeUpdate();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/repository/MemberWordTypoStatsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/repository/MemberWordTypoStatsRepository.java
@@ -1,0 +1,53 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.statistics.repository;
+
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberWordTypoStats;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class MemberWordTypoStatsRepository {
+  private final EntityManager em;
+
+  public void save(MemberWordTypoStats stats) {
+    em.persist(stats);
+  }
+
+  public Optional<MemberWordTypoStats> findByMemberIdAndLanguageAndExpected(
+      Long memberId, WordLanguage language, String expected) {
+    return em.createQuery(
+            "select s from MemberWordTypoStats s "
+                + "where s.member.id = :memberId "
+                + "and s.language = :language "
+                + "and s.expected = :expected",
+            MemberWordTypoStats.class)
+        .setParameter("memberId", memberId)
+        .setParameter("language", language)
+        .setParameter("expected", expected)
+        .getResultStream()
+        .findFirst();
+  }
+
+  public List<MemberWordTypoStats> findTop10ByMemberIdAndLanguage(
+      Long memberId, WordLanguage language) {
+    return em.createQuery(
+            "select s from MemberWordTypoStats s "
+                + "where s.member.id = :memberId "
+                + "and s.language = :language "
+                + "order by s.typoCount desc",
+            MemberWordTypoStats.class)
+        .setParameter("memberId", memberId)
+        .setParameter("language", language)
+        .setMaxResults(10)
+        .getResultList();
+  }
+
+  public void deleteAllInBatch() {
+    em.createQuery("delete from MemberWordTypoStats").executeUpdate();
+  }
+}


### PR DESCRIPTION
## 주요 내용
- 회원 단어 오타 통계 저장용 엔티티 및 Repository 추가
- wordDetails.typos 2중 unwind MongoDB 집계 Repository 추가

## 세부 내용
### 도메인
- MemberWordTypoStats: (member, language, expected) UNIQUE
  - typoCount 누적
  - create/merge/overwrite
- MemberWordTypoDetailStats: (member, language, expected, actual) UNIQUE
  - typoCount + initialCount/medialCount/finalCount/letterCount (WordTypoType별)
  - create/merge/overwrite

### DTO
- MemberWordTypoAggregation: MongoDB 집계 결과 매핑용

### JPA Repository
- MemberWordTypoStatsRepository
  - save / findByMemberIdAndLanguageAndExpected / findTop10ByMemberIdAndLanguage / deleteAllInBatch
- MemberWordTypoDetailStatsRepository
  - save / findByMemberIdAndLanguageAndExpectedAndActual / findByMemberIdAndLanguageAndExpected / deleteAllInBatch

### MongoDB 집계 Repository
- MemberWordTypoAggregationRepository
  - aggregateByMemberIdsBetween / aggregateByMemberIds
  - 세션 outlier 제외 후 wordDetails → wordDetails.typos 2중 unwind
  - (memberId, language, typos.expected, typos.actual) 기준 그룹핑
  - WordTypoType별 INITIAL/MEDIAL/FINAL/LETTER 카운트