### PR TITLE
feat: Quote 삭제 시스템 정비 — 논리 삭제 일관성 + 영구 삭제 기능

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/TestAuthController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/TestAuthController.java
@@ -1,0 +1,46 @@
+package com.typingpractice.typing_practice_be.auth.controller;
+
+import com.typingpractice.typing_practice_be.auth.dto.LoginResponse;
+import com.typingpractice.typing_practice_be.auth.dto.TestLoginRequest;
+import com.typingpractice.typing_practice_be.auth.dto.google.GoogleUserInfo;
+import com.typingpractice.typing_practice_be.auth.service.AuthService;
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.jwt.JwtTokenProvider;
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.member.dto.LoginResult;
+import com.typingpractice.typing_practice_be.member.service.MemberService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Profile("local")
+public class TestAuthController {
+
+  private final AuthService authService;
+  private final MemberService memberService;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @PostMapping("/auth/test")
+  public ApiResponse<LoginResponse> testLogin(@RequestBody TestLoginRequest request) {
+
+    LoginResult loginResult =
+        memberService.loginOrSignIn(
+            GoogleUserInfo.create(
+                request.getProviderId(),
+                "email",
+                "user_" + UUID.randomUUID().toString().substring(0, 8),
+                "picture"));
+
+    Member member = loginResult.getMember();
+
+    String token = jwtTokenProvider.createToken(member.getId(), member.getRole());
+    String refreshToken = authService.createRefreshToken(member);
+
+    return ApiResponse.ok(LoginResponse.from(loginResult, token, refreshToken));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.typingpractice.typing_practice_be.common.security.CustomAuthenticatio
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -20,6 +21,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Configuration
@@ -31,6 +33,7 @@ public class SecurityConfig {
   private final AuthService authService;
   private final CustomAuthenticationEntryPoint authenticationEntryPoint;
   private final CustomAccessDeniedHandler accessDeniedHandler;
+  private final Environment environment;
 
   @Bean
   public JwtAuthenticationFilter jwtAuthenticationFilter(
@@ -40,48 +43,51 @@ public class SecurityConfig {
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    boolean isLocal = Arrays.asList(environment.getActiveProfiles()).contains("local");
+
     http.cors(Customizer.withDefaults())
         .csrf(AbstractHttpConfigurer::disable)
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 안 씀
         .authorizeHttpRequests(
-            auth ->
-                auth
-                    // 인증 불필요
-                    .requestMatchers("/swagger-ui/**", "/api-docs/**")
+            auth -> {
+              if (isLocal) {
+                // 인증 불필요
+                auth.requestMatchers("/swagger-ui/**", "/api-docs/**")
                     .permitAll()
                     .requestMatchers("/auth/test")
-                    .permitAll()
-                    //
-                    .requestMatchers("/auth/google")
-                    .permitAll()
-                    .requestMatchers("/auth/refresh")
-                    .permitAll()
-                    .requestMatchers(HttpMethod.GET, "/quotes")
-                    .permitAll()
-                    .requestMatchers(HttpMethod.GET, "/words")
-                    .permitAll()
-                    .requestMatchers("/error")
-                    .permitAll()
-                    .requestMatchers(HttpMethod.POST, "/typing-records")
-                    .permitAll()
-                    .requestMatchers(HttpMethod.POST, "/word-typing-records")
-                    .permitAll()
-                    .requestMatchers("/actuator/prometheus")
-                    .permitAll()
-                    // 관리자 전용
-                    .requestMatchers("/admin/**")
-                    .hasRole("ADMIN")
+                    .permitAll();
+              }
+              auth.requestMatchers("/auth/google")
+                  .permitAll()
+                  .requestMatchers("/auth/refresh")
+                  .permitAll()
+                  .requestMatchers(HttpMethod.GET, "/quotes")
+                  .permitAll()
+                  .requestMatchers(HttpMethod.GET, "/words")
+                  .permitAll()
+                  .requestMatchers("/error")
+                  .permitAll()
+                  .requestMatchers(HttpMethod.POST, "/typing-records")
+                  .permitAll()
+                  .requestMatchers(HttpMethod.POST, "/word-typing-records")
+                  .permitAll()
+                  .requestMatchers("/actuator/prometheus")
+                  .permitAll()
+                  // 관리자 전용
+                  .requestMatchers("/admin/**")
+                  .hasRole("ADMIN")
 
-                    // BANNED 제외 (USER, ADMIN만)
-                    .requestMatchers(HttpMethod.POST, "/quotes/public")
-                    .hasAnyRole("USER", "ADMIN")
-                    .requestMatchers(HttpMethod.POST, "/quotes/*/publish")
-                    .hasAnyRole("USER", "ADMIN")
-                    .requestMatchers(HttpMethod.POST, "/reports")
-                    .hasAnyRole("USER", "ADMIN")
-                    .anyRequest()
-                    .authenticated())
+                  // BANNED 제외 (USER, ADMIN만)
+                  .requestMatchers(HttpMethod.POST, "/quotes/public")
+                  .hasAnyRole("USER", "ADMIN")
+                  .requestMatchers(HttpMethod.POST, "/quotes/*/publish")
+                  .hasAnyRole("USER", "ADMIN")
+                  .requestMatchers(HttpMethod.POST, "/reports")
+                  .hasAnyRole("USER", "ADMIN")
+                  .anyRequest()
+                  .authenticated();
+            })
         .exceptionHandling(
             ex ->
                 ex.authenticationEntryPoint(authenticationEntryPoint)

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
@@ -14,10 +14,11 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 // @AdminOnly
+@RequestMapping("/admin/quotes")
 public class AdminQuoteController {
   private final AdminQuoteService adminQuoteService;
 
-  @GetMapping("/admin/quotes")
+  @GetMapping()
   public ApiResponse<AdminQuotePaginationResponse> getQuotes(
       @ModelAttribute @Valid QuotePaginationRequest request) {
 
@@ -28,7 +29,7 @@ public class AdminQuoteController {
     return ApiResponse.ok(AdminQuotePaginationResponse.from(result));
   }
 
-  @GetMapping("/admin/quotes/{quoteId}")
+  @GetMapping("/{quoteId}")
   public ApiResponse<AdminQuoteResponse> getQuoteById(@PathVariable Long quoteId) {
     Quote quote = adminQuoteService.findQuoteByIdWithTypingStats(quoteId);
 
@@ -36,7 +37,7 @@ public class AdminQuoteController {
   }
 
   // 승인
-  @PostMapping("/admin/quotes/{quoteId}/approve")
+  @PostMapping("/{quoteId}/approve")
   public ApiResponse<QuoteResponse> approvePendingQuote(@PathVariable Long quoteId) {
 
     Quote quote = adminQuoteService.approvePublish(quoteId);
@@ -45,7 +46,7 @@ public class AdminQuoteController {
   }
 
   // 거부
-  @PostMapping("/admin/quotes/{quoteId}/reject")
+  @PostMapping("/{quoteId}/reject")
   public ApiResponse<QuoteResponse> rejectPendingQuote(@PathVariable Long quoteId) {
 
     Quote quote = adminQuoteService.rejectPublish(quoteId);
@@ -54,7 +55,7 @@ public class AdminQuoteController {
   }
 
   // 공개 문장 수정
-  @PatchMapping("/admin/quotes/{quoteId}")
+  @PatchMapping("/{quoteId}")
   public ApiResponse<QuoteResponse> patchQuote(
       @PathVariable Long quoteId, @RequestBody QuoteUpdateRequest request) {
 
@@ -66,7 +67,7 @@ public class AdminQuoteController {
   }
 
   // 삭제
-  @DeleteMapping("/admin/quotes/{quoteId}")
+  @DeleteMapping("/{quoteId}")
   public ApiResponse<Void> deleteQuote(@PathVariable Long quoteId) {
 
     adminQuoteService.deleteQuote(quoteId);
@@ -74,7 +75,7 @@ public class AdminQuoteController {
     return ApiResponse.ok(null);
   }
 
-  @PatchMapping("/admin/quotes/{quoteId}/hide")
+  @PatchMapping("/{quoteId}/hide")
   public ApiResponse<QuoteResponse> hideQuote(@PathVariable Long quoteId) {
     Quote hideQuote = adminQuoteService.hideQuote(quoteId);
 
@@ -82,11 +83,28 @@ public class AdminQuoteController {
   }
 
   // 숨김 해제
-  @PostMapping("/admin/quotes/{quoteId}/restore")
+  @PostMapping("/{quoteId}/restore")
   public ApiResponse<QuoteResponse> restoreHiddenQuotes(@PathVariable Long quoteId) {
 
     Quote quote = adminQuoteService.cancelHidden(quoteId);
 
     return ApiResponse.ok(QuoteResponse.from(quote));
+  }
+
+  @GetMapping("/deleted")
+  public ApiResponse<DeletedQuotePaginationResponse> getDeletedQuotes(
+      @ModelAttribute @Valid QuotePaginationRequest request) {
+    QuotePaginationQuery query = QuotePaginationQuery.from(request);
+
+    PageResult<Quote> result = adminQuoteService.findDeletedQuotes(query);
+
+    return ApiResponse.ok(DeletedQuotePaginationResponse.from(result));
+  }
+
+  @DeleteMapping("/{quoteId}/permanent")
+  public ApiResponse<Void> permanentDeleteQuote(@PathVariable Long quoteId) {
+    adminQuoteService.permanentDeleteQuote(quoteId);
+
+    return ApiResponse.ok(null);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -35,7 +35,11 @@ public class Quote extends BaseEntity {
 
   @Embedded private QuoteProfile profile;
 
-  @OneToOne(mappedBy = "quote", fetch = FetchType.LAZY)
+  @OneToOne(
+      mappedBy = "quote",
+      fetch = FetchType.LAZY,
+      cascade = CascadeType.REMOVE,
+      orphanRemoval = true)
   private QuoteTypingStats typingStats;
 
   private String sentence;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/DeletedQuotePaginationResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/DeletedQuotePaginationResponse.java
@@ -1,0 +1,24 @@
+package com.typingpractice.typing_practice_be.quote.dto;
+
+import com.typingpractice.typing_practice_be.common.dto.PageResult;
+import com.typingpractice.typing_practice_be.common.dto.PaginationResponse;
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class DeletedQuotePaginationResponse extends PaginationResponse {
+  private List<DeletedQuoteResponse> content;
+
+  protected DeletedQuotePaginationResponse(int page, int size, boolean hasNext) {
+    super(page, size, hasNext);
+  }
+
+  public static DeletedQuotePaginationResponse from(PageResult<Quote> result) {
+    DeletedQuotePaginationResponse response =
+        new DeletedQuotePaginationResponse(result.getPage(), result.getSize(), result.isHasNext());
+
+    response.content = result.getContent().stream().map(DeletedQuoteResponse::from).toList();
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/DeletedQuoteResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/DeletedQuoteResponse.java
@@ -1,0 +1,21 @@
+package com.typingpractice.typing_practice_be.quote.dto;
+
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeletedQuoteResponse extends QuoteResponse {
+  private LocalDateTime deletedAt;
+
+  public static DeletedQuoteResponse from(Quote quote) {
+    DeletedQuoteResponse response = new DeletedQuoteResponse();
+    response.fillFrom(quote);
+    response.deletedAt = quote.getDeletedAt();
+
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
@@ -4,7 +4,6 @@ import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.quote.config.SimilarityThresholdProperties;
 import com.typingpractice.typing_practice_be.quote.domain.*;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteIdWithDifficulty;
-import com.typingpractice.typing_practice_be.quote.query.PublicQuoteQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
@@ -136,7 +135,7 @@ public class QuoteRepository {
     return typedQuery.getResultList();
   }
 
-  public List<Quote> findPublicQuotes(PublicQuoteQuery query) {
+  /*public List<Quote> findPublicQuotes(PublicQuoteQuery query) {
     // 랜덤 순서
     em.createNativeQuery("SELECT SETSEED(:seed)")
         .setParameter("seed", query.getSeed())
@@ -190,7 +189,7 @@ public class QuoteRepository {
 
       return typedQuery.getResultList();
     }
-  }
+  }*/
 
   public boolean existsBySentenceHash(String sentenceHash, Long memberId) {
     Long count =
@@ -336,7 +335,8 @@ public class QuoteRepository {
     int page = query.getPage();
     int size = query.getSize();
 
-    String jpql = "select q from Quote q join q.member m where m.id = :memberId";
+    String jpql =
+        "select q from Quote q join q.member m left join fetch q.typingStats where m.id = :memberId";
 
     if (query.getStatus() != null && query.getType() != null) {
       jpql += " and q.status = :status and q.type = :type";
@@ -372,7 +372,7 @@ public class QuoteRepository {
   public List<Quote> findPageByLanguageAndIdRange(
       QuoteLanguage language, Long cursorId, Long maxId, int size) {
     return em.createQuery(
-            "select q from Quote q where q.language = :language and q.id > :cursorId and q.id <= :maxId order by q.id ASC",
+            "select q from Quote q left join fetch q.typingStats where q.language = :language and q.id > :cursorId and q.id <= :maxId order by q.id ASC",
             Quote.class)
         .setParameter("language", language)
         .setParameter("cursorId", cursorId)

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
@@ -392,4 +392,37 @@ public class QuoteRepository {
         .setParameter("language", language)
         .getSingleResult();
   }
+
+  public List<Quote> findDeletedQuotes(QuotePaginationQuery query) {
+    int page = query.getPage();
+    int size = query.getSize();
+
+    return em.createNativeQuery(
+            "SELECT * FROM quote WHERE deleted = true "
+                + "ORDER BY deleted_at DESC LIMIT :limit OFFSET :offset",
+            Quote.class)
+        .setParameter("limit", size + 1)
+        .setParameter("offset", (page - 1) * size)
+        .getResultList();
+  }
+
+  public Optional<Quote> findDeletedQuoteById(Long quoteId) {
+    List<Quote> results =
+        em.createNativeQuery(
+                "select * from quote where quote_id = :quoteId and deleted = true limit 1",
+                Quote.class)
+            .setParameter("quoteId", quoteId)
+            .getResultList();
+
+    return results.isEmpty() ? Optional.empty() : Optional.of(results.getFirst());
+  }
+
+  public void permanentDeleteQuote(Long quoteId) {
+    em.createNativeQuery("delete from quote_typing_stats where quote_id = :quoteId")
+        .setParameter("quoteId", quoteId)
+        .executeUpdate();
+    em.createNativeQuery("delete from quote where quote_id = :quoteId")
+        .setParameter("quoteId", quoteId)
+        .executeUpdate();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
@@ -10,10 +10,10 @@ import com.typingpractice.typing_practice_be.quote.exception.QuoteNotProcessable
 import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuoteUpdateQuery;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
-import java.util.List;
-
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.repository.ReportRepository;
+import com.typingpractice.typing_practice_be.typingrecord.repository.TypingRecordRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +25,7 @@ public class AdminQuoteService {
   private final QuoteRepository quoteRepository;
   private final ReportRepository reportRepository;
   private final QuoteIdCacheService quoteIdCacheService;
+  private final TypingRecordRepository typingRecordRepository;
 
   @Transactional
   public Quote approvePublish(Long quoteId) {
@@ -120,5 +121,28 @@ public class AdminQuoteService {
     quote.updateStatus(QuoteStatus.HIDDEN);
 
     return quote;
+  }
+
+  public PageResult<Quote> findDeletedQuotes(QuotePaginationQuery query) {
+    List<Quote> deletedQuotes = quoteRepository.findDeletedQuotes(query);
+    boolean hasNext = deletedQuotes.size() > query.getSize();
+    List<Quote> content = hasNext ? deletedQuotes.subList(0, query.getSize()) : deletedQuotes;
+
+    return new PageResult<>(content, query.getPage(), query.getSize(), hasNext);
+  }
+
+  @Transactional
+  public void permanentDeleteQuote(Long quoteId) {
+    Quote quote =
+        quoteRepository.findDeletedQuoteById(quoteId).orElseThrow(QuoteNotFoundException::new);
+
+    Long ownerId = quote.getMember().getId();
+    QuoteLanguage language = quote.getLanguage();
+
+    typingRecordRepository.deleteByQuoteId(quoteId);
+
+    quoteRepository.permanentDeleteQuote(quoteId);
+
+    quoteIdCacheService.invalidateMemberIds(ownerId, language);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.quote.service;
 
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminQuoteService {
   private final QuoteRepository quoteRepository;
   private final ReportRepository reportRepository;
+  private final QuoteIdCacheService quoteIdCacheService;
 
   @Transactional
   public Quote approvePublish(Long quoteId) {
@@ -75,7 +77,12 @@ public class AdminQuoteService {
 
     reports.forEach(report -> report.process(true));
 
+    Long ownerId = targetQuote.getMember().getId();
+    QuoteLanguage language = targetQuote.getLanguage();
+
     quoteRepository.deleteQuote(targetQuote);
+
+    quoteIdCacheService.invalidateMemberIds(ownerId, language);
   }
 
   @Transactional

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
@@ -3,6 +3,8 @@ package com.typingpractice.typing_practice_be.typingrecord.repository;
 import com.typingpractice.typing_practice_be.adaptiveserving.dto.AdaptiveServingRecord;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.typingrecord.domain.TypingRecord;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.bson.Document;
 import org.springframework.data.domain.Sort;
@@ -11,9 +13,6 @@ import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -114,5 +113,11 @@ public class TypingRecordRepository {
         .include("cpm", "accuracy", "quoteDifficulty", "avgCpmSnapshot", "avgAccSnapshot");
 
     return mongoTemplate.find(query, AdaptiveServingRecord.class, "typingRecord");
+  }
+
+  public long deleteByQuoteId(Long quoteId) {
+    return mongoTemplate
+        .remove(Query.query(Criteria.where("quoteId").is(quoteId)), "typingRecord")
+        .getDeletedCount();
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/QuoteTypingStats.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/QuoteTypingStats.java
@@ -7,9 +7,15 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
+@SQLRestriction("deleted = false")
+@SQLDelete(
+    sql =
+        "UPDATE quote_typing_stats SET deleted = true, deleted_at = NOW() where quote_typing_stats_id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuoteTypingStats extends BaseEntity {
   @Id

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/QuoteTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/QuoteTypingStatsBatchService.java
@@ -88,8 +88,8 @@ public class QuoteTypingStatsBatchService {
           Integer totalAttemptCount = totalAttemptsCount.get(quote.getId());
           if (agg == null) continue; // 통계값이 없는 경우
 
-          QuoteTypingStats stats =
-              quoteTypingStatsRepository.findByQuoteId(quote.getId()).orElse(null);
+          QuoteTypingStats stats = quote.getTypingStats();
+          // quoteTypingStatsRepository.findByQuoteId(quote.getId()).orElse(null);
 
           if (stats == null) {
             // 기존 타이핑 통계가 없으면 생성


### PR DESCRIPTION
## 주요 내용
- Quote 논리 삭제 시 자식 엔티티(QuoteTypingStats)와 관련 캐시 일관성 확보
- 저작권 침해 등 특수 상황 대응을 위한 영구 삭제 기능 추가 (2단계 삭제 정책)
- 로컬 전용 디버깅 기능(Swagger, 테스트 로그인)이 prod 환경에 노출되지 않도록 차단
- @OneToOne mappedBy LAZY 무력화로 발생하던 N+1 쿼리 제거

## 배경
- 기존 Quote 논리 삭제는 동작하나, 자식 엔티티(QuoteTypingStats)는 그대로 남고 어드민 삭제 시 member-ids Redis 캐시 무효화가 누락되어 일관성 문제가 존재
- 저작권 문제가 있는 문장은 단순 논리 삭제로는 sentence 컬럼이 DB 에 그대로 남아 보호되지 않음
- Swagger 와 테스트 로그인은 디버깅 편의용이지만 prod 환경 노출 시 보안 위험
- 위 작업 진행 중 QuoteRepository 의 N+1 쿼리 발생 지점 발견하여 함께 정리

## 세부 내용
### Quote 논리 삭제 일관성 보완
- Quote.typingStats 에 cascade=REMOVE, orphanRemoval=true 추가하여 부모 논리 삭제 시 자식도 함께 처리
- QuoteTypingStats 에 @SQLRestriction, @SQLDelete 추가하여 cascade 경로에서도 논리 삭제 동작
- AdminQuoteService.deleteQuote 에서 member-ids Redis 캐시 무효화 누락 보완

### Quote 영구 삭제 기능 추가
- DELETE /admin/quotes/{quoteId}/permanent: 논리 삭제된 quote 를 DB 에서 완전 제거
- GET /admin/quotes/deleted: 영구 삭제 대상 목록 조회 (deletedAt DESC)
- 2단계 삭제 정책: 활성 quote 는 먼저 논리 삭제 → 검토 후 영구 삭제 가능 (실수 방지)
- @SQLDelete 우회를 위해 native query 로 quote_typing_stats → quote 순 물리 삭제
- MongoDB TypingRecord 일괄 삭제로 저작권 흔적 완전 제거
- MongoDB → PostgreSQL → Redis 순서로 처리하여 재시도 idempotent 보장
- AdminQuoteController 의 path 를 클래스 레벨 @RequestMapping("/admin/quotes") 로 통합

### 로컬 전용 기능 prod 환경 차단
- 테스트 로그인 핸들러를 TestAuthController 로 분리하여 @Profile("local") 적용
- SecurityConfig 에서 Environment 주입 후 isLocal 분기로 swagger / 테스트 로그인 권한 규칙 격리
- 컨트롤러 차단(@Profile)과 보안 규칙 차단(isLocal)으로 이중 보호

### QuoteRepository fetch join 적용으로 N+1 제거
- findByMember: typingStats fetch join 추가, 회원 문장 페이지 조회 시 페이지 사이즈만큼 발생하던 추가 SELECT 제거
- findPageByLanguageAndIdRange: typingStats fetch join 추가, 통계 배치 페이지 처리 시 PAGE_SIZE 만큼 발생하던 LAZY 무력화 SELECT 제거
- QuoteTypingStatsBatchService: findByQuoteId 별도 호출 제거하고 quote.getTypingStats() 사용으로 변경
- findPublicQuotes: 사용처 없는 dead code 블록 주석 처리