### PR TITLE
refactor: Quote 통계 배치에 회원 일괄 조회 패턴 적용

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/MemberDailyStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/MemberDailyStatsBatchService.java
@@ -11,6 +11,9 @@ import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -62,11 +65,21 @@ public class MemberDailyStatsBatchService {
     for (int i = 0; i < memberIds.size(); i += CHUNK_SIZE) {
       List<Long> chunk = memberIds.subList(i, Math.min(i + CHUNK_SIZE, memberIds.size()));
 
+      Map<Long, Member> memberMap =
+          memberRepository.findAllByIds(chunk).stream()
+              .collect(Collectors.toMap(Member::getId, m -> m));
+
       List<MemberDailyAggregation> aggregations =
           memberDailyAggregationRepository.aggregateByMemberIdsBetween(chunk, from, to);
 
       for (MemberDailyAggregation agg : aggregations) {
-        upsert(agg);
+        Member member = memberMap.get(agg.getMemberId());
+        if (member == null) {
+          log.warn("Member 미존재, 스킵 - memberId: {}", agg.getMemberId());
+          continue;
+        }
+
+        upsert(agg, member);
         totalProcessed++;
       }
     }
@@ -74,19 +87,14 @@ public class MemberDailyStatsBatchService {
     return totalProcessed;
   }
 
-  private void upsert(MemberDailyAggregation agg) {
+  private void upsert(MemberDailyAggregation agg, Member member) {
     LocalDate date = agg.getDateAsLocalDate();
     MemberDailyStats stats =
         memberDailyStatsRepository
-            .findByMemberIdAndDateAndLanguage(agg.getMemberId(), date, agg.getLanguage())
+            .findByMemberIdAndDateAndLanguage(member.getId(), date, agg.getLanguage())
             .orElse(null);
 
     if (stats == null) {
-      Member member = memberRepository.findById(agg.getMemberId()).orElse(null);
-      if (member == null) {
-        log.warn("Member 미존재, 스킵 - memberId: {}", agg.getMemberId());
-        return;
-      }
       stats =
           MemberDailyStats.create(
               member,

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/MemberTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/MemberTypingStatsBatchService.java
@@ -14,6 +14,9 @@ import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -68,13 +71,22 @@ public class MemberTypingStatsBatchService {
     for (int i = 0; i < memberIds.size(); i += CHUNK_SIZE) {
       List<Long> chunk = memberIds.subList(i, Math.min(i + CHUNK_SIZE, memberIds.size()));
 
+      Map<Long, Member> memberMap =
+          memberRepository.findAllByIds(chunk).stream()
+              .collect(Collectors.toMap(Member::getId, m -> m));
+
       List<MemberTypingAggregation> aggregations =
           overwrite
               ? typingAggregationRepository.aggregateByMemberIds(chunk)
               : typingAggregationRepository.aggregateByMemberIdsBetween(chunk, from, to);
 
       for (MemberTypingAggregation agg : aggregations) {
-        upsert(agg.getMemberId(), agg, overwrite, from, to);
+        Member member = memberMap.get(agg.getMemberId());
+        if (member == null) {
+          log.warn("Member 미존재, 스킵 - memberId: {}", agg.getMemberId());
+          continue;
+        }
+        upsert(agg, overwrite, from, to, member);
         totalProcessed++;
       }
     }
@@ -83,22 +95,18 @@ public class MemberTypingStatsBatchService {
   }
 
   private void upsert(
-      Long memberId,
       MemberTypingAggregation agg,
       boolean overwrite,
       LocalDateTime from,
-      LocalDateTime to) {
+      LocalDateTime to,
+      Member member) {
+    Long memberId = member.getId();
     MemberTypingStats stats =
         memberTypingStatsRepository
             .findByMemberIdAndLanguage(memberId, agg.getLanguage())
             .orElse(null);
 
     if (stats == null) {
-      Member member = memberRepository.findById(memberId).orElse(null);
-      if (member == null) {
-        log.warn("Member 미존재, 스킵 - memberId: {}", memberId);
-        return;
-      }
 
       stats =
           MemberTypingStats.create(

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/MemberTypoStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/MemberTypoStatsBatchService.java
@@ -14,6 +14,7 @@ import com.typingpractice.typing_practice_be.typingrecord.statistics.repository.
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -70,13 +71,22 @@ public class MemberTypoStatsBatchService {
     for (int i = 0; i < memberIds.size(); i += CHUNK_SIZE) {
       List<Long> chunk = memberIds.subList(i, Math.min(i + CHUNK_SIZE, memberIds.size()));
 
+      Map<Long, Member> memberMap =
+          memberRepository.findAllByIds(chunk).stream()
+              .collect(Collectors.toMap(Member::getId, m -> m));
+
       List<MemberTypoAggregation> aggregations =
           isManual
               ? memberTypoAggregationRepository.aggregateByMemberIds(chunk)
               : memberTypoAggregationRepository.aggregateByMemberIdsBetween(chunk, from, to);
 
       for (MemberTypoAggregation agg : aggregations) {
-        upsertDetail(agg, isManual);
+        Member member = memberMap.get(agg.getMemberId());
+        if (member == null) {
+          log.warn("Member 미존재, 스킵 - memberId: {}", agg.getMemberId());
+          continue;
+        }
+        upsertDetail(agg, isManual, member);
         totalProcessed++;
       }
 
@@ -86,35 +96,26 @@ public class MemberTypoStatsBatchService {
                   agg -> agg.getMemberId() + "_" + agg.getLanguage() + "_" + agg.getExpected()))
           .forEach(
               (key, group) -> {
-                int totalCount = group.stream().mapToInt(MemberTypoAggregation::getCount).sum();
                 MemberTypoAggregation first = group.getFirst();
+                Member member = memberMap.get(first.getMemberId());
+                if (member == null) return;
+
+                int totalCount = group.stream().mapToInt(MemberTypoAggregation::getCount).sum();
                 upsertTypoStats(
-                    first.getMemberId(),
-                    first.getLanguage(),
-                    first.getExpected(),
-                    totalCount,
-                    isManual);
+                    member, first.getLanguage(), first.getExpected(), totalCount, isManual);
               });
     }
 
     return totalProcessed;
   }
 
-  private Member findMember(Long memberId) {
-    Member member = memberRepository.findById(memberId).orElse(null);
-    if (member == null) {
-      log.warn("Member 미존재, 스킵 - memberId: {}", memberId);
-    }
-    return member;
-  }
-
-  private void upsertDetail(MemberTypoAggregation agg, boolean isManual) {
+  private void upsertDetail(MemberTypoAggregation agg, boolean isManual, Member member) {
     // 기존 정보 merge
     if (!isManual) {
       MemberTypoDetailStats stats =
           memberTypoDetailStatsRepository
               .findByMemberIdAndLanguageAndExpectedAndActual(
-                  agg.getMemberId(), agg.getLanguage(), agg.getExpected(), agg.getActual())
+                  member.getId(), agg.getLanguage(), agg.getExpected(), agg.getActual())
               .orElse(null);
 
       if (stats != null) {
@@ -129,9 +130,6 @@ public class MemberTypoStatsBatchService {
     }
 
     // 새로 생성
-    Member member = findMember(agg.getMemberId());
-    if (member == null) return;
-
     memberTypoDetailStatsRepository.save(
         MemberTypoDetailStats.create(
             member,
@@ -146,11 +144,11 @@ public class MemberTypoStatsBatchService {
   }
 
   private void upsertTypoStats(
-      Long memberId, QuoteLanguage language, String expected, int count, boolean isManual) {
+      Member member, QuoteLanguage language, String expected, int count, boolean isManual) {
     if (!isManual) {
       MemberTypoStats stats =
           memberTypoStatsRepository
-              .findByMemberIdAndLanguageAndExpected(memberId, language, expected)
+              .findByMemberIdAndLanguageAndExpected(member.getId(), language, expected)
               .orElse(null);
 
       if (stats != null) {
@@ -158,9 +156,6 @@ public class MemberTypoStatsBatchService {
         return;
       }
     }
-
-    Member member = findMember(memberId);
-    if (member == null) return;
 
     memberTypoStatsRepository.save(MemberTypoStats.create(member, language, expected, count));
   }


### PR DESCRIPTION
## 주요 내용
- Quote 회원 통계 배치 3종에 chunk 단위 memberRepository.findAllByIds 적용
- findById 반복 호출 제거, upsert 메서드는 Member 객체를 직접 받도록 변경
- Word 통계 배치와 동일한 패턴으로 일관성 확보

## 세부 내용
### 공통 변경
- processChunks에서 chunk별 findAllByIds 1회 호출하여 memberMap 구성
- Member 미존재 시 processChunks에서 한 번만 경고 로그 후 continue
- upsert 시그니처에 Member 파라미터 추가 → 조회 책임이 호출자로 이동

### MemberTypingStatsBatchService
- upsert(agg, overwrite, from, to, member) 시그니처 변경
- memberId는 member.getId()로 내부에서 획득
- 적응형 서빙 mu/sigma 업데이트 로직은 유지

### MemberDailyStatsBatchService
- upsert(agg, member) 시그니처 변경

### MemberTypoStatsBatchService
- upsertDetail(agg, isManual, member) 시그니처 변경
- upsertTypoStats(member, language, expected, count, isManual) 시그니처 변경
- 미사용 private findMember 메서드 제거