### PR TITLE
refactor: 적응형 서빙 난이도 비율 및 랜덤 비율 조정

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/service/AdaptiveQuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/adaptiveserving/service/AdaptiveQuoteService.java
@@ -23,11 +23,11 @@ public class AdaptiveQuoteService {
   private final QuoteIdCacheService quoteIdCacheService;
   private final QuoteRepository quoteRepository;
 
-  private static final int EASY_RATIO = 2;
-  private static final int FIT_RATIO = 5;
-  private static final int HARD_RATIO = 3;
+  private static final int EASY_RATIO = 1;
+  private static final int FIT_RATIO = 7;
+  private static final int HARD_RATIO = 2;
   private static final float MIN_HALF_WIDTH = 3f;
-  private static final float RANDOM_RATIO = 0.2f;
+  private static final float RANDOM_RATIO = 0.05f;
 
   public List<AdaptiveQuoteResponse> getAdaptiveQuotes(
       Long memberId, QuoteLanguage language, int count, List<Long> excludeIds) {


### PR DESCRIPTION
## 주요 내용
- 난이도 가중치를 조정하여 적정 난이도 문장 위주로 서빙
- RANDOM 서빙 비율을 축소하여 적응형 매칭 비중 강화

## 세부 내용
### AdaptiveQuoteService 상수 변경
- `EASY_RATIO` 2 → 1
- `FIT_RATIO` 5 → 7
- `HARD_RATIO` 3 → 2
- `RANDOM_RATIO` 0.2f → 0.05f

### 변경 후 서빙 분포
- 전체 서빙 = RANDOM 5% + ADAPTIVE 95%
- ADAPTIVE 내부 비율: 쉬움 10% / 적정 70% / 어려움 20%
- 최종 분포: RANDOM 5% / 쉬움 9.5% / 적정 66.5% / 어려움 19%

### 변경 배경
- 기존 분포(RANDOM 20% + 적정 40%)에서 중앙 난이도 문장 체감 비중이 과도했음
- 비회원 랜덤 서빙(일 약 2,500건)으로 글로벌 난이도 통계 표본은 충분히 확보되므로 회원 RANDOM 비율을 축소해도 배치 집계 영향 없음
- 신규 회원 cold start는 초기 sigma(15)로 인한 매칭 반경 확대(±7.5)로 자연 보장되어 별도 분기 불필요