### PR TITLE
feat: 폰트를 SUIT + Pretendard JP 조합으로 변경

### DIFF
--- a/tp-react/index.html
+++ b/tp-react/index.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="utf-8"/>
     <link rel="icon" href="/TPfavi.png" type="image/x-icon"/>
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.min.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/sun-typeface/SUIT@2/fonts/variable/woff2/SUIT-Variable.css"/>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-jp.min.css"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <meta name="theme-color" content="#6d28d9"/>
 

--- a/tp-react/src/components/AppDiv/AppDiv.css
+++ b/tp-react/src/components/AppDiv/AppDiv.css
@@ -1,5 +1,9 @@
 * {
     font-family:
+            'SUIT Variable',
+            SUIT,
+            'Pretendard JP Variable',
+            'Pretendard JP',
             system-ui,
             -apple-system,
             BlinkMacSystemFont,

--- a/tp-react/src/components/Head/title/Title.css
+++ b/tp-react/src/components/Head/title/Title.css
@@ -1,4 +1,5 @@
 .title {
+    font-family: 'Pretendard JP Variable', 'Pretendard JP', sans-serif;
     font-size: 1.75rem;
     color: var(--color-text);
     font-weight: 600;

--- a/tp-react/src/index.css
+++ b/tp-react/src/index.css
@@ -138,7 +138,7 @@
    =========================================== */
 body {
     margin: 0;
-    font-family: Pretendard, -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
+    font-family: 'SUIT Variable', SUIT, 'Pretendard JP Variable', 'Pretendard JP', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',
     sans-serif;
     -webkit-font-smoothing: antialiased;


### PR DESCRIPTION
## 주요 내용
- 본문 폰트를 Pretendard에서 SUIT으로 변경
- 일본어는 Pretendard JP로 fallback
- 헤더 로고("Typing Practice")는 Pretendard JP로 고정

## 세부 내용
### index.html
- Pretendard CDN 제거, SUIT Variable + Pretendard JP Variable CDN 추가

### font-family 설정
- AppDiv.css, index.css의 font-family 순서를 'SUIT Variable', SUIT, 'Pretendard JP Variable', 'Pretendard JP', system-ui, ... 로 변경
- 한글/영문/숫자/기호는 SUIT으로 표시
- 일본어 가나/한자는 SUIT에 글리프가 없어 Pretendard JP로 자동 fallback

### 헤더 로고 고정
- Title.css의 .title 클래스에 font-family를 'Pretendard JP Variable', 'Pretendard JP'로 명시
- 서비스 아이덴티티 유지를 위해 본문 폰트 변경과 무관하게 Pretendard 결로 고정