### PR TITLE
feat: Word 어드민 조회 엔드포인트 추가 + 경로 복수형 통일

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/AuthController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/AuthController.java
@@ -14,8 +14,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.UUID;
-
 @RestController
 @RequestMapping("/auth")
 @RequiredArgsConstructor
@@ -25,24 +23,24 @@ public class AuthController {
   private final MemberService memberService;
   private final JwtTokenProvider jwtTokenProvider;
 
-  @PostMapping("/test")
-  public ApiResponse<LoginResponse> testLogin(@RequestBody TestLoginRequest request) {
-
-    LoginResult loginResult =
-        memberService.loginOrSignIn(
-            GoogleUserInfo.create(
-                request.getProviderId(),
-                "email",
-                "user_" + UUID.randomUUID().toString().substring(0, 8),
-                "picture"));
-
-    Member member = loginResult.getMember();
-
-    String token = jwtTokenProvider.createToken(member.getId(), member.getRole());
-    String refreshToken = authService.createRefreshToken(member);
-
-    return ApiResponse.ok(LoginResponse.from(loginResult, token, refreshToken));
-  }
+  //  @PostMapping("/test")
+  //  public ApiResponse<LoginResponse> testLogin(@RequestBody TestLoginRequest request) {
+  //
+  //    LoginResult loginResult =
+  //        memberService.loginOrSignIn(
+  //            GoogleUserInfo.create(
+  //                request.getProviderId(),
+  //                "email",
+  //                "user_" + UUID.randomUUID().toString().substring(0, 8),
+  //                "picture"));
+  //
+  //    Member member = loginResult.getMember();
+  //
+  //    String token = jwtTokenProvider.createToken(member.getId(), member.getRole());
+  //    String refreshToken = authService.createRefreshToken(member);
+  //
+  //    return ApiResponse.ok(LoginResponse.from(loginResult, token, refreshToken));
+  //  }
 
   @PostMapping("/google")
   public ApiResponse<LoginResponse> googleLogin(@RequestBody GoogleLoginRequest request) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/controller/AdminWordController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/controller/AdminWordController.java
@@ -1,10 +1,15 @@
 package com.typingpractice.typing_practice_be.word.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.dto.PageResult;
 import com.typingpractice.typing_practice_be.word.domain.Word;
-import com.typingpractice.typing_practice_be.word.dto.WordCreateRequest;
-import com.typingpractice.typing_practice_be.word.dto.WordResponse;
-import com.typingpractice.typing_practice_be.word.dto.WordUpdateRequest;
+import com.typingpractice.typing_practice_be.word.dto.response.AdminWordPaginationResponse;
+import com.typingpractice.typing_practice_be.word.dto.request.WordCreateRequest;
+import com.typingpractice.typing_practice_be.word.dto.request.WordPaginationRequest;
+import com.typingpractice.typing_practice_be.word.dto.response.AdminWordResponse;
+import com.typingpractice.typing_practice_be.word.dto.response.WordResponse;
+import com.typingpractice.typing_practice_be.word.dto.request.WordUpdateRequest;
+import com.typingpractice.typing_practice_be.word.query.WordPaginationQuery;
 import com.typingpractice.typing_practice_be.word.service.WordService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +17,24 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/admin/word")
+@RequestMapping("/admin/words")
 public class AdminWordController {
   private final WordService wordService;
+
+  @GetMapping()
+  public ApiResponse<AdminWordPaginationResponse> getWords(
+      @ModelAttribute @Valid WordPaginationRequest request) {
+    WordPaginationQuery query = WordPaginationQuery.from(request);
+    PageResult<Word> result = wordService.findAllForAdmin(query);
+
+    return ApiResponse.ok(AdminWordPaginationResponse.from(result));
+  }
+
+  @GetMapping("/{id}")
+  public ApiResponse<AdminWordResponse> getWord(@PathVariable Long id) {
+    Word word = wordService.findByIdWithTypingStats(id);
+    return ApiResponse.ok(AdminWordResponse.from(word));
+  }
 
   @PostMapping()
   public ApiResponse<WordResponse> postWord(@RequestBody @Valid WordCreateRequest request) {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/controller/WordController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/controller/WordController.java
@@ -2,8 +2,8 @@ package com.typingpractice.typing_practice_be.word.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.word.domain.Word;
-import com.typingpractice.typing_practice_be.word.dto.WordRequest;
-import com.typingpractice.typing_practice_be.word.dto.WordResponse;
+import com.typingpractice.typing_practice_be.word.dto.request.WordRequest;
+import com.typingpractice.typing_practice_be.word.dto.response.WordResponse;
 import com.typingpractice.typing_practice_be.word.service.WordService;
 import jakarta.validation.Valid;
 import java.util.List;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/domain/WordOrderBy.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/domain/WordOrderBy.java
@@ -1,0 +1,7 @@
+package com.typingpractice.typing_practice_be.word.domain;
+
+public enum WordOrderBy {
+  id,
+  difficulty,
+  createdAt
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/request/WordCreateRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/request/WordCreateRequest.java
@@ -1,4 +1,4 @@
-package com.typingpractice.typing_practice_be.word.dto;
+package com.typingpractice.typing_practice_be.word.dto.request;
 
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
 import jakarta.validation.constraints.Size;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/request/WordPaginationRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/request/WordPaginationRequest.java
@@ -1,0 +1,26 @@
+package com.typingpractice.typing_practice_be.word.dto.request;
+
+import com.typingpractice.typing_practice_be.common.domain.SortDirection;
+import com.typingpractice.typing_practice_be.common.dto.PaginationRequest;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.domain.WordOrderBy;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true)
+public class WordPaginationRequest extends PaginationRequest {
+  private final WordLanguage language;
+  private final WordOrderBy orderBy;
+
+  public WordPaginationRequest(
+      Integer page,
+      Integer size,
+      SortDirection sortDirection,
+      WordLanguage language,
+      WordOrderBy orderBy) {
+    super(page, size, sortDirection);
+    this.language = language;
+    this.orderBy = orderBy != null ? orderBy : WordOrderBy.id;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/request/WordRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/request/WordRequest.java
@@ -1,4 +1,4 @@
-package com.typingpractice.typing_practice_be.word.dto;
+package com.typingpractice.typing_practice_be.word.dto.request;
 
 import com.typingpractice.typing_practice_be.word.domain.WordDifficultyTier;
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/request/WordUpdateRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/request/WordUpdateRequest.java
@@ -1,4 +1,4 @@
-package com.typingpractice.typing_practice_be.word.dto;
+package com.typingpractice.typing_practice_be.word.dto.request;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/response/AdminWordPaginationResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/response/AdminWordPaginationResponse.java
@@ -1,0 +1,24 @@
+package com.typingpractice.typing_practice_be.word.dto.response;
+
+import com.typingpractice.typing_practice_be.common.dto.PageResult;
+import com.typingpractice.typing_practice_be.common.dto.PaginationResponse;
+import com.typingpractice.typing_practice_be.word.domain.Word;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class AdminWordPaginationResponse extends PaginationResponse {
+  private List<AdminWordResponse> content;
+
+  protected AdminWordPaginationResponse(int page, int size, boolean hasNext) {
+    super(page, size, hasNext);
+  }
+
+  public static AdminWordPaginationResponse from(PageResult<Word> result) {
+    AdminWordPaginationResponse response =
+        new AdminWordPaginationResponse(result.getPage(), result.getSize(), result.isHasNext());
+    response.content = result.getContent().stream().map(AdminWordResponse::from).toList();
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/response/AdminWordResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/response/AdminWordResponse.java
@@ -1,0 +1,81 @@
+package com.typingpractice.typing_practice_be.word.dto.response;
+
+import com.typingpractice.typing_practice_be.word.domain.Word;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.domain.WordProfile;
+import com.typingpractice.typing_practice_be.wordtypingrecord.statistics.domain.WordTypingStats;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AdminWordResponse {
+  private Long wordId;
+  private String word;
+  private WordLanguage language;
+  private Float difficulty;
+  private LocalDateTime createdAt;
+
+  private ProfileInfo profile;
+  private TypingStatsInfo typingStats;
+
+  public static AdminWordResponse from(Word word) {
+    AdminWordResponse response = new AdminWordResponse();
+
+    response.wordId = word.getId();
+    response.word = word.getWord();
+    response.language = word.getLanguage();
+    response.difficulty = word.getDifficulty();
+    response.createdAt = word.getCreatedAt();
+    response.profile = ProfileInfo.from(word.getProfile());
+
+    if (word.getTypingStats() != null) {
+      response.typingStats = TypingStatsInfo.from(word.getTypingStats());
+    }
+
+    return response;
+  }
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class ProfileInfo {
+    private int length;
+    private float difficultySeed;
+    private Float jamoComplex;
+    private Float diphthongRate;
+    private Float shiftJamoRate;
+    private Float caseFlipRate;
+
+    public static ProfileInfo from(WordProfile profile) {
+      ProfileInfo info = new ProfileInfo();
+      info.length = profile.getLength();
+      info.difficultySeed = profile.getDifficultySeed();
+      info.jamoComplex = profile.getJamoComplex();
+      info.diphthongRate = profile.getDiphthongRate();
+      info.shiftJamoRate = profile.getShiftJamoRate();
+      info.caseFlipRate = profile.getCaseFlipRate();
+      return info;
+    }
+  }
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class TypingStatsInfo {
+    private int totalAttemptsCount;
+    private int validAttemptsCount;
+    private float avgTimeMs;
+    private float correctRate;
+
+    public static TypingStatsInfo from(WordTypingStats stats) {
+      TypingStatsInfo info = new TypingStatsInfo();
+      info.totalAttemptsCount = stats.getTotalAttemptsCount();
+      info.validAttemptsCount = stats.getValidAttemptsCount();
+      info.avgTimeMs = stats.getAvgTimeMs();
+      info.correctRate = stats.getCorrectRate();
+      return info;
+    }
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/response/WordResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/dto/response/WordResponse.java
@@ -1,4 +1,4 @@
-package com.typingpractice.typing_practice_be.word.dto;
+package com.typingpractice.typing_practice_be.word.dto.response;
 
 import com.typingpractice.typing_practice_be.word.domain.Word;
 import lombok.Getter;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/query/WordPaginationQuery.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/query/WordPaginationQuery.java
@@ -1,0 +1,33 @@
+package com.typingpractice.typing_practice_be.word.query;
+
+import com.typingpractice.typing_practice_be.common.domain.SortDirection;
+import com.typingpractice.typing_practice_be.common.query.PaginationQuery;
+import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.domain.WordOrderBy;
+import com.typingpractice.typing_practice_be.word.dto.request.WordPaginationRequest;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true)
+public class WordPaginationQuery extends PaginationQuery {
+
+  private final WordLanguage language;
+  private final WordOrderBy orderBy;
+
+  private WordPaginationQuery(
+      int page, int size, SortDirection sortDirection, WordLanguage language, WordOrderBy orderBy) {
+    super(page, size, sortDirection);
+    this.language = language;
+    this.orderBy = orderBy;
+  }
+
+  public static WordPaginationQuery from(WordPaginationRequest request) {
+    return new WordPaginationQuery(
+        request.getPage(),
+        request.getSize(),
+        request.getSortDirection(),
+        request.getLanguage(),
+        request.getOrderBy());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/repository/WordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/repository/WordRepository.java
@@ -2,7 +2,9 @@ package com.typingpractice.typing_practice_be.word.repository;
 
 import com.typingpractice.typing_practice_be.word.domain.Word;
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
+import com.typingpractice.typing_practice_be.word.query.WordPaginationQuery;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -68,5 +70,35 @@ public class WordRepository {
             Long.class)
         .setParameter("language", language)
         .getResultList();
+  }
+
+  public Optional<Word> findByIdWithTypingStats(Long wordId) {
+    return em.createQuery(
+            "select w from Word w left join fetch w.typingStats where w.id = :wordId", Word.class)
+        .setParameter("wordId", wordId)
+        .getResultStream()
+        .findFirst();
+  }
+
+  public List<Word> findAll(WordPaginationQuery query) {
+    int page = query.getPage();
+    int size = query.getSize();
+
+    String jpql = "select w from Word w left join fetch w.typingStats";
+
+    if (query.getLanguage() != null) {
+      jpql += " where w.language = :language";
+    }
+
+    jpql += " order by w." + query.getOrderBy() + " " + query.getSortDirection();
+
+    TypedQuery<Word> typedQuery =
+        em.createQuery(jpql, Word.class).setFirstResult((page - 1) * size).setMaxResults(size + 1);
+
+    if (query.getLanguage() != null) {
+      typedQuery.setParameter("language", query.getLanguage());
+    }
+
+    return typedQuery.getResultList();
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/service/WordService.java
@@ -1,10 +1,12 @@
 package com.typingpractice.typing_practice_be.word.service;
 
+import com.typingpractice.typing_practice_be.common.dto.PageResult;
 import com.typingpractice.typing_practice_be.word.domain.Word;
 import com.typingpractice.typing_practice_be.word.domain.WordDifficultyTier;
 import com.typingpractice.typing_practice_be.word.domain.WordLanguage;
 import com.typingpractice.typing_practice_be.word.domain.WordProfile;
 import com.typingpractice.typing_practice_be.word.exception.WordNotFoundException;
+import com.typingpractice.typing_practice_be.word.query.WordPaginationQuery;
 import com.typingpractice.typing_practice_be.word.repository.WordRepository;
 import java.util.*;
 
@@ -41,6 +43,19 @@ public class WordService {
     Collections.shuffle(fetched);
 
     return fetched;
+  }
+
+  public PageResult<Word> findAllForAdmin(WordPaginationQuery query) {
+    List<Word> words = wordRepository.findAll(query);
+
+    boolean hasNext = words.size() > query.getSize();
+    List<Word> content = hasNext ? words.subList(0, query.getSize()) : words;
+
+    return new PageResult<>(content, query.getPage(), query.getSize(), hasNext);
+  }
+
+  public Word findByIdWithTypingStats(Long wordId) {
+    return wordRepository.findByIdWithTypingStats(wordId).orElseThrow(WordNotFoundException::new);
   }
 
   @Transactional


### PR DESCRIPTION
## 주요 내용
- 어드민용 단어 목록/단일 조회 엔드포인트 추가
- 단일 조회 시 WordTypingStats 함께 반환 (프로필, 시도 횟수, 정답률 등)
- 어드민 단어 경로를 /admin/word → /admin/words 복수형으로 통일

## 세부 내용
### 엔드포인트 (신규)
- GET /admin/words: 페이지네이션 목록 (language, orderBy, sortDirection 필터)
- GET /admin/words/{id}: 단일 단어 + WordTypingStats 상세

### 경로 변경
- POST /admin/word → POST /admin/words
- PATCH /admin/word/{id} → PATCH /admin/words/{id}
- DELETE /admin/word/{id} → DELETE /admin/words/{id}

### 페이지네이션 DTO
- WordOrderBy: id / difficulty / createdAt
- WordPaginationRequest: language nullable, orderBy 기본 id
- WordPaginationQuery: Request → 서비스 계층 변환

### 응답 DTO
- AdminWordResponse: word + difficulty(Float) + createdAt + ProfileInfo + TypingStatsInfo
- AdminWordPaginationResponse: PageResult<Word> 기반 페이지 응답

### Repository / Service
- WordRepository.findAll(query): typingStats join fetch + 페이지네이션 (size+1로 hasNext 판정)
- WordRepository.findByIdWithTypingStats: 단일 조회 시 typingStats 함께 fetch
- WordService.findAllForAdmin / findByIdWithTypingStats