### PR TITLE
fix: 단어 모드 retry 시 word 조회 중복 호출 수정 + 통계 보기 버튼 추가

### DIFF
--- a/tp-react/src/pages/WordMode/components/WordResult/WordResult.css
+++ b/tp-react/src/pages/WordMode/components/WordResult/WordResult.css
@@ -90,6 +90,22 @@
     gap: 0.5rem;
 }
 
+.word-result-stats-link,
+.word-result-login-prompt {
+    border: none;
+    background: transparent;
+    color: var(--color-primary);
+    font-size: 0.9375rem;
+    cursor: pointer;
+    padding: 0;
+    transition: opacity 0.15s;
+}
+
+.word-result-stats-link:hover,
+.word-result-login-prompt:hover {
+    opacity: 0.7;
+}
+
 .word-result-retry-btn {
     display: flex;
     align-items: center;

--- a/tp-react/src/pages/WordMode/components/WordResult/WordResult.jsx
+++ b/tp-react/src/pages/WordMode/components/WordResult/WordResult.jsx
@@ -1,8 +1,8 @@
 import {useEffect, useRef, useCallback} from "react";
+import {useNavigate} from "react-router-dom";
 import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useAuth} from "@/Context/AuthContext.tsx";
 import {useWord} from "../../context/WordContext";
-import {fetchWords} from "@/utils/wordService";
 import {koreanSeparator} from "@/utils/koreanSeparator.ts";
 import {getAnonymousId} from "@/utils/tracking.ts";
 import {saveWordTypingRecord} from "@/utils/wordTypingRecordApi";
@@ -15,8 +15,9 @@ import "./WordResult.css";
 
 const WordResult = () => {
     const {isDark} = useTheme();
-    const {user} = useAuth();
-    const {state, dispatch, startTimeRef} = useWord();
+    const {user, triggerLogin} = useAuth();
+    const navigate = useNavigate();
+    const {state, dispatch} = useWord();
     const {wpm, accuracy, correctWordCount, words, wordIds, difficulty, wordCount, elapsedMs, wordCpms, wordAccs, typos, wordDetails} = state;
     const retryBtnRef = useRef(null);
 
@@ -71,14 +72,12 @@ const WordResult = () => {
     }, 0) + (words.length - 1); // 단어 사이 스페이스
     const cpm = elapsedSec > 0 ? Math.round(totalJamo / (elapsedSec / 60)) : 0;
 
-    const handleRetry = useCallback(async () => {
-        // fetchWords 대기 중 이전 단어가 보이지 않도록 즉시 초기화
+    const handleRetry = useCallback(() => {
+        // dispatch RETRY로 phase를 'typing'으로 전환
+        // → WordTyping이 마운트되며 자체적으로 fetchWords 호출
         dispatch({type: 'RETRY', words: [], wordIds: []});
-        const result = await fetchWords(difficulty, wordCount);
-        startTimeRef.current = null;
         recordSentRef.current = false;
-        dispatch({type: 'RETRY', words: result.words, wordIds: result.wordIds});
-    }, [difficulty, wordCount, dispatch, startTimeRef]);
+    }, [dispatch]);
 
     // Tab → retry 버튼으로 직접 포커스, Enter → retry 실행
     useEffect(() => {
@@ -144,6 +143,16 @@ const WordResult = () => {
 
             {/* 하단 */}
             <div className="word-result-bottom">
+                {user && (
+                    <button className="word-result-stats-link" onClick={() => navigate('/stats')}>
+                        {t('popupViewStats')}
+                    </button>
+                )}
+                {!user && (
+                    <button className="word-result-login-prompt" onClick={() => triggerLogin()}>
+                        {t('popupLoginPrompt')}
+                    </button>
+                )}
                 <button
                     ref={retryBtnRef}
                     className="word-result-retry-btn"

--- a/tp-react/src/pages/WordMode/components/WordResult/WordResultPopup.jsx
+++ b/tp-react/src/pages/WordMode/components/WordResult/WordResultPopup.jsx
@@ -1,7 +1,6 @@
 import {useEffect, useCallback} from "react";
 import {useTheme} from "@/Context/ThemeContext.tsx";
 import {useWord} from "../../context/WordContext";
-import {fetchWords} from "@/utils/wordService";
 import {t} from "@/utils/i18n.ts";
 import "./WordResultPopup.css";
 
@@ -14,17 +13,17 @@ const difficultyLabels = {
 
 const WordResultPopup = () => {
     const {isDark} = useTheme();
-    const {state, dispatch, startTimeRef} = useWord();
+    const {state, dispatch} = useWord();
     const {phase, wpm, accuracy, correctWordCount, words, difficulty, wordCount, elapsedMs} = state;
 
     const totalWords = words.length;
     const elapsedSec = elapsedMs / 1000;
 
-    const handleClose = useCallback(async () => {
-        const result = await fetchWords(difficulty, wordCount);
-        startTimeRef.current = null;
-        dispatch({type: 'RETRY', words: result.words, wordIds: result.wordIds});
-    }, [difficulty, wordCount, dispatch, startTimeRef]);
+    const handleClose = useCallback(() => {
+        // dispatch RETRY로 phase를 'typing'으로 전환
+        // → WordTyping이 마운트되며 자체적으로 fetchWords 호출
+        dispatch({type: 'RETRY', words: [], wordIds: []});
+    }, [dispatch]);
 
     // ESC로 닫기 (= retry)
     useEffect(() => {


### PR DESCRIPTION
## 주요 내용
- 단어 모드 retry 시 fetchWords가 2번 호출되던 문제 수정
- 단어 모드 결과 화면에 자세한 통계 보기 / 로그인 유도 버튼 추가

## 세부 내용
### retry 중복 호출 수정
- WordResult.handleRetry에서 fetchWords 호출 제거
- dispatch RETRY로 phase를 'typing'으로 전환하면 WordTyping이 마운트되며 자체적으로 fetchWords 호출
- 기존: WordResult가 빈 words dispatch → phase 'typing' 전환 → WordTyping 마운트 후 자체 fetchWords + WordResult의 await fetchWords 동시 진행으로 중복 호출 발생
- WordResultPopup도 동일하게 정리 (현재 미사용 컴포넌트지만 패턴 통일)

### 통계 보기 버튼 추가
- 로그인 사용자: 자세한 통계 보기 버튼 → /stats 이동
- 비로그인 사용자: 로그인 유도 버튼 → triggerLogin 호출
- SessionResult와 동일한 UX/스타일 적용