### PR TITLE
feat: 회원 단어 오타 통계 조회 API 추가 (typos / typos detail)

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberWordStatisticsController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/controller/MemberWordStatisticsController.java
@@ -6,6 +6,8 @@ import com.typingpractice.typing_practice_be.statistics.service.MemberWordStatis
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
 import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberDailyWordStatsResponse;
 import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberWordTypingStatsResponse;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberWordTypoDetailStatsResponse;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberWordTypoStatsResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -36,6 +38,21 @@ public class MemberWordStatisticsController {
     return ApiResponse.ok(
         memberWordStatisticsService.getDailyStats(
             memberId, request.getLanguage(), request.getDays()));
+  }
+
+  @GetMapping("/typos")
+  public ApiResponse<MemberWordTypoStatsResponse> getTypoStats(
+      @RequestParam WordLanguage language) {
+    Long memberId = getMemberId();
+    return ApiResponse.ok(memberWordStatisticsService.getTypoStats(memberId, language));
+  }
+
+  @GetMapping("/typos/detail")
+  public ApiResponse<MemberWordTypoDetailStatsResponse> getTypoDetailStats(
+      @RequestParam WordLanguage language, @RequestParam String expected) {
+    Long memberId = getMemberId();
+    return ApiResponse.ok(
+        memberWordStatisticsService.getTypoDetailStats(memberId, language, expected));
   }
 
   @PostMapping("/refresh")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberWordStatisticsService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/statistics/service/MemberWordStatisticsService.java
@@ -5,16 +5,26 @@ import com.typingpractice.typing_practice_be.statistics.exception.RefreshCooldow
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
 import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberDailyWordStatsResponse;
 import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberWordTypingStatsResponse;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberWordTypoDetailStatsResponse;
+import com.typingpractice.typing_practice_be.wordtypingrecord.dto.response.MemberWordTypoStatsResponse;
 import com.typingpractice.typing_practice_be.wordtypingrecord.repository.WordTypingRecordRepository;
 import com.typingpractice.typing_practice_be.wordtypingrecord.repository.aggregation.MemberDailyWordAggregationRepository;
 import com.typingpractice.typing_practice_be.wordtypingrecord.repository.aggregation.MemberWordTypingAggregationRepository;
+import com.typingpractice.typing_practice_be.wordtypingrecord.repository.aggregation.MemberWordTypoAggregationRepository;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberDailyWordStats;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberWordTypingStats;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberWordTypoDetailStats;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberWordTypoStats;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.TodayWordTypoDetailSnapshot;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.TodayWordTypoSnapshot;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.aggregation.MemberDailyWordAggregation;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.aggregation.MemberWordTypingAggregation;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.TodayWordTypingSnapshot;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.aggregation.MemberWordTypoAggregation;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.repository.MemberDailyWordStatsRepository;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.repository.MemberWordTypingStatsRepository;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.repository.MemberWordTypoDetailStatsRepository;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.repository.MemberWordTypoStatsRepository;
 import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.service.TodayWordTypingStatsRedisService;
 
 import java.time.Duration;
@@ -34,10 +44,13 @@ public class MemberWordStatisticsService {
   private final WordTypingRecordRepository wordTypingRecordRepository;
   private final MemberWordTypingAggregationRepository memberWordTypingAggregationRepository;
   private final MemberDailyWordAggregationRepository memberDailyWordAggregationRepository;
+  private final MemberWordTypoAggregationRepository memberWordTypoAggregationRepository;
 
   // pg
   private final MemberWordTypingStatsRepository memberWordTypingStatsRepository;
   private final MemberDailyWordStatsRepository memberDailyWordStatsRepository;
+  private final MemberWordTypoStatsRepository memberWordTypoStatsRepository;
+  private final MemberWordTypoDetailStatsRepository memberWordTypoDetailStatsRepository;
 
   // redis
   private final TodayWordTypingStatsRedisService todayWordTypingStatsRedisService;
@@ -112,6 +125,55 @@ public class MemberWordStatisticsService {
     }
 
     return MemberDailyWordStatsResponse.of(days, pgList, yesterdayAgg, today, todayKst);
+  }
+
+  public MemberWordTypoStatsResponse getTypoStats(Long memberId, WordLanguage language) {
+    List<MemberWordTypoStats> pgList =
+        memberWordTypoStatsRepository.findTop10ByMemberIdAndLanguage(memberId, language);
+
+    TodayWordTypoSnapshot today =
+        todayWordTypingStatsRedisService.getTypoByLanguage(memberId, language);
+
+    List<MemberWordTypoAggregation> yesterdayList = List.of();
+    if (isYesterdayBatchPending(memberId, language)) {
+      LocalDate yesterday = LocalDate.now(TimeUtils.KST).minusDays(1);
+      LocalDateTime from = TimeUtils.startOfDayKstToUtc(yesterday);
+      LocalDateTime to = TimeUtils.endOfDayKstToUtc(yesterday);
+
+      yesterdayList =
+          memberWordTypoAggregationRepository.aggregateByMemberIdsBetween(
+              List.of(memberId), from, to);
+    }
+
+    return MemberWordTypoStatsResponse.of(language, pgList, yesterdayList, today);
+  }
+
+  public MemberWordTypoDetailStatsResponse getTypoDetailStats(
+      Long memberId, WordLanguage language, String expected) {
+    List<MemberWordTypoDetailStats> pgList =
+        memberWordTypoDetailStatsRepository.findByMemberIdAndLanguageAndExpected(
+            memberId, language, expected);
+
+    TodayWordTypoDetailSnapshot todayFiltered =
+        todayWordTypingStatsRedisService.getTypoDetailByLanguageAndExpected(
+            memberId, language, expected);
+
+    List<MemberWordTypoAggregation> yesterdayList = List.of();
+    if (isYesterdayBatchPending(memberId, language)) {
+      LocalDate yesterday = LocalDate.now(TimeUtils.KST).minusDays(1);
+      LocalDateTime from = TimeUtils.startOfDayKstToUtc(yesterday);
+      LocalDateTime to = TimeUtils.endOfDayKstToUtc(yesterday);
+
+      yesterdayList =
+          memberWordTypoAggregationRepository
+              .aggregateByMemberIdsBetween(List.of(memberId), from, to)
+              .stream()
+              .filter(agg -> agg.getExpected().equals(expected))
+              .toList();
+    }
+
+    return MemberWordTypoDetailStatsResponse.of(
+        language, expected, pgList, yesterdayList, todayFiltered);
   }
 
   public MemberWordTypingStatsResponse refreshStats(Long memberId, WordLanguage language) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/response/MemberWordTypoDetailStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/response/MemberWordTypoDetailStatsResponse.java
@@ -1,0 +1,128 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.dto.response;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberWordTypoDetailStats;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.TodayWordTypoDetailEntry;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.TodayWordTypoDetailSnapshot;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.aggregation.MemberWordTypoAggregation;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberWordTypoDetailStatsResponse {
+  private List<DetailEntry> content;
+
+  public static MemberWordTypoDetailStatsResponse of(
+      WordLanguage language,
+      String expected,
+      List<MemberWordTypoDetailStats> pgList,
+      List<MemberWordTypoAggregation> yesterdayList,
+      TodayWordTypoDetailSnapshot todayFiltered) {
+    Map<String, DetailEntry> mergedMap = new HashMap<>();
+
+    for (MemberWordTypoDetailStats stats : pgList) {
+      String key =
+          TodayWordTypoDetailSnapshot.toKey(
+              stats.getLanguage(), stats.getExpected(), stats.getActual());
+      mergedMap.put(key, DetailEntry.from(stats));
+    }
+
+    for (MemberWordTypoAggregation agg : yesterdayList) {
+      String key =
+          TodayWordTypoDetailSnapshot.toKey(agg.getLanguage(), agg.getExpected(), agg.getActual());
+      mergedMap.merge(key, DetailEntry.from(agg), DetailEntry::merge);
+    }
+
+    for (Map.Entry<String, TodayWordTypoDetailEntry> entry :
+        todayFiltered.getDetailMap().entrySet()) {
+      mergedMap.merge(
+          entry.getKey(),
+          DetailEntry.fromToday(language, expected, entry.getKey(), entry.getValue()),
+          DetailEntry::merge);
+    }
+
+    MemberWordTypoDetailStatsResponse response = new MemberWordTypoDetailStatsResponse();
+    response.content =
+        mergedMap.values().stream()
+            .sorted((a, b) -> Integer.compare(b.getTypoCount(), a.getTypoCount()))
+            .toList();
+
+    return response;
+  }
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class DetailEntry {
+    private WordLanguage language;
+    private String expected;
+    private String actual;
+    private int typoCount;
+    private int initialCount;
+    private int medialCount;
+    private int finalCount;
+    private int letterCount;
+
+    public static DetailEntry from(MemberWordTypoAggregation agg) {
+      DetailEntry entry = new DetailEntry();
+
+      entry.language = agg.getLanguage();
+      entry.expected = agg.getExpected();
+      entry.actual = agg.getActual();
+      entry.typoCount = agg.getCount();
+      entry.initialCount = agg.getInitialCount();
+      entry.medialCount = agg.getMedialCount();
+      entry.finalCount = agg.getFinalCount();
+      entry.letterCount = agg.getLetterCount();
+      return entry;
+    }
+
+    public static DetailEntry from(MemberWordTypoDetailStats stats) {
+      DetailEntry entry = new DetailEntry();
+      entry.language = stats.getLanguage();
+      entry.expected = stats.getExpected();
+      entry.actual = stats.getActual();
+      entry.typoCount = stats.getTypoCount();
+      entry.initialCount = stats.getInitialCount();
+      entry.medialCount = stats.getMedialCount();
+      entry.finalCount = stats.getFinalCount();
+      entry.letterCount = stats.getLetterCount();
+      return entry;
+    }
+
+    public static DetailEntry fromToday(
+        WordLanguage language, String expected, String hashKey, TodayWordTypoDetailEntry today) {
+      String prefix = language + ":" + expected + ":";
+      String actual = hashKey.substring(prefix.length());
+
+      DetailEntry entry = new DetailEntry();
+      entry.language = language;
+      entry.expected = expected;
+      entry.actual = actual;
+      entry.typoCount = today.getCount();
+      entry.initialCount = today.getInitialCount();
+      entry.medialCount = today.getMedialCount();
+      entry.finalCount = today.getFinalCount();
+      entry.letterCount = today.getLetterCount();
+      return entry;
+    }
+
+    public static DetailEntry merge(DetailEntry existing, DetailEntry today) {
+      DetailEntry merged = new DetailEntry();
+      merged.language = existing.language;
+      merged.expected = existing.expected;
+      merged.actual = existing.actual;
+      merged.typoCount = existing.typoCount + today.typoCount;
+      merged.initialCount = existing.initialCount + today.initialCount;
+      merged.medialCount = existing.medialCount + today.medialCount;
+      merged.finalCount = existing.finalCount + today.finalCount;
+      merged.letterCount = existing.letterCount + today.letterCount;
+      return merged;
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/response/MemberWordTypoStatsResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/wordtypingrecord/dto/response/MemberWordTypoStatsResponse.java
@@ -1,0 +1,76 @@
+package com.typingpractice.typing_practice_be.wordtypingrecord.dto.response;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.MemberWordTypoStats;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.TodayWordTypoSnapshot;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.dto.aggregation.MemberWordTypoAggregation;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@ToString
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberWordTypoStatsResponse {
+  private List<TypoEntry> content;
+
+  public static MemberWordTypoStatsResponse of(
+      WordLanguage language,
+      List<MemberWordTypoStats> pgList,
+      List<MemberWordTypoAggregation> yesterdayList,
+      TodayWordTypoSnapshot today) {
+    Map<String, Integer> mergedMap = new HashMap<>();
+
+    for (MemberWordTypoStats stats : pgList) {
+      String key = TodayWordTypoSnapshot.toKey(stats.getLanguage(), stats.getExpected());
+      mergedMap.put(key, stats.getTypoCount());
+    }
+
+    for (MemberWordTypoAggregation agg : yesterdayList) {
+      String key = TodayWordTypoSnapshot.toKey(agg.getLanguage(), agg.getExpected());
+      mergedMap.merge(key, agg.getCount(), Integer::sum);
+    }
+
+    for (Map.Entry<String, Integer> entry : today.getTypoCountMap().entrySet()) {
+      mergedMap.merge(entry.getKey(), entry.getValue(), Integer::sum);
+    }
+
+    String prefix = language + ":";
+    MemberWordTypoStatsResponse response = new MemberWordTypoStatsResponse();
+    response.content =
+        mergedMap.entrySet().stream()
+            .filter(e -> e.getKey().startsWith(prefix))
+            .map(
+                e -> {
+                  String expected = e.getKey().substring(prefix.length());
+                  return TypoEntry.create(language, expected, e.getValue());
+                })
+            .sorted((a, b) -> Integer.compare(b.getCount(), a.getCount()))
+            .limit(10)
+            .toList();
+
+    return response;
+  }
+
+  @Getter
+  @ToString
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class TypoEntry {
+    private WordLanguage language;
+    private String expected;
+    private int count;
+
+    public static TypoEntry create(WordLanguage language, String expected, int count) {
+      TypoEntry entry = new TypoEntry();
+      entry.language = language;
+      entry.expected = expected;
+      entry.count = count;
+      return entry;
+    }
+  }
+}


### PR DESCRIPTION
## 주요 내용
- 회원 단어 모드 오타 통계 조회 엔드포인트 추가
- PostgreSQL 확정값 + MongoDB 어제 집계 + Redis 오늘 스냅샷의 3-way 병합으로 응답 구성
- 04시 배치 전후 공백 구간에서도 누락 없는 오타 통계 반환

## 세부 내용
### 엔드포인트 (신규)
- GET /members/me/word-stats/typos?language=KOREAN
  - 회원이 자주 틀린 expected 글자 Top 10 반환
- GET /members/me/word-stats/typos/detail?language=KOREAN&expected=한
  - 특정 expected에 대해 어떤 actual로 오타를 냈는지 분포 반환
  - 각 (expected, actual) 쌍별 INITIAL/MEDIAL/FINAL/LETTER 카운트 포함

### 서비스
- MemberWordStatisticsService.getTypoStats
  - pg: MemberWordTypoStats Top 10
  - today: TodayWordTypoSnapshot (언어별 prefix 필터)
  - yesterday: 배치 미완료 시 MongoDB 집계
- MemberWordStatisticsService.getTypoDetailStats
  - pg: MemberWordTypoDetailStats by expected
  - today: TodayWordTypoDetailSnapshot (language:expected prefix 필터)
  - yesterday: 배치 미완료 시 MongoDB 집계 후 expected 필터

### 응답 DTO
- MemberWordTypoStatsResponse
  - TypoEntry: language, expected, count
  - 3소스 typoCount 단순 합산 후 desc 정렬, 상위 10개 limit
  - 다른 언어 데이터 혼입 방지를 위한 prefix 필터 명시
- MemberWordTypoDetailStatsResponse
  - DetailEntry: language, expected, actual, typoCount + INITIAL/MEDIAL/FINAL/LETTER
  - DetailEntry.merge로 카운트별 합산
  - typoCount 기준 desc 정렬