### PR TITLE
feat: 저작권 정책 강화 + 공지사항 팝업 + v1.8.1

### DIFF
--- a/tp-react/src/components/Contact/Contact.jsx
+++ b/tp-react/src/components/Contact/Contact.jsx
@@ -9,12 +9,18 @@ const Contact = () => {
         <div className={`contact-wrapper ${isDark && "dark"}`}>
             <div className="contact-links">
                 <a
+                    href={"mailto:khn4636@gmail.com"}
+                    className={`contact ${isDark && "dark"}`}
+                >
+                    Email
+                </a>
+                <a
                     href={"https://open.kakao.com/o/sMHDrAog"}
                     target="_blank"
                     rel="noopener noreferrer"
                     className={`contact ${isDark && "dark"}`}
                 >
-                    Contact
+                    KakaoTalk
                 </a>
                 <Link to="/privacy" className={`contact ${isDark && "dark"}`}>
                     Privacy Policy

--- a/tp-react/src/components/NoticePopup/NoticePopup.css
+++ b/tp-react/src/components/NoticePopup/NoticePopup.css
@@ -1,0 +1,93 @@
+.notice-popup-overlay {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.4);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 2000;
+}
+
+.notice-popup {
+    background-color: var(--color-popup-bg);
+    color: var(--color-text);
+    border-radius: 1rem;
+    padding: 2rem;
+    max-width: 480px;
+    width: 90%;
+    max-height: 80vh;
+    overflow-y: auto;
+    border: 1px solid var(--color-border);
+    box-shadow: 0 25px 50px -12px rgba(0, 0, 0, 0.25);
+}
+
+.notice-popup-header {
+    margin-bottom: 1rem;
+}
+
+.notice-popup-date {
+    font-size: 0.75rem;
+    color: var(--color-text-placeholder);
+    display: block;
+    margin-bottom: 0.25rem;
+}
+
+.notice-popup-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0;
+}
+
+.notice-popup-content {
+    font-size: 0.9375rem;
+    line-height: 1.6;
+    color: var(--color-text-muted);
+    margin: 0 0 1.5rem 0;
+    white-space: pre-line;
+}
+
+.notice-popup-actions {
+    padding-top: 1rem;
+    border-top: 1px solid var(--color-border);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.notice-popup-action-btn {
+    width: 100%;
+    padding: 0.625rem;
+    border: none;
+    border-radius: 0.5rem;
+    background-color: var(--color-primary);
+    color: white;
+    font-size: 0.875rem;
+    font-weight: 500;
+    cursor: pointer;
+    transition: opacity 0.15s;
+}
+
+.notice-popup-action-btn:hover {
+    opacity: 0.85;
+}
+
+.notice-popup-close-btn {
+    width: 100%;
+    padding: 0.5rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    background-color: transparent;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+    cursor: pointer;
+    transition: all 0.15s;
+}
+
+.notice-popup-close-btn:hover {
+    color: var(--color-text);
+    border-color: var(--color-text-muted);
+}

--- a/tp-react/src/components/NoticePopup/NoticePopup.tsx
+++ b/tp-react/src/components/NoticePopup/NoticePopup.tsx
@@ -1,0 +1,76 @@
+import {useEffect, useState} from "react";
+import {useNavigate} from "react-router-dom";
+import {Storage_Read_Notices} from "@/const/config.const";
+import {getLatestUnreadPopupNotice, localized, Notice} from "@/data/noticeData";
+import {t} from "@/utils/i18n";
+import "./NoticePopup.css";
+
+const readIds = (): string[] => {
+    try {
+        const raw = localStorage.getItem(Storage_Read_Notices);
+        return raw ? JSON.parse(raw) : [];
+    } catch {
+        return [];
+    }
+};
+
+const markAsRead = (id: string) => {
+    const list = readIds();
+    if (!list.includes(id)) {
+        list.push(id);
+        localStorage.setItem(Storage_Read_Notices, JSON.stringify(list));
+    }
+};
+
+const NoticePopup = () => {
+    const navigate = useNavigate();
+    const [notice, setNotice] = useState<Notice | null>(null);
+
+    useEffect(() => {
+        const target = getLatestUnreadPopupNotice(readIds());
+        if (target) setNotice(target);
+    }, []);
+
+    if (!notice) return null;
+
+    const handleClose = () => {
+        markAsRead(notice.id);
+        setNotice(null);
+    };
+
+    const handleAction = () => {
+        if (!notice.actionLink) return;
+        markAsRead(notice.id);
+        const url = notice.actionLink.url;
+        if (url.startsWith('/')) {
+            navigate(url);
+        } else {
+            window.open(url, '_blank', 'noopener,noreferrer');
+        }
+        setNotice(null);
+    };
+
+    return (
+        <div className="notice-popup-overlay">
+            <div className="notice-popup">
+                <div className="notice-popup-header">
+                    <span className="notice-popup-date">{notice.date}</span>
+                    <h2 className="notice-popup-title">{localized(notice.title)}</h2>
+                </div>
+                <p className="notice-popup-content">{localized(notice.content)}</p>
+                <div className="notice-popup-actions">
+                    {notice.actionLink && (
+                        <button className="notice-popup-action-btn" onClick={handleAction}>
+                            {localized(notice.actionLink.label)}
+                        </button>
+                    )}
+                    <button className="notice-popup-close-btn" onClick={handleClose}>
+                        {t('updateClose')}
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default NoticePopup;

--- a/tp-react/src/const/config.const.ts
+++ b/tp-react/src/const/config.const.ts
@@ -6,6 +6,7 @@ export const Storage_Font_Size = "Typing-Practice-fontSize" as const;
 export const Storage_Averages_Visible = "Typing-Practice-averagesVisible" as const;
 export const Storage_Compact_Mode = "Typing-Practice-compactMode" as const;
 export const Storage_Last_Seen_Version = "Typing-Practice-lastSeenVersion" as const;
+export const Storage_Read_Notices = "Typing-Practice-readNotices" as const;
 export const Storage_Refresh_Token = "Typing-Practice-refreshToken" as const;
 export const Storage_Consent = "Typing-Practice-storageConsent" as const;
 export const Storage_Feature_Guide = "Typing-Practice-featureGuide" as const;

--- a/tp-react/src/data/noticeData.ts
+++ b/tp-react/src/data/noticeData.ts
@@ -1,0 +1,59 @@
+import {lang} from '@/utils/i18n';
+
+interface LocalizedText {
+    ko: string;
+    ja: string;
+    en: string;
+}
+
+export interface Notice {
+    id: string; // localStorage 키 식별자, 한 번 정하면 변경 금지
+    date: string; // YYYY-MM-DD
+    title: LocalizedText;
+    content: LocalizedText;
+    showPopup: boolean; // false면 공지 페이지에만 노출
+    actionLink?: {
+        label: LocalizedText;
+        url: string; // 내부 라우트 또는 외부 URL
+    };
+}
+
+export const noticeList: Notice[] = [
+    {
+        id: 'copyright-policy-2026-05',
+        date: '2026-05-02',
+        showPopup: true,
+        title: {
+            ko: '저작권 정책 안내',
+            ja: '著作権ポリシーのご案内',
+            en: 'Copyright Policy Notice',
+        },
+        content: {
+            ko: '문장 업로드 시 타인의 저작권이 있는 콘텐츠(노래 가사, 시, 소설, 기사 등)를 무단으로 업로드하지 마세요.\n출처를 표시하더라도 저작권자의 허락 없는 업로드는 권리 침해에 해당합니다.\n업로드한 콘텐츠로 인한 모든 법적 책임은 업로드한 본인에게 있으며, 권리 침해 신고가 접수되거나 부적절한 콘텐츠로 판단되는 경우 사전 통보 없이 비공개 또는 삭제될 수 있습니다.',
+            ja: '文章のアップロード時に、他人の著作権がある内容(歌詞、詩、小説、記事など)を無断でアップロードしないでください。出典を表示しても、著作権者の許諾なしのアップロードは権利侵害に該当します。\nアップロードした内容に対するすべての法的責任はアップロードした本人にあり、権利侵害の通報を受けたり、不適切な内容と判断された場合、事前の通知なしに非公開または削除されることがあります。',
+            en: 'When uploading sentences, do not upload copyrighted content (lyrics, poems, novels, articles, etc.) without permission. Citing the source does not exempt unauthorized uploads from being infringement.\nYou are solely responsible for any legal consequences of uploaded content. Content may be hidden or removed without prior notice upon receipt of infringement reports or if deemed inappropriate.',
+        },
+        actionLink: {
+            label: {ko: '약관 보기', ja: '利用規約を見る', en: 'View Terms'},
+            url: '/terms',
+        },
+    },
+];
+
+/**
+ * showPopup이 true인 가장 최근 공지 (사용자가 아직 안 본 것)를 반환
+ */
+export const getLatestUnreadPopupNotice = (readNoticeIds: string[]): Notice | null => {
+    const popupNotices = noticeList.filter(n => n.showPopup);
+    if (popupNotices.length === 0) return null;
+    // 최신순(date desc) 정렬 후 안 본 것 중 첫 번째
+    const sorted = [...popupNotices].sort((a, b) => b.date.localeCompare(a.date));
+    return sorted.find(n => !readNoticeIds.includes(n.id)) || null;
+};
+
+/**
+ * 현재 언어로 LocalizedText 추출
+ */
+export const localized = (text: LocalizedText): string => {
+    return text[lang];
+};

--- a/tp-react/src/data/updateHistory.ts
+++ b/tp-react/src/data/updateHistory.ts
@@ -36,9 +36,34 @@ export function localize(item: LocalizedText): string {
 
 export const updateHistory: UpdateEntry[] = [
     {
+        version: "1.8.1",
+        date: "2026-05-02",
+        showPopup: true,
+        hidden: false,
+        features: [
+            {
+                ko: "Footer에 이메일 문의 채널 추가 (해외 사용자 대상)",
+                ja: "フッターにメール問い合わせチャネル追加（海外ユーザー向け）",
+                en: "Added email contact channel in footer (for international users)"
+            },
+            {
+                ko: "약관 및 개인정보처리방침에 저작권 정책과 신고 절차 안내 추가",
+                ja: "利用規約およびプライバシーポリシーに著作権ポリシーと通報手続きの案内を追加",
+                en: "Added copyright policy and reporting procedure to Terms and Privacy Policy"
+            },
+        ],
+        improvements: [
+            {
+                ko: "문장 업로드 시 입력 줄바꿈은 무시하고, 저작권 정책 동의 체크가 필요하도록 변경",
+                ja: "文章アップロード時、入力の改行は無視し、著作権ポリシーへの同意チェックを必須に変更",
+                en: "Line breaks are ignored when uploading sentences, and copyright policy agreement is now required"
+            },
+        ],
+    },
+    {
         version: "1.8.0",
         date: "2026-04-27",
-        showPopup: true,
+        showPopup: false,
         hidden: false,
         features: [
             {

--- a/tp-react/src/pages/Home/Home.jsx
+++ b/tp-react/src/pages/Home/Home.jsx
@@ -1,6 +1,7 @@
 import {useEffect} from 'react';
 import {useNavigate} from 'react-router-dom';
 import UpdatePopup from './components/UpdatePopup/UpdatePopup';
+import NoticePopup from '../../components/NoticePopup/NoticePopup';
 import SessionResult from './components/SessionResult/SessionResult';
 import Info from './components/Info/Info';
 import Quote from './components/Quote/Quote';
@@ -30,6 +31,7 @@ function Home() {
     return (
         <SettingContextProvider>
             <UpdatePopup/>
+            <NoticePopup/>
             <Info/>
             <QuoteContextProvider>
                 {showPopup ? (

--- a/tp-react/src/pages/PrivacyPolicy/PrivacyPolicy.jsx
+++ b/tp-react/src/pages/PrivacyPolicy/PrivacyPolicy.jsx
@@ -11,7 +11,7 @@ function PrivacyPolicy() {
     return (
         <div className={`privacy-container ${isDark ? 'dark' : ''}`}>
             <h1 className="privacy-title">{isKorean ? '개인정보 처리방침' : 'Privacy Policy'}</h1>
-            <p className="privacy-updated">{isKorean ? '최종 수정일: 2026년 3월 29일' : 'Last updated: March 29, 2026'}</p>
+            <p className="privacy-updated">{isKorean ? '최종 수정일: 2026년 5월 2일' : 'Last updated: May 2, 2026'}</p>
 
             <section className="privacy-section">
                 <h2>{isKorean ? '1. 개요' : '1. Overview'}</h2>
@@ -33,8 +33,24 @@ function PrivacyPolicy() {
                 <h3>{isKorean ? '타이핑 기록' : 'Typing Records'}</h3>
                 <p>
                     {isKorean
-                        ? '로그인 상태에서 타이핑 결과(속도, 정확도, 초기화 횟수, 오타 패턴)를 서버에 저장합니다. 이 데이터는 개인 통계 및 진행 상황 추적에 사용됩니다.'
-                        : 'When you are logged in, we store your typing results including speed (CPM), accuracy, reset count, and typo patterns. This data is used to provide your personal statistics and track your progress.'}
+                        ? '타이핑 결과(속도, 정확도, 초기화 횟수, 오타 패턴)를 서버에 저장합니다. 이 데이터는 개인 통계 및 진행 상황 추적, 그리고 익명의 집계 통계 산출에 사용됩니다.'
+                        : 'We store your typing results including speed (CPM), accuracy, reset count, and typo patterns. This data is used for personal statistics, progress tracking, and aggregated anonymous statistics.'}
+                </p>
+                <h3>{isKorean ? '비회원 식별자 및 세션 정보' : 'Anonymous Identifiers and Session Information'}</h3>
+                <p>
+                    {isKorean
+                        ? '비로그인 사용자가 GDPR 동의 후 서비스를 이용하는 경우, 브라우저 로컬 저장소에 익명 식별자(UUID)를 생성하여 타이핑 기록과 함께 저장합니다. 또한 다음 정보를 함께 수집합니다:'
+                        : 'For non-logged-in users who have consented under GDPR, we generate an anonymous identifier (UUID) in the browser\'s local storage and store it with your typing records. We also collect the following:'}
+                </p>
+                <ul>
+                    <li>{isKorean ? '세션 식별자(sessionId): 브라우저 세션 동안만 유지되며, 사용자 행동 분석에 사용됩니다.' : 'Session identifier (sessionId): retained only during the browser session, used for behavior analysis.'}</li>
+                    <li>{isKorean ? '리퍼러(referrer): 어떤 경로로 서비스에 접속했는지를 파악합니다.' : 'Referrer: identifies how users arrived at the service.'}</li>
+                    <li>{isKorean ? '디바이스 유형(deviceType): 모바일/데스크톱 등 환경별 사용 패턴 분석에 사용됩니다.' : 'Device type: used to analyze usage patterns across mobile/desktop environments.'}</li>
+                </ul>
+                <p>
+                    {isKorean
+                        ? '이 정보는 서비스 개선과 익명 집계 통계 목적으로만 사용되며, 개인을 식별하는 데 사용되지 않습니다. GDPR 동의를 거부한 경우 익명 식별자는 생성되지 않습니다.'
+                        : 'This information is used solely for service improvement and aggregated anonymous statistics, and is not used to identify individuals. If you decline GDPR consent, no anonymous identifier is generated.'}
                 </p>
                 <h3>{isKorean ? '사용자 등록 문장' : 'User-Submitted Sentences'}</h3>
                 <p>
@@ -91,8 +107,8 @@ function PrivacyPolicy() {
                 </ul>
                 <p>
                     {isKorean
-                        ? <>권리 행사를 원하시면 <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">카카오톡</a>으로 문의해 주세요.</>
-                        : <>To exercise these rights, please contact us at <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">KakaoTalk</a>.</>}
+                        ? <>권리 행사를 원하시면 이메일(<a href="mailto:khn4636@gmail.com">khn4636@gmail.com</a>) 또는 <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">카카오톡</a>으로 문의해 주세요.</>
+                        : <>To exercise these rights, please contact us via email (<a href="mailto:khn4636@gmail.com">khn4636@gmail.com</a>) or <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">KakaoTalk</a>.</>}
                 </p>
             </section>
 

--- a/tp-react/src/pages/QuoteUpload/QuoteUpload.css
+++ b/tp-react/src/pages/QuoteUpload/QuoteUpload.css
@@ -150,6 +150,38 @@
     opacity: 0.6;
 }
 
+/* 저작권 경고 박스 */
+.quote-upload-copyright-warning {
+    margin-bottom: 1.5rem;
+    padding: 0.875rem 1rem;
+    border: 1px solid var(--color-border);
+    border-left: 3px solid #f59e0b;
+    border-radius: 0.5rem;
+    background-color: var(--color-bg-secondary);
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+    line-height: 1.5;
+    white-space: pre-line;
+}
+
+/* 약관 동의 체크박스 */
+.quote-upload-agreement {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    margin: 1rem 0;
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    cursor: pointer;
+    user-select: none;
+}
+
+.quote-upload-agreement input[type="checkbox"] {
+    margin-top: 0.2rem;
+    cursor: pointer;
+    accent-color: var(--color-primary);
+}
+
 /* 하단 버튼 */
 .quote-upload-actions {
     display: flex;
@@ -192,7 +224,8 @@
 }
 
 .quote-upload-submit-btn:disabled {
-    background-color: var(--color-border);
+    background-color: var(--color-primary);
+    opacity: 0.4;
     cursor: not-allowed;
 }
 

--- a/tp-react/src/pages/QuoteUpload/QuoteUpload.jsx
+++ b/tp-react/src/pages/QuoteUpload/QuoteUpload.jsx
@@ -21,6 +21,7 @@ function QuoteUpload() {
     const [showConfirm, setShowConfirm] = useState(false);
     const [confirmMessage, setConfirmMessage] = useState('');
     const [isResultPopup, setIsResultPopup] = useState(false);
+    const [agreedToTerms, setAgreedToTerms] = useState(false);
 
     // 초기화 완료 후 로그인 안 되어 있으면 홈으로 이동
     useEffect(() => {
@@ -92,6 +93,12 @@ function QuoteUpload() {
 
         if (validEntries.length === 0) {
             showError(t('enterAtLeastOne'));
+            return;
+        }
+
+        // 약관 동의 필수 (공개/비공개 무관)
+        if (!agreedToTerms) {
+            showError(t('mustAgreeCopyrightPolicy'));
             return;
         }
 
@@ -215,6 +222,10 @@ function QuoteUpload() {
                 </span>
             </div>
 
+            <div className="quote-upload-copyright-warning">
+                {t('uploadCopyrightWarning')}
+            </div>
+
             <div className="quote-upload-entries">
                 {entries.map((entry, index) => (
                     <UploadEntry
@@ -241,6 +252,15 @@ function QuoteUpload() {
                 </span>
             </button>
 
+            <label className="quote-upload-agreement">
+                <input
+                    type="checkbox"
+                    checked={agreedToTerms}
+                    onChange={(e) => setAgreedToTerms(e.target.checked)}
+                />
+                <span>{t('uploadAgreement')}</span>
+            </label>
+
             <div className="quote-upload-actions">
                 <button className="quote-upload-cancel-btn" onClick={() => navigate('/')}>
                     {t('cancel')}
@@ -248,7 +268,7 @@ function QuoteUpload() {
                 <button
                     className="quote-upload-submit-btn"
                     onClick={handleUploadClick}
-                    disabled={isUploading}
+                    disabled={isUploading || !agreedToTerms || getValidEntries().length === 0}
                 >
                     {isUploading ? (
                         <>

--- a/tp-react/src/pages/QuoteUpload/components/UploadEntry.tsx
+++ b/tp-react/src/pages/QuoteUpload/components/UploadEntry.tsx
@@ -26,9 +26,18 @@ const UploadEntry = ({entry, index, showDelete, onUpdate, onRemove}: UploadEntry
         e: React.ChangeEvent<HTMLTextAreaElement>,
         field: 'sentence' | 'author',
     ) => {
+        // 줄바꿈 제거 (붙여넣기로 들어온 경우 포함)
+        const value = e.target.value.replace(/[\r\n]+/g, '');
+        e.target.value = value;
         e.target.style.height = 'auto';
         e.target.style.height = e.target.scrollHeight + 'px';
-        onUpdate(entry.id, field, e.target.value);
+        onUpdate(entry.id, field, value);
+    };
+
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        if (e.key === 'Enter') {
+            e.preventDefault();
+        }
     };
 
     return (
@@ -67,6 +76,7 @@ const UploadEntry = ({entry, index, showDelete, onUpdate, onRemove}: UploadEntry
                         maxLength={MAX_SENTENCE_LENGTH}
                         value={entry.sentence}
                         onChange={(e) => handleTextareaChange(e, 'sentence')}
+                        onKeyDown={handleKeyDown}
                         rows={1}
                     />
                     <span
@@ -81,6 +91,7 @@ const UploadEntry = ({entry, index, showDelete, onUpdate, onRemove}: UploadEntry
                         maxLength={MAX_AUTHOR_LENGTH}
                         value={entry.author}
                         onChange={(e) => handleTextareaChange(e, 'author')}
+                        onKeyDown={handleKeyDown}
                         rows={1}
                     />
                 </div>

--- a/tp-react/src/pages/Stats/Stats.jsx
+++ b/tp-react/src/pages/Stats/Stats.jsx
@@ -137,13 +137,13 @@ function Stats() {
                         className={`stats-mode-btn ${mode === 'sentence' ? 'active' : ''}`}
                         onClick={() => setMode('sentence')}
                     >
-                        {t('sentenceMode')}
+                        {t('statsSentenceMode')}
                     </button>
                     <button
                         className={`stats-mode-btn ${mode === 'word' ? 'active' : ''}`}
                         onClick={() => setMode('word')}
                     >
-                        {t('wordMode')}
+                        {t('statsWordMode')}
                     </button>
                 </div>
                 <button className="stats-refresh-btn" onClick={handleRefresh} title="새로고침">

--- a/tp-react/src/pages/TermsOfService/TermsOfService.jsx
+++ b/tp-react/src/pages/TermsOfService/TermsOfService.jsx
@@ -11,7 +11,7 @@ function TermsOfService() {
     return (
         <div className={`terms-container ${isDark ? 'dark' : ''}`}>
             <h1 className="terms-title">{isKorean ? '서비스 이용약관' : 'Terms of Service'}</h1>
-            <p className="terms-updated">{isKorean ? '최종 수정일: 2026년 3월 29일' : 'Last updated: March 29, 2026'}</p>
+            <p className="terms-updated">{isKorean ? '최종 수정일: 2026년 5월 2일' : 'Last updated: May 2, 2026'}</p>
 
             <section className="terms-section">
                 <h2>{isKorean ? '1. 서비스 소개' : '1. About the Service'}</h2>
@@ -40,16 +40,52 @@ function TermsOfService() {
             </section>
 
             <section className="terms-section">
-                <h2>{isKorean ? '3. 사용자 콘텐츠' : '3. User Content'}</h2>
+                <h2>{isKorean ? '3. 사용자 콘텐츠 및 저작권' : '3. User Content and Copyright'}</h2>
                 <p>
                     {isKorean
-                        ? '사용자가 업로드한 문장은 공개 설정 시 다른 사용자에게 노출될 수 있습니다. 저작권이 있는 문장을 업로드하는 경우 그에 대한 책임은 업로드한 사용자에게 있습니다. 부적절한 문장은 관리자에 의해 삭제될 수 있습니다.'
-                        : 'Sentences uploaded by users may be visible to other users when set to public. Users are responsible for any copyrighted content they upload. Inappropriate sentences may be removed by administrators.'}
+                        ? '사용자가 업로드한 문장은 공개 설정 시 다른 사용자에게 노출될 수 있습니다. 사용자는 다음 사항에 동의하고 책임을 집니다:'
+                        : 'Sentences uploaded by users may be visible to other users when set to public. By uploading, users agree to the following:'}
+                </p>
+                <ul>
+                    <li>{isKorean ? '타인의 저작권, 초상권, 명예, 기타 권리를 침해하는 콘텐츠를 업로드하지 않습니다.' : 'Do not upload content that infringes on copyrights, portrait rights, reputation, or other rights of others.'}</li>
+                    <li>{isKorean ? '노래 가사, 시, 소설, 기사 등 저작권이 있는 콘텐츠를 무단으로 업로드하지 않습니다. 출처를 표시하더라도 저작권자의 허락 없는 업로드는 권리 침해에 해당합니다.' : 'Do not upload copyrighted content such as lyrics, poems, novels, or articles without permission. Citing the source does not exempt unauthorized uploads from being infringement.'}</li>
+                    <li>{isKorean ? '업로드한 콘텐츠로 인한 모든 법적 책임은 업로드한 사용자 본인에게 있습니다.' : 'All legal responsibility for uploaded content rests with the uploading user.'}</li>
+                    <li>{isKorean ? '운영자는 업로드된 콘텐츠를 사전에 검증하지 않으며, 권리 침해 신고가 접수되거나 부적절한 콘텐츠로 판단되는 경우 사전 통보 없이 비공개 또는 삭제할 수 있습니다.' : 'The operator does not pre-screen uploaded content. Content may be hidden or deleted without prior notice upon receiving infringement reports or when judged inappropriate.'}</li>
+                    <li>{isKorean ? '권리 침해로 인해 운영자에게 손해가 발생한 경우, 업로드한 사용자에게 구상권을 청구할 수 있습니다.' : 'If the operator suffers damages due to rights infringement, the uploading user may be liable for indemnification.'}</li>
+                </ul>
+            </section>
+
+            <section className="terms-section">
+                <h2>{isKorean ? '4. 저작권 침해 신고' : '4. Copyright Infringement Reports'}</h2>
+                <p>
+                    {isKorean
+                        ? '본 서비스에 업로드된 콘텐츠가 귀하의 저작권을 침해한다고 판단되시면 아래 절차에 따라 신고해 주시기 바랍니다.'
+                        : 'If you believe content uploaded to this service infringes your copyright, please follow the procedure below to file a report.'}
+                </p>
+                <p>
+                    <strong>{isKorean ? '신고 시 포함사항' : 'Information to include in your report'}</strong>
+                </p>
+                <ul>
+                    <li>{isKorean ? '신고자 성명 및 연락처' : 'Reporter\'s name and contact information'}</li>
+                    <li>{isKorean ? '침해받은 저작물 정보 (제목, 저작자 등)' : 'Information about the infringed work (title, author, etc.)'}</li>
+                    <li>{isKorean ? '침해 콘텐츠의 위치 또는 식별 정보 (URL, 문장 내용 등)' : 'Location or identification of the infringing content (URL, sentence text, etc.)'}</li>
+                    <li>{isKorean ? '신고자가 저작권자 본인 또는 정당한 대리인임을 확인하는 진술' : 'Statement confirming you are the copyright owner or an authorized agent'}</li>
+                    <li>{isKorean ? '신고 내용이 사실임을 서약하는 문구' : 'A statement that the information in the report is accurate'}</li>
+                </ul>
+                <p>
+                    {isKorean
+                        ? <>신고는 이메일(<a href="mailto:khn4636@gmail.com">khn4636@gmail.com</a>) 또는 <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">카카오톡</a>으로 접수해 주시기 바랍니다. 신고 접수 후 영업일 기준 3~7일 이내에 검토 후 조치하며, 결과를 신고자에게 통지합니다.</>
+                        : <>Please submit reports via email (<a href="mailto:khn4636@gmail.com">khn4636@gmail.com</a>) or <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">KakaoTalk</a>. Reports will be reviewed within 3-7 business days after receipt, and the result will be communicated to the reporter.</>}
+                </p>
+                <p>
+                    {isKorean
+                        ? '반복적으로 권리 침해 콘텐츠를 업로드하는 사용자의 계정은 영구 정지될 수 있습니다.'
+                        : 'Accounts of users who repeatedly upload infringing content may be permanently suspended.'}
                 </p>
             </section>
 
             <section className="terms-section">
-                <h2>{isKorean ? '4. 계정' : '4. Accounts'}</h2>
+                <h2>{isKorean ? '5. 계정' : '5. Accounts'}</h2>
                 <p>
                     {isKorean
                         ? 'Google OAuth를 통해 로그인하며, 별도의 비밀번호를 저장하지 않습니다. 계정 삭제를 원하시면 문의해 주세요.'
@@ -58,7 +94,7 @@ function TermsOfService() {
             </section>
 
             <section className="terms-section">
-                <h2>{isKorean ? '5. 서비스 변경 및 중단' : '5. Service Changes and Termination'}</h2>
+                <h2>{isKorean ? '6. 서비스 변경 및 중단' : '6. Service Changes and Termination'}</h2>
                 <p>
                     {isKorean
                         ? '서비스는 사전 공지 없이 변경되거나 중단될 수 있습니다. 무료 서비스이므로 서비스 중단으로 인한 책임을 지지 않습니다.'
@@ -67,7 +103,7 @@ function TermsOfService() {
             </section>
 
             <section className="terms-section">
-                <h2>{isKorean ? '6. 면책 조항' : '6. Disclaimer'}</h2>
+                <h2>{isKorean ? '7. 면책 조항' : '7. Disclaimer'}</h2>
                 <p>
                     {isKorean
                         ? '서비스는 "있는 그대로" 제공되며, 명시적이거나 묵시적인 어떠한 보증도 하지 않습니다. 서비스 이용으로 인해 발생하는 손해에 대해 책임을 지지 않습니다.'
@@ -76,7 +112,7 @@ function TermsOfService() {
             </section>
 
             <section className="terms-section">
-                <h2>{isKorean ? '7. 약관 변경' : '7. Changes to These Terms'}</h2>
+                <h2>{isKorean ? '8. 약관 변경' : '8. Changes to These Terms'}</h2>
                 <p>
                     {isKorean
                         ? '이 약관은 수시로 업데이트될 수 있습니다. 변경 사항은 이 페이지에 수정 날짜와 함께 반영됩니다.'
@@ -85,11 +121,11 @@ function TermsOfService() {
             </section>
 
             <section className="terms-section">
-                <h2>{isKorean ? '8. 문의' : '8. Contact'}</h2>
+                <h2>{isKorean ? '9. 문의' : '9. Contact'}</h2>
                 <p>
                     {isKorean
-                        ? <>서비스 이용에 관한 문의는 <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">카카오톡</a>으로 연락해 주세요.</>
-                        : <>For inquiries about the service, please contact us at <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">KakaoTalk</a>.</>}
+                        ? <>서비스 이용에 관한 문의는 이메일(<a href="mailto:khn4636@gmail.com">khn4636@gmail.com</a>) 또는 <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">카카오톡</a>으로 연락해 주세요.</>
+                        : <>For inquiries about the service, please contact us via email (<a href="mailto:khn4636@gmail.com">khn4636@gmail.com</a>) or <a href="https://open.kakao.com/o/sMHDrAog" target="_blank" rel="noopener noreferrer">KakaoTalk</a>.</>}
                 </p>
             </section>
 

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -1,5 +1,5 @@
-type Lang = 'ko' | 'ja' | 'en';
-const lang: Lang = navigator.language.startsWith('ko') ? 'ko' : navigator.language.startsWith('ja') ? 'ja' : 'en';
+export type Lang = 'ko' | 'ja' | 'en';
+export const lang: Lang = navigator.language.startsWith('ko') ? 'ko' : navigator.language.startsWith('ja') ? 'ja' : 'en';
 document.documentElement.lang = lang;
 const l = (ko: string, ja: string, en: string) => lang === 'ko' ? ko : lang === 'ja' ? ja : en;
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
@@ -121,6 +121,21 @@ const translations = {
     // 업로드 페이지
     uploadTitle: l('문장 업로드', '文章アップロード', 'Upload Sentences'),
     uploadTypeHint: l('각 문장마다 공개/비공개를 선택할 수 있습니다.', '各文章ごとに公開/非公開を選択できます。', 'You can set each sentence as public or private.'),
+    uploadCopyrightWarning: l(
+        '⚠️ 노래 가사, 시, 소설, 기사 등 타인의 저작권이 있는 콘텐츠는 출처를 표시하더라도 무단 업로드 시 권리 침해에 해당합니다.\n업로드한 콘텐츠로 인한 모든 법적 책임은 업로드한 본인에게 있습니다.\n* 입력 시 줄바꿈은 적용되지 않습니다.',
+        '⚠️ 歌詞、詩、小説、記事など他人の著作権がある内容は、出典を表示しても無断アップロードは権利侵害に該当します。\nアップロードした内容による法的責任はすべてアップロードした本人にあります。\n* 入力時、改行は適用されません。',
+        '⚠️ Copyrighted content (lyrics, poems, novels, articles, etc.) is considered infringement when uploaded without permission, even if the source is cited.\nYou are solely responsible for any legal consequences arising from the content you upload.\n* Line breaks are not applied to inputs.'
+    ),
+    uploadAgreement: l(
+        '저작권 정책에 동의하며, 업로드한 콘텐츠로 인한 모든 책임이 본인에게 있음을 확인합니다.',
+        '著作権ポリシーに同意し、アップロードした内容に対するすべての責任が本人にあることを確認します。',
+        'I agree to the copyright policy and acknowledge that I am solely responsible for the content I upload.'
+    ),
+    mustAgreeCopyrightPolicy: l(
+        '공개 문장 업로드를 위해 저작권 정책에 동의해주세요.',
+        '公開文章アップロードのために著作権ポリシーに同意してください。',
+        'Please agree to the copyright policy to upload public sentences.'
+    ),
     uploadTooltipPublic: l('관리자 승인 후 모든 사용자에게 노출됩니다.', '管理者の承認後、すべてのユーザーに公開されます。', 'Visible to all users after admin approval.'),
     uploadTooltipPrivate: l('본인만 사용할 수 있습니다.', '自分だけが使用できます。', 'Only visible to you.'),
     sentencePlaceholder: (min: number, max: number) => l(`문장을 입력하세요 (${min}-${max}자)`, `文章を入力してください（${min}〜${max}文字）`, `Enter a sentence (${min}-${max} characters)`),
@@ -161,8 +176,8 @@ const translations = {
     practiceCount: l('연습 횟수', '練習回数', 'Practices'),
     wordsAttempted: l('단어 수', '単語数', 'Words'),
     totalWordsAttempted: l('누적 단어', '累積単語', 'Total Words'),
-    sentenceMode: l('문장', '文章', 'Sentence'),
-    wordMode: l('단어', '単語', 'Word'),
+    statsSentenceMode: l('문장', '文章', 'Sentence'),
+    statsWordMode: l('단어', '単語', 'Word'),
     totalAverage: l('전체 평균', '全体平均', 'Overall Avg'),
     avgReset: l('평균 초기화', '平均リセット', 'Avg Resets'),
     vsOverall: l('vs 전체', 'vs 全体', 'vs overall'),


### PR DESCRIPTION
## 주요 내용
- 약관 및 개인정보처리방침에 저작권 정책과 신고 절차 추가
- 문장 업로드 페이지에 저작권 경고와 동의 체크박스 추가
- 공지사항 팝업 시스템 신규 도입
- Footer에 이메일 문의 채널 추가

## 세부 내용
### 약관 및 개인정보처리방침
- TermsOfService: 사용자 콘텐츠 섹션을 저작권 책임 명시 형태로 강화, 저작권 침해 신고 섹션 신규 추가 (신고 시 포함사항, 신고 채널, 처리 일정, 반복 침해자 영구 정지 정책)
- PrivacyPolicy: 비회원 식별자(anonymousId)와 세션 정보(sessionId, referrer, deviceType) 수집 안내 추가
- 신고/문의 채널을 이메일과 카카오톡 두 가지로 안내
- 최종 수정일 2026-05-02로 갱신

### 문장 업로드 페이지
- 저작권 경고 박스 추가 (노란색 좌측 보더)
- 약관 동의 체크박스 추가 — 공개/비공개 무관 항상 필수
- 업로드 버튼 비활성화 조건 추가: 업로드 중, 동의 미체크, 문장 미입력
- disabled 색상을 primary + opacity 0.4로 변경 (다크모드 가독성)
- 입력 시 줄바꿈 차단 — Enter 키 무시 + 붙여넣기 시 \r\n 자동 제거
- 줄바꿈 포함 텍스트 붙여넣기 시 textarea 높이가 비정상적으로 늘어나던 버그 수정

### Footer
- Contact 단일 링크를 Email + KakaoTalk 두 링크로 분리 (해외 사용자 대응)

### 공지사항 팝업
- noticeData.ts 신규 — Notice 인터페이스, 공지 목록, 헬퍼 함수
- NoticePopup.tsx + CSS 신규 — 오버레이 클릭 닫기 없음, 닫기 버튼 또는 액션 버튼으로만 닫힘
- Storage_Read_Notices localStorage 키 추가
- 첫 공지: 저작권 정책 안내 + 약관 페이지 링크
- Home에 NoticePopup 추가

### i18n 정리
- sentenceMode/wordMode 키 중복 정의 분리: Stats 페이지 토글용을 statsSentenceMode/statsWordMode로 변경
- lang 변수 export로 변경 (외부 모듈에서 현재 언어 참조 가능)
- 업로드 관련 키 추가: uploadCopyrightWarning, uploadAgreement, mustAgreeCopyrightPolicy

### updateHistory v1.8.1
- 사용자 대상 변경사항 정리 (결과 화면 페이지 전환, 항목별 로딩, 폰트 변경, 단어 모드 깜빡임 수정 등)
- v1.8.0 showPopup false로 변경