### PR TITLE
refactor: QuoteRepository fetch join 적용으로 N+1 제거

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
@@ -4,7 +4,6 @@ import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.quote.config.SimilarityThresholdProperties;
 import com.typingpractice.typing_practice_be.quote.domain.*;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteIdWithDifficulty;
-import com.typingpractice.typing_practice_be.quote.query.PublicQuoteQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
@@ -136,7 +135,7 @@ public class QuoteRepository {
     return typedQuery.getResultList();
   }
 
-  public List<Quote> findPublicQuotes(PublicQuoteQuery query) {
+  /*public List<Quote> findPublicQuotes(PublicQuoteQuery query) {
     // 랜덤 순서
     em.createNativeQuery("SELECT SETSEED(:seed)")
         .setParameter("seed", query.getSeed())
@@ -190,7 +189,7 @@ public class QuoteRepository {
 
       return typedQuery.getResultList();
     }
-  }
+  }*/
 
   public boolean existsBySentenceHash(String sentenceHash, Long memberId) {
     Long count =
@@ -336,7 +335,8 @@ public class QuoteRepository {
     int page = query.getPage();
     int size = query.getSize();
 
-    String jpql = "select q from Quote q join q.member m where m.id = :memberId";
+    String jpql =
+        "select q from Quote q join q.member m left join fetch q.typingStats where m.id = :memberId";
 
     if (query.getStatus() != null && query.getType() != null) {
       jpql += " and q.status = :status and q.type = :type";
@@ -372,7 +372,7 @@ public class QuoteRepository {
   public List<Quote> findPageByLanguageAndIdRange(
       QuoteLanguage language, Long cursorId, Long maxId, int size) {
     return em.createQuery(
-            "select q from Quote q where q.language = :language and q.id > :cursorId and q.id <= :maxId order by q.id ASC",
+            "select q from Quote q left join fetch q.typingStats where q.language = :language and q.id > :cursorId and q.id <= :maxId order by q.id ASC",
             Quote.class)
         .setParameter("language", language)
         .setParameter("cursorId", cursorId)

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/QuoteTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/QuoteTypingStatsBatchService.java
@@ -88,8 +88,8 @@ public class QuoteTypingStatsBatchService {
           Integer totalAttemptCount = totalAttemptsCount.get(quote.getId());
           if (agg == null) continue; // 통계값이 없는 경우
 
-          QuoteTypingStats stats =
-              quoteTypingStatsRepository.findByQuoteId(quote.getId()).orElse(null);
+          QuoteTypingStats stats = quote.getTypingStats();
+          // quoteTypingStatsRepository.findByQuoteId(quote.getId()).orElse(null);
 
           if (stats == null) {
             // 기존 타이핑 통계가 없으면 생성


### PR DESCRIPTION
## 주요 내용
- @OneToOne mappedBy LAZY 무력화로 발생하던 N+1 쿼리 제거
- 사용 빈도가 높은 회원 문장 조회 및 통계 배치 경로 최적화

## 세부 내용
### QuoteRepository
- findByMember: typingStats fetch join 추가, 회원 문장 페이지 조회 시 페이지 사이즈만큼 발생하던 추가 SELECT 제거
- findPageByLanguageAndIdRange: typingStats fetch join 추가, 통계 배치 페이지 처리 시 PAGE_SIZE 만큼 발생하던 LAZY 무력화 SELECT 제거
- findPublicQuotes: 사용처 없는 dead code 블록 주석 처리

### QuoteTypingStatsBatchService
- findByQuoteId 별도 호출 제거하고 quote.getTypingStats() 사용으로 변경
- fetch join 으로 영속성 컨텍스트에 함께 로드된 인스턴스를 활용하여 dirty checking 으로 동일 동작 유지