### PR TITLE
feat: 공지사항 도메인 기반 구조 추가

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -44,7 +44,9 @@ public enum ErrorCode {
   REPORT_NOT_PROCESSABLE(HttpStatus.BAD_REQUEST, "처리할 수 없는 신고 내역입니다."),
 
   DAILY_REPORT_LIMIT(HttpStatus.CONFLICT, "하루 신고 제한 횟수에 도달했습니다."),
-  DAILY_QUOTE_UPLOAD_LIMIT(HttpStatus.CONFLICT, "하루 업로드 제한 횟수에 도달했습니다.");
+  DAILY_QUOTE_UPLOAD_LIMIT(HttpStatus.CONFLICT, "하루 업로드 제한 횟수에 도달했습니다."),
+
+  ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AnnouncementController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AnnouncementController.java
@@ -1,0 +1,20 @@
+package com.typingpractice.typing_practice_be.notice.announcement.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/notice/announcement")
+public class AnnouncementController {
+  @GetMapping("")
+  public ApiResponse<Void> getAnnouncements() {
+    return ApiResponse.ok(null);
+  }
+
+  @GetMapping("/recent")
+  public ApiResponse<Void> getRecentAnnouncement() {
+    return ApiResponse.ok(null);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/domain/Announcement.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/domain/Announcement.java
@@ -1,0 +1,68 @@
+package com.typingpractice.typing_practice_be.notice.announcement.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@SQLRestriction("deleted = false")
+@SQLDelete(
+    sql = "UPDATE announcement SET deleted = true, deleted_at = NOW() WHERE announcement_id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Announcement extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "announcement_id")
+  private Long id;
+
+  @Column(columnDefinition = "timestamp with time zone", nullable = false)
+  private LocalDateTime postedAt;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private LocalizedText title;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private LocalizedText content;
+
+  @Column(nullable = false)
+  private boolean published = true;
+
+  public static Announcement create(
+      LocalDateTime postedAt, LocalizedText title, LocalizedText content) {
+    Announcement a = new Announcement();
+    a.postedAt = postedAt;
+    a.title = title;
+    a.content = content;
+    a.published = true;
+    return a;
+  }
+
+  public void update(LocalDateTime postedAt, LocalizedText title, LocalizedText content) {
+    this.postedAt = postedAt;
+    this.title = title;
+    this.content = content;
+  }
+
+  public void publish() {
+    this.published = true;
+  }
+
+  public void unpublish() {
+    this.published = false;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/exception/AnnouncementNotFoundException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/exception/AnnouncementNotFoundException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.notice.announcement.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class AnnouncementNotFoundException extends BusinessException {
+  public AnnouncementNotFoundException() {
+    super(ErrorCode.ANNOUNCEMENT_NOT_FOUND);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/repository/AnnouncementRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/repository/AnnouncementRepository.java
@@ -1,0 +1,57 @@
+package com.typingpractice.typing_practice_be.notice.announcement.repository;
+
+import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class AnnouncementRepository {
+  private final EntityManager em;
+
+  public Announcement save(Announcement announcement) {
+    em.persist(announcement);
+    return announcement;
+  }
+
+  public Optional<Announcement> findById(Long id) {
+    return Optional.ofNullable(em.find(Announcement.class, id));
+  }
+
+  public Optional<Announcement> findLatestPublished() {
+    return em.createQuery(
+            "select a from Announcement a "
+                + "where a.published = true "
+                + "order by a.postedAt desc",
+            Announcement.class)
+        .setMaxResults(1)
+        .getResultStream()
+        .findFirst();
+  }
+
+  public List<Announcement> findPublishedRecent(int limit) {
+    return em.createQuery(
+            "select a from Announcement a "
+                + "where a.published = true "
+                + "order by a.postedAt desc",
+            Announcement.class)
+        .setMaxResults(limit)
+        .getResultList();
+  }
+
+  public List<Announcement> findAllForAdmin(int page, int size) {
+    return em.createQuery(
+            "select a from Announcement a order by a.postedAt desc", Announcement.class)
+        .setFirstResult((page - 1) * size)
+        .setMaxResults(size)
+        .getResultList();
+  }
+
+  public void delete(Announcement announcement) {
+    em.remove(announcement);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/domain/LocalizedText.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/domain/LocalizedText.java
@@ -1,0 +1,3 @@
+package com.typingpractice.typing_practice_be.notice.domain;
+
+public record LocalizedText(String ko, String en, String ja) {}


### PR DESCRIPTION
## 주요 내용
- notice 패키지 하위에 announcement 도메인 신설
- 다국어 데이터를 위한 LocalizedText 공유 record 추가
- 공지사항 조회/생성/삭제를 위한 엔티티와 리포지토리 골격 마련

## 세부 내용
### 공통
- ErrorCode에 ANNOUNCEMENT_NOT_FOUND 추가

### Notice 공통 도메인
- LocalizedText record 추가 (ko 필수, en/ja 선택)

### Announcement 도메인
- Announcement 엔티티 추가
  - postedAt, title/content (JSONB), published 플래그
  - BaseEntity 상속으로 createdAt/updatedAt/soft delete 적용
  - publish/unpublish 도메인 메서드 제공
- AnnouncementRepository 추가
  - save, findById, delete
  - findLatestPublished (공개용 최신 1건)
  - findPublishedRecent (공개용 최근 N건)
  - findAllForAdmin (어드민용 페이지네이션)
- AnnouncementNotFoundException 추가
- AnnouncementController 스켈레톤 추가 (목록/최신 엔드포인트만 선언)