### PR TITLE
fix: GlobalWordStatistics 조회 시 최신 row 반환하도록 정렬 추가

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/repository/GlobalWordStatisticsRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/word/statistics/repository/GlobalWordStatisticsRepository.java
@@ -19,9 +19,10 @@ public class GlobalWordStatisticsRepository {
 
   public Optional<GlobalWordStatistics> findByLanguage(WordLanguage language) {
     return em.createQuery(
-            "select g from GlobalWordStatistics g where g.language = :language",
+            "select g from GlobalWordStatistics g where g.language = :language order by g.createdAt DESC",
             GlobalWordStatistics.class)
         .setParameter("language", language)
+        .setMaxResults(1)
         .getResultStream()
         .findFirst();
   }


### PR DESCRIPTION
## 주요 내용
- findByLanguage가 정렬 없이 임의 row를 반환하던 문제 수정
- createdAt DESC + LIMIT 1로 항상 최신 통계 row를 반환하도록 변경

## 세부 내용
### GlobalWordStatisticsRepository
- findByLanguage JPQL에 order by g.createdAt DESC 추가
- setMaxResults(1)로 최신 1건만 조회

### 배경
- save가 em.persist 기반이라 매 배치마다 새 row가 누적되는 구조
- 정렬이 없어 임의 row가 반환되며, 04시 배치 직후 단어 0개 상태에서 생성된 빈 stats가 조회될 경우 WordDifficultySeedCalculator에서 NPE 발생
- 단어 등록 운영 사고로 확인된 이슈 수정