### PR TITLE
feat: 회원 단어 오타 통계 배치 + 회원 일괄 조회 패턴 적용

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepository.java
@@ -10,6 +10,8 @@ public interface MemberRepository {
 
   Optional<Member> findById(Long memberId);
 
+  List<Member> findAllByIds(List<Long> memberIds);
+
   Optional<Member> findByProviderId(String providerId);
 
   Long save(Member member);

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepositoryImpl.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/member/repository/MemberRepositoryImpl.java
@@ -65,6 +65,15 @@ public class MemberRepositoryImpl implements MemberRepository {
   }
 
   @Override
+  public List<Member> findAllByIds(List<Long> memberIds) {
+    if (memberIds.isEmpty()) return List.of();
+
+    return em.createQuery("select m from Member m where m.id in :ids", Member.class)
+        .setParameter("ids", memberIds)
+        .getResultList();
+  }
+
+  @Override
   public Long save(Member member) {
     em.persist(member);
 

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminWordStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/AdminWordStatisticsController.java
@@ -5,6 +5,7 @@ import com.typingpractice.typing_practice_be.statistics.dto.MemberStatsDayReques
 import com.typingpractice.typing_practice_be.word.statistics.service.GlobalWordStatisticsBatchService;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.service.MemberDailyWordStatsBatchService;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.service.MemberWordTypingStatsBatchService;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.service.MemberWordTypoStatsBatchService;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.service.WordTypingStatsBatchService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +19,7 @@ public class AdminWordStatisticsController {
   private final WordTypingStatsBatchService wordTypingStatsBatchService;
   private final MemberWordTypingStatsBatchService memberWordTypingStatsBatchService;
   private final MemberDailyWordStatsBatchService memberDailyWordStatsBatchService;
+  private final MemberWordTypoStatsBatchService memberWordTypoStatsBatchService;
 
   @PostMapping("/global-word/recalculate")
   public ApiResponse<Void> recalculateGlobalWordStats() {
@@ -43,6 +45,12 @@ public class AdminWordStatisticsController {
       @RequestBody @Valid MemberStatsDayRequest request) {
     memberDailyWordStatsBatchService.runRecalculationForDate(request.getDate());
 
+    return ApiResponse.ok(null);
+  }
+
+  @PostMapping("/member-word-typo/recalculate")
+  public ApiResponse<Void> recalculateMemberWordTypoStats() {
+    memberWordTypoStatsBatchService.runManualRecalculation();
     return ApiResponse.ok(null);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/scheduler/StatisticsScheduler.java
@@ -10,6 +10,7 @@ import com.typingpractice.typing_practice_be.typingrecord.statistics.service.bat
 import com.typingpractice.typing_practice_be.word.statistics.service.GlobalWordStatisticsBatchService;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.service.MemberDailyWordStatsBatchService;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.service.MemberWordTypingStatsBatchService;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.service.MemberWordTypoStatsBatchService;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.service.WordTypingStatsBatchService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,6 +32,7 @@ public class StatisticsScheduler {
   private final GlobalWordStatisticsBatchService globalWordStatisticsBatchService;
   private final MemberWordTypingStatsBatchService memberWordTypingStatsBatchService;
   private final MemberDailyWordStatsBatchService memberDailyWordStatsBatchService;
+  private final MemberWordTypoStatsBatchService memberWordTypoStatsBatchService;
 
   @Scheduled(cron = "0 0 3 * * *", zone = TimeUtils.KST_ZONE)
   public void runDailyBatch() {
@@ -51,6 +53,7 @@ public class StatisticsScheduler {
     globalWordStatisticsBatchService.runScheduledBatch(); // 전역 통계 (단어 특성 + 타이핑 성능)
     memberWordTypingStatsBatchService.runScheduledBatch(); // 개인 타이핑 통계
     memberDailyWordStatsBatchService.runScheduledBatch(); // 개인 일간 통계
+    memberWordTypoStatsBatchService.runScheduledBatch(); // 개인 오타 통계
     log.info("단어 전역 통계 배치 완료");
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/service/MemberDailyWordStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/service/MemberDailyWordStatsBatchService.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -60,11 +62,22 @@ public class MemberDailyWordStatsBatchService {
     int totalProcessed = 0;
     for (int i = 0; i < memberIds.size(); i += CHUNK_SIZE) {
       List<Long> chunk = memberIds.subList(i, Math.min(i + CHUNK_SIZE, memberIds.size()));
+
+      Map<Long, Member> memberMap =
+          memberRepository.findAllByIds(chunk).stream()
+              .collect(Collectors.toMap(Member::getId, m -> m));
+
       List<MemberDailyWordAggregation> aggregations =
           aggregationRepository.aggregateByMemberIdsBetween(chunk, from, to);
 
       for (MemberDailyWordAggregation agg : aggregations) {
-        upsert(agg);
+        Member member = memberMap.get(agg.getMemberId());
+        if (member == null) {
+          log.warn("Member 미존재, 스킵 - memberId: {}", agg.getMemberId());
+          continue;
+        }
+
+        upsert(agg, member);
         totalProcessed++;
       }
     }
@@ -72,7 +85,7 @@ public class MemberDailyWordStatsBatchService {
     return totalProcessed;
   }
 
-  private void upsert(MemberDailyWordAggregation agg) {
+  private void upsert(MemberDailyWordAggregation agg, Member member) {
     LocalDate date = agg.getDateAsLocalDate();
     MemberDailyWordStats stats =
         statsRepository
@@ -80,12 +93,6 @@ public class MemberDailyWordStatsBatchService {
             .orElse(null);
 
     if (stats == null) {
-      Member member = memberRepository.findById(agg.getMemberId()).orElse(null);
-      if (member == null) {
-        log.warn("Member 미존재, 스킵 - memberId: {}", agg.getMemberId());
-        return;
-      }
-
       stats =
           MemberDailyWordStats.create(
               member,

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/service/MemberWordTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/service/MemberWordTypingStatsBatchService.java
@@ -16,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -60,13 +62,23 @@ public class MemberWordTypingStatsBatchService {
     for (int i = 0; i < memberIds.size(); i += CHUNK_SIZE) {
       List<Long> chunk = memberIds.subList(i, Math.min(i + CHUNK_SIZE, memberIds.size()));
 
+      Map<Long, Member> memberMap =
+          memberRepository.findAllByIds(chunk).stream()
+              .collect(Collectors.toMap(Member::getId, m -> m));
+
       List<MemberWordTypingAggregation> aggregations =
           overwrite
               ? aggregationRepository.aggregateByMemberIds(chunk)
               : aggregationRepository.aggregateByMemberIdsBetween(chunk, from, to);
 
       for (MemberWordTypingAggregation agg : aggregations) {
-        upsert(agg, overwrite);
+        Member member = memberMap.get(agg.getMemberId());
+        if (member == null) {
+          log.warn("Member 미존재, 스킵 - memberId: {}", agg.getMemberId());
+          continue;
+        }
+
+        upsert(agg, overwrite, member);
         totalProcessed++;
       }
     }
@@ -74,19 +86,13 @@ public class MemberWordTypingStatsBatchService {
     return totalProcessed;
   }
 
-  private void upsert(MemberWordTypingAggregation agg, boolean overwrite) {
+  private void upsert(MemberWordTypingAggregation agg, boolean overwrite, Member member) {
     MemberWordTypingStats stats =
         statsRepository
             .findByMemberIdAndLanguage(agg.getMemberId(), agg.getLanguage())
             .orElse(null);
 
     if (stats == null) {
-      Member member = memberRepository.findById(agg.getMemberId()).orElse(null);
-      if (member == null) {
-        log.warn("Member 미존재, 스킵 - memberId: {}", agg.getMemberId());
-        return;
-      }
-
       stats =
           MemberWordTypingStats.create(
               member,

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/service/MemberWordTypoStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/statistics/service/MemberWordTypoStatsBatchService.java
@@ -1,0 +1,160 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.statistics.service;
+
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.wordtypingrecord.repository.WordTypingRecordRepository;
+import com.typingpractice.typing_practice_be.wordtypingrecord.repository.aggregation.MemberWordTypoAggregationRepository;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberWordTypoDetailStats;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberWordTypoStats;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.MemberWordTypoAggregation;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.repository.MemberWordTypoDetailStatsRepository;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.repository.MemberWordTypoStatsRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberWordTypoStatsBatchService {
+  private final WordTypingRecordRepository wordTypingRecordRepository;
+  private final MemberWordTypoAggregationRepository memberWordTypoAggregationRepository;
+  private final MemberWordTypoStatsRepository memberWordTypoStatsRepository;
+  private final MemberWordTypoDetailStatsRepository memberWordTypoDetailStatsRepository;
+  private final MemberRepository memberRepository;
+
+  private static final int CHUNK_SIZE = 500;
+
+  @Transactional
+  public void runScheduledBatch() {
+    LocalDate yesterdayKst = LocalDate.now(TimeUtils.KST).minusDays(1);
+
+    LocalDateTime from = TimeUtils.startOfDayKstToUtc(yesterdayKst);
+    LocalDateTime to = TimeUtils.endOfDayKstToUtc(yesterdayKst);
+
+    log.info("MemberWordTypoStats 증분 배치 시작 - 범위: {} ~ {}", from, to);
+
+    List<Long> memberIds = wordTypingRecordRepository.findDistinctMemberIdsBetween(from, to);
+    int totalProcessed = processChunks(memberIds, from, to, false);
+
+    log.info("MemberWordTypoStats 증분 배치 완료 - {}건 처리", totalProcessed);
+  }
+
+  @Transactional
+  public void runManualRecalculation() {
+    log.info("MemberWordTypoStats 전체 재계산 시작");
+
+    memberWordTypoDetailStatsRepository.deleteAllInBatch();
+    memberWordTypoStatsRepository.deleteAllInBatch();
+
+    List<Long> memberIds = wordTypingRecordRepository.findDistinctMemberIds();
+    int totalProcessed = processChunks(memberIds, null, null, true);
+
+    log.info("MemberWordTypoStats 전체 재계산 완료 - {}건 처리", totalProcessed);
+  }
+
+  private int processChunks(
+      List<Long> memberIds, LocalDateTime from, LocalDateTime to, boolean isManual) {
+    int totalProcessed = 0;
+    for (int i = 0; i < memberIds.size(); i += CHUNK_SIZE) {
+      List<Long> chunk = memberIds.subList(i, Math.min(i + CHUNK_SIZE, memberIds.size()));
+
+      Map<Long, Member> memberMap =
+          memberRepository.findAllByIds(chunk).stream()
+              .collect(Collectors.toMap(Member::getId, m -> m));
+
+      List<MemberWordTypoAggregation> aggregations =
+          isManual
+              ? memberWordTypoAggregationRepository.aggregateByMemberIds(chunk)
+              : memberWordTypoAggregationRepository.aggregateByMemberIdsBetween(chunk, from, to);
+
+      for (MemberWordTypoAggregation agg : aggregations) {
+        Member member = memberMap.get(agg.getMemberId());
+
+        if (member == null) {
+          log.warn("Member 미존재, 스킵 - memberId: {}", agg.getMemberId());
+          continue;
+        }
+        upsertDetail(agg, isManual, member);
+        totalProcessed++;
+      }
+
+      aggregations.stream()
+          .collect(
+              Collectors.groupingBy(
+                  agg -> agg.getMemberId() + "_" + agg.getLanguage() + "_" + agg.getExpected()))
+          .forEach(
+              (key, group) -> {
+                MemberWordTypoAggregation first = group.getFirst();
+                Member member = memberMap.get(first.getMemberId());
+                if (member == null) return;
+
+                int totalCount = group.stream().mapToInt(MemberWordTypoAggregation::getCount).sum();
+                upsertTypoStats(
+                    member, first.getLanguage(), first.getExpected(), totalCount, isManual);
+              });
+    }
+
+    return totalProcessed;
+  }
+
+  private void upsertDetail(MemberWordTypoAggregation agg, boolean isManual, Member member) {
+    if (!isManual) {
+      MemberWordTypoDetailStats stats =
+          memberWordTypoDetailStatsRepository
+              .findByMemberIdAndLanguageAndExpectedAndActual(
+                  member.getId(), agg.getLanguage(), agg.getExpected(), agg.getActual())
+              .orElse(null);
+
+      if (stats != null) {
+        stats.merge(
+            agg.getCount(),
+            agg.getInitialCount(),
+            agg.getMedialCount(),
+            agg.getFinalCount(),
+            agg.getLetterCount());
+        return;
+      }
+    }
+
+    memberWordTypoDetailStatsRepository.save(
+        MemberWordTypoDetailStats.create(
+            member,
+            agg.getLanguage(),
+            agg.getExpected(),
+            agg.getActual(),
+            agg.getCount(),
+            agg.getInitialCount(),
+            agg.getMedialCount(),
+            agg.getFinalCount(),
+            agg.getLetterCount()));
+  }
+
+  private void upsertTypoStats(
+      Member member, WordLanguage language, String expected, int count, boolean isManual) {
+    if (!isManual) {
+      MemberWordTypoStats stats =
+          memberWordTypoStatsRepository
+              .findByMemberIdAndLanguageAndExpected(member.getId(), language, expected)
+              .orElse(null);
+
+      if (stats != null) {
+        stats.merge(count);
+        return;
+      }
+    }
+
+    memberWordTypoStatsRepository.save(
+        MemberWordTypoStats.create(member, language, expected, count));
+  }
+}


### PR DESCRIPTION
## 주요 내용
- 회원 단어 오타 통계 배치 서비스 추가 및 04시 스케줄/어드민 재계산 등록
- MemberRepository.findAllByIds 추가로 chunk 단위 일괄 조회 지원
- Word 회원 통계 배치 3종에 회원 일괄 조회 패턴 적용하여 findById 반복 호출 제거

## 세부 내용
### MemberRepository 확장
- findAllByIds(List<Long>) 추가
- 빈 리스트 방어 후 JPQL IN 쿼리로 단일 조회

### 오타 통계 배치 서비스
- MemberWordTypoStatsBatchService 신설
  - runScheduledBatch: 전날 범위 증분 merge
  - runManualRecalculation: deleteAllInBatch 후 전체 재계산
  - chunk 500 단위 처리, memberMap으로 회원 일괄 조회
  - upsertDetail/upsertTypoStats는 Member 객체를 직접 받아 책임 분리

### 04시 스케줄러
- StatisticsScheduler.runWordDailyBatch 끝에 memberWordTypoStatsBatchService.runScheduledBatch() 추가
- 배치 순서: WordTyping → GlobalWord → MemberWordTyping → MemberDailyWord → MemberWordTypo

### 어드민 트리거
- AdminWordStatisticsController에 POST /admin/stats/member-word-typo/recalculate 추가

### 기존 배치 리팩토링
- MemberWordTypingStatsBatchService / MemberDailyWordStatsBatchService
  - processChunks에서 chunk별 memberMap 구성 (findAllByIds 1회 호출)
  - Member 미존재 시 processChunks에서 한 번만 경고 로그
  - upsert 시그니처에 Member 파라미터 추가 → 조회 책임이 호출자로 이동