### PR TITLE
feat: 공지사항 도메인 구현 (DTO/Repository/Service)

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/dto/CursorPage.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/dto/CursorPage.java
@@ -1,0 +1,16 @@
+package com.typingpractice.typing_practice_be.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class CursorPage<T, C> {
+	private final List<T> content;
+	private final C nextCursor;
+	private final boolean hasNext;
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AdminAnnouncementController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AdminAnnouncementController.java
@@ -1,0 +1,40 @@
+package com.typingpractice.typing_practice_be.notice.announcement.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/announcements")
+@RequiredArgsConstructor
+public class AdminAnnouncementController {
+  @PostMapping
+  public ApiResponse<Void> postAnnouncement() {
+    return ApiResponse.ok(null);
+  }
+
+  @PatchMapping("/{id}")
+  public ApiResponse<Void> patchAnnouncement(@PathVariable Long id) {
+    return ApiResponse.ok(null);
+  }
+
+  @DeleteMapping("/{id}")
+  public ApiResponse<Void> deleteAnnouncement(@PathVariable Long id) {
+    return ApiResponse.ok(null);
+  }
+
+  @GetMapping
+  public ApiResponse<Void> getAnnouncements() {
+    return ApiResponse.ok(null);
+  }
+
+  @GetMapping("/pinned")
+  public ApiResponse<Void> getPinnedAnnouncements() {
+    return ApiResponse.ok(null);
+  }
+
+  @GetMapping("/{id}")
+  public ApiResponse<Void> getAnnouncementById(@PathVariable Long id) {
+    return ApiResponse.ok(null);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AnnouncementController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AnnouncementController.java
@@ -2,19 +2,30 @@ package com.typingpractice.typing_practice_be.notice.announcement.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/notice/announcement")
+@RequestMapping("/announcements")
 public class AnnouncementController {
-  @GetMapping("")
-  public ApiResponse<Void> getAnnouncements() {
-    return ApiResponse.ok(null);
-  }
+	@GetMapping
+	public ApiResponse<Void> getAnnouncements() {
+		return ApiResponse.ok(null);
+	}
 
-  @GetMapping("/recent")
-  public ApiResponse<Void> getRecentAnnouncement() {
-    return ApiResponse.ok(null);
-  }
+	@GetMapping("/latest")
+	public ApiResponse<Void> getLatestAnnouncement() {
+		return ApiResponse.ok(null);
+	}
+
+	@GetMapping("/pinned")
+	public ApiResponse<Void> getPinnedAnnouncement() {
+		return ApiResponse.ok(null);
+	}
+
+	@GetMapping("/{id}")
+	public ApiResponse<Void> getAnnouncementById(@PathVariable Long id) {
+		return ApiResponse.ok(null);
+	}
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/domain/Announcement.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/domain/Announcement.java
@@ -20,49 +20,58 @@ import java.time.LocalDateTime;
 @Getter
 @SQLRestriction("deleted = false")
 @SQLDelete(
-    sql = "UPDATE announcement SET deleted = true, deleted_at = NOW() WHERE announcement_id = ?")
+				sql = "UPDATE announcement SET deleted = true, deleted_at = NOW() WHERE announcement_id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Announcement extends BaseEntity {
-  @Id
-  @GeneratedValue
-  @Column(name = "announcement_id")
-  private Long id;
+	@Id
+	@GeneratedValue
+	@Column(name = "announcement_id")
+	private Long id;
 
-  @Column(columnDefinition = "timestamp with time zone", nullable = false)
-  private LocalDateTime postedAt;
+	@Column(columnDefinition = "timestamp with time zone", nullable = false)
+	private LocalDateTime postedAt;
 
-  @JdbcTypeCode(SqlTypes.JSON)
-  @Column(columnDefinition = "jsonb", nullable = false)
-  private LocalizedText title;
+	@JdbcTypeCode(SqlTypes.JSON)
+	@Column(columnDefinition = "jsonb", nullable = false)
+	private LocalizedText title;
 
-  @JdbcTypeCode(SqlTypes.JSON)
-  @Column(columnDefinition = "jsonb", nullable = false)
-  private LocalizedText content;
+	@JdbcTypeCode(SqlTypes.JSON)
+	@Column(columnDefinition = "jsonb", nullable = false)
+	private LocalizedText content;
 
-  @Column(nullable = false)
-  private boolean published = true;
+	@Column(nullable = false)
+	private boolean published = true;
 
-  public static Announcement create(
-      LocalDateTime postedAt, LocalizedText title, LocalizedText content) {
-    Announcement a = new Announcement();
-    a.postedAt = postedAt;
-    a.title = title;
-    a.content = content;
-    a.published = true;
-    return a;
-  }
+	@Column(nullable = false)
+	private boolean pinned;
 
-  public void update(LocalDateTime postedAt, LocalizedText title, LocalizedText content) {
-    this.postedAt = postedAt;
-    this.title = title;
-    this.content = content;
-  }
+	public static Announcement create(
+					LocalDateTime postedAt,
+					LocalizedText title,
+					LocalizedText content,
+					boolean published,
+					boolean pinned) {
+		Announcement a = new Announcement();
+		a.postedAt = postedAt;
+		a.title = title;
+		a.content = content;
+		a.published = published;
+		a.pinned = pinned;
+		return a;
+	}
 
-  public void publish() {
-    this.published = true;
-  }
+	public void update(
+					LocalDateTime postedAt,
+					LocalizedText title,
+					LocalizedText content,
+					Boolean published,
+					Boolean pinned) {
+		if (postedAt != null) this.postedAt = postedAt;
+		if (title != null) this.title = title;
+		if (content != null) this.content = content;
+		if (published != null) this.published = published;
+		if (pinned != null) this.pinned = pinned;
+	}
 
-  public void unpublish() {
-    this.published = false;
-  }
+
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementCursor.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementCursor.java
@@ -1,0 +1,6 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import java.time.LocalDateTime;
+
+public record AnnouncementCursor(LocalDateTime postedAt, Long id) {
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementDetail.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementDetail.java
@@ -1,0 +1,29 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+
+import java.time.LocalDateTime;
+
+public record AnnouncementDetail(
+				Long id,
+				LocalDateTime postedAt,
+				LocalizedText title,
+				LocalizedText content,
+				boolean published,
+				boolean pinned,
+				LocalDateTime createdAt,
+				LocalDateTime updatedAt) {
+
+	public static AnnouncementDetail from(Announcement a) {
+		return new AnnouncementDetail(
+						a.getId(),
+						a.getPostedAt(),
+						a.getTitle(),
+						a.getContent(),
+						a.isPublished(),
+						a.isPinned(),
+						a.getCreatedAt(),
+						a.getUpdatedAt());
+	}
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementIdResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementIdResponse.java
@@ -1,0 +1,5 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+public record AnnouncementIdResponse(Long id) {
+
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementSummary.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementSummary.java
@@ -1,0 +1,27 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+
+import java.time.LocalDateTime;
+
+public record AnnouncementSummary(
+				Long id,
+				LocalDateTime postedAt,
+				LocalizedText title,
+				boolean published,
+				boolean pinned,
+				LocalDateTime createdAt,
+				LocalDateTime updatedAt) {
+
+	public static AnnouncementSummary from(Announcement a) {
+		return new AnnouncementSummary(
+						a.getId(),
+						a.getPostedAt(),
+						a.getTitle(),
+						a.isPublished(),
+						a.isPinned(),
+						a.getCreatedAt(),
+						a.getUpdatedAt());
+	}
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/CreateAnnouncementRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/CreateAnnouncementRequest.java
@@ -1,0 +1,23 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record CreateAnnouncementRequest(
+				@NotNull LocalDateTime postedAt,
+				@NotNull @Valid LocalizedTextRequest title,
+				@NotNull @Valid LocalizedTextRequest content,
+				@NotNull Boolean published,
+				@NotNull Boolean pinned
+) {
+	public LocalizedText titleAsValue() {
+		return title.toValue();
+	}
+
+	public LocalizedText contentAsValue() {
+		return content.toValue();
+	}
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/LocalizedTextRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/LocalizedTextRequest.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import jakarta.validation.constraints.NotBlank;
+
+public record LocalizedTextRequest(@NotBlank String ko, String en, String ja) {
+	public LocalizedText toValue() {
+		return new LocalizedText(ko, en, ja);
+	}
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/UpdateAnnouncementRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/UpdateAnnouncementRequest.java
@@ -1,0 +1,21 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+
+public record UpdateAnnouncementRequest(
+				LocalDateTime postedAt,
+				@Valid LocalizedTextRequest title,
+				@Valid LocalizedTextRequest content,
+				Boolean published,
+				Boolean pinned) {
+	public LocalizedText titleAsValue() {
+		return title == null ? null : title.toValue();
+	}
+
+	public LocalizedText contentAsValue() {
+		return content == null ? null : content.toValue();
+	}
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/repository/AnnouncementRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/repository/AnnouncementRepository.java
@@ -1,7 +1,9 @@
 package com.typingpractice.typing_practice_be.notice.announcement.repository;
 
 import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementCursor;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -11,47 +13,83 @@ import java.util.Optional;
 @Repository
 @RequiredArgsConstructor
 public class AnnouncementRepository {
-  private final EntityManager em;
+	private final EntityManager em;
 
-  public Announcement save(Announcement announcement) {
-    em.persist(announcement);
-    return announcement;
-  }
+	public Announcement save(Announcement announcement) {
+		em.persist(announcement);
+		return announcement;
+	}
 
-  public Optional<Announcement> findById(Long id) {
-    return Optional.ofNullable(em.find(Announcement.class, id));
-  }
+	public Optional<Announcement> findById(Long id) {
+		return em.createQuery("select a from Announcement a where a.id = :id", Announcement.class)
+						.setParameter("id", id)
+						.getResultStream()
+						.findFirst();
+	}
 
-  public Optional<Announcement> findLatestPublished() {
-    return em.createQuery(
-            "select a from Announcement a "
-                + "where a.published = true "
-                + "order by a.postedAt desc",
-            Announcement.class)
-        .setMaxResults(1)
-        .getResultStream()
-        .findFirst();
-  }
+	public void delete(Announcement announcement) {
+		em.remove(announcement);
+	}
 
-  public List<Announcement> findPublishedRecent(int limit) {
-    return em.createQuery(
-            "select a from Announcement a "
-                + "where a.published = true "
-                + "order by a.postedAt desc",
-            Announcement.class)
-        .setMaxResults(limit)
-        .getResultList();
-  }
+	// 사용자: 게시된 공지 중 가장 최신 1건 (pinned 무관). 팝업용.
+	public Optional<Announcement> findLatestPublished() {
+		return em.createQuery(
+										"select a from Announcement a "
+														+ "where a.published = true "
+														+ "order by a.postedAt desc, a.id desc",
+										Announcement.class)
+						.setMaxResults(1)
+						.getResultStream()
+						.findFirst();
+	}
 
-  public List<Announcement> findAllForAdmin(int page, int size) {
-    return em.createQuery(
-            "select a from Announcement a order by a.postedAt desc", Announcement.class)
-        .setFirstResult((page - 1) * size)
-        .setMaxResults(size)
-        .getResultList();
-  }
+	/**
+	 * 사용자: 게시된 고정 공지 전체
+	 */
+	public List<Announcement> findPublishedPinned() {
+		return em.createQuery(
+										"select a from Announcement a "
+														+ "where a.published = true and a.pinned = true "
+														+ "order by a.postedAt desc, a.id desc",
+										Announcement.class)
+						.getResultList();
+	}
 
-  public void delete(Announcement announcement) {
-    em.remove(announcement);
-  }
+	public List<Announcement> findAllPinned() {
+		return em.createQuery(
+						"select a from Announcement a " +
+										"where a.pinned = true " +
+										"order by a.postedAt, a.id desc", Announcement.class
+		).getResultList();
+	}
+
+	public List<Announcement> findPublishedNonPinnedByCursor(AnnouncementCursor cursor, int size) {
+		return findByCursor(cursor, size, true);
+	}
+
+	public List<Announcement> findAllNonPinnedByCursor(AnnouncementCursor cursor, int size) {
+		return findByCursor(cursor, size, false);
+	}
+
+	private List<Announcement> findByCursor(AnnouncementCursor cursor, int size, boolean publishedOnly) {
+		StringBuilder jpql =
+						new StringBuilder("select a from Announcement a where a.pinned = false");
+		if (publishedOnly) {
+			jpql.append(" and a.published = true");
+		}
+		if (cursor != null) {
+			jpql.append(
+							" and (a.postedAt < :cursorPostedAt" +
+											" or (a.postedAt = :cursorPostedAt and a.id < :cursorId))"
+			);
+		}
+		jpql.append(" order by a.postedAt desc, a.id desc");
+
+		TypedQuery<Announcement> query = em.createQuery(jpql.toString(), Announcement.class);
+		if (cursor != null) {
+			query.setParameter("cursorPostedAt", cursor.postedAt());
+			query.setParameter("cursorId", cursor.id());
+		}
+		return query.setMaxResults(size + 1).getResultList();
+	}
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementService.java
@@ -1,0 +1,81 @@
+package com.typingpractice.typing_practice_be.notice.announcement.service;
+
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
+import com.typingpractice.typing_practice_be.notice.announcement.exception.AnnouncementNotFoundException;
+import com.typingpractice.typing_practice_be.notice.announcement.repository.AnnouncementRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminAnnouncementService {
+  private final AnnouncementRepository announcementRepository;
+
+  @Transactional
+  public Long create(CreateAnnouncementRequest request) {
+    Announcement announcement =
+        Announcement.create(
+            request.postedAt(),
+            request.titleAsValue(),
+            request.contentAsValue(),
+            request.published(),
+            request.pinned());
+
+    return announcementRepository.save(announcement).getId();
+  }
+
+  @Transactional
+  public void update(Long id, UpdateAnnouncementRequest request) {
+    Announcement announcement =
+        announcementRepository.findById(id).orElseThrow(AnnouncementNotFoundException::new);
+
+    announcement.update(
+        request.postedAt(),
+        request.titleAsValue(),
+        request.contentAsValue(),
+        request.published(),
+        request.pinned());
+  }
+
+  @Transactional
+  public void delete(Long id) {
+    Announcement announcement =
+        announcementRepository.findById(id).orElseThrow(AnnouncementNotFoundException::new);
+
+    announcementRepository.delete(announcement);
+  }
+
+  public AnnouncementDetail findOne(Long id) {
+    return announcementRepository
+        .findById(id)
+        .map(AnnouncementDetail::from)
+        .orElseThrow(AnnouncementNotFoundException::new);
+  }
+
+  public List<AnnouncementDetail> findPinned() {
+    return announcementRepository.findAllPinned().stream().map(AnnouncementDetail::from).toList();
+  }
+
+  /** 어드민: 일반 공지 커서 페이지네이션 (게시 여부 무관). */
+  public CursorPage<AnnouncementSummary, AnnouncementCursor> findList(
+      AnnouncementCursor cursor, int size) {
+    List<Announcement> fetched = announcementRepository.findAllNonPinnedByCursor(cursor, size);
+
+    boolean hasNext = fetched.size() > size;
+    List<Announcement> page = hasNext ? fetched.subList(0, size) : fetched;
+
+    List<AnnouncementSummary> content = page.stream().map(AnnouncementSummary::from).toList();
+
+    AnnouncementCursor nextCursor =
+        hasNext
+            ? new AnnouncementCursor(page.getLast().getPostedAt(), page.getLast().getId())
+            : null;
+
+    return new CursorPage<>(content, nextCursor, hasNext);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AnnouncementService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AnnouncementService.java
@@ -1,0 +1,55 @@
+package com.typingpractice.typing_practice_be.notice.announcement.service;
+
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementCursor;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementDetail;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementSummary;
+import com.typingpractice.typing_practice_be.notice.announcement.repository.AnnouncementRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnnouncementService {
+  private final AnnouncementRepository announcementRepository;
+
+  /** 팝업용: 최신 게시 공지 1건 (없으면 null) */
+  public AnnouncementDetail findLatest() {
+    return announcementRepository.findLatestPublished().map(AnnouncementDetail::from).orElse(null);
+  }
+
+  /** 게시된 고정 공지 전체 */
+  public List<AnnouncementSummary> findPinned() {
+    return announcementRepository.findPublishedPinned().stream()
+        .map(AnnouncementSummary::from)
+        .toList();
+  }
+
+  /** 게시된 일반 공지 커서 페이지네이션 */
+  public CursorPage<AnnouncementSummary, AnnouncementCursor> findList(
+      AnnouncementCursor cursor, int size) {
+    List<Announcement> fetched =
+        announcementRepository.findPublishedNonPinnedByCursor(cursor, size);
+
+    return toCursorPage(fetched, size);
+  }
+
+  private CursorPage<AnnouncementSummary, AnnouncementCursor> toCursorPage(
+      List<Announcement> fetched, int size) {
+    boolean hasNext = fetched.size() > size;
+    List<Announcement> page = hasNext ? fetched.subList(0, size) : fetched;
+
+    List<AnnouncementSummary> content = page.stream().map(AnnouncementSummary::from).toList();
+
+    AnnouncementCursor nextCursor =
+        hasNext
+            ? new AnnouncementCursor(content.getLast().postedAt(), content.getLast().id())
+            : null;
+
+    return new CursorPage<>(content, nextCursor, hasNext);
+  }
+}

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteServiceTest.java
@@ -11,27 +11,23 @@ import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
 import com.typingpractice.typing_practice_be.quote.domain.*;
-import com.typingpractice.typing_practice_be.quote.dto.PublicQuoteRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteCreateRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteUpdateRequest;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotOwnedException;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotProcessableException;
-import com.typingpractice.typing_practice_be.quote.query.PublicQuoteQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuoteCreateQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuoteUpdateQuery;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
-
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.Optional;
-
 import com.typingpractice.typing_practice_be.quote.service.difficulty.DifficultySeedCalculator;
 import com.typingpractice.typing_practice_be.quote.service.difficulty.QuoteProfileCalculator;
 import com.typingpractice.typing_practice_be.quote.statistics.domain.GlobalQuoteStatistics;
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsService;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,492 +38,484 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class QuoteServiceTest {
-	@Mock
-	private QuoteRepository quoteRepository;
-	@Mock
-	private MemberRepository memberRepository;
-	@Mock
-	private DailyLimitService dailyLimitService;
-
-	@Mock
-	private QuoteLanguageValidator quoteLanguageValidator;
-	@Mock
-	private QuoteProfileCalculator quoteProfileCalculator;
-	@Mock
-	private DifficultySeedCalculator difficultySeedCalculator;
-	@Mock
-	private GlobalQuoteStatisticsService globalQuoteStatisticsService;
-
-	@InjectMocks
-	private QuoteService quoteService;
-
-	private Member createMember(Long id) {
-		Member member = Member.createMember("test-provider-id", "test@test.com", "testMember");
-		setId(member, id);
-		return member;
-	}
-
-	private void setId(Object entity, Long id) {
-		try {
-			Field idField = entity.getClass().getDeclaredField("id");
-			idField.setAccessible(true);
-			idField.set(entity, id);
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	private Quote createQuote(Member member, QuoteType type, QuoteStatus status) {
-		Quote quote =
-						Quote.create(member, "테스트 문장입니다.", "저자", type, QuoteLanguage.KOREAN, null, 0f, "hash");
-		if (type == QuoteType.PUBLIC && status == QuoteStatus.ACTIVE) {
-			quote.approvePublish();
-		}
-
-		return quote;
-	}
-
-	private QuoteCreateQuery createCreateQuery(QuoteType type) {
-		QuoteCreateRequest request =
-						QuoteCreateRequest.create("테스트 문장입니다.", "저자", QuoteLanguage.KOREAN);
-		return QuoteCreateQuery.from(request, type, QuoteLanguage.KOREAN);
-	}
-
-	private QuoteUpdateQuery createUpdateQuery(String sentence, String author) {
-		QuoteUpdateRequest request = QuoteUpdateRequest.create(sentence, author);
-		return QuoteUpdateQuery.from(request);
-	}
-
-	private QuotePaginationQuery createPaginationQuery() {
-		QuotePaginationRequest request =
-						new QuotePaginationRequest(1, 10, SortDirection.DESC, null, null, QuoteOrderBy.id);
-		return QuotePaginationQuery.from(request);
-	}
-
-	@Nested
-	@DisplayName("findById")
-	class FindById {
-		@Test
-		@DisplayName("조회 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when
-			Quote result = quoteService.findById(1L);
-
-			// then
-			assertThat(result).isEqualTo(quote);
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 문장 - 예외 발생")
-		void notFound() {
-			// given
-			when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.findById(1L))
-							.isInstanceOf(QuoteNotFoundException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("create")
-	class Create {
-		@Test
-		@DisplayName("PRIVATE 문장 생성 성공")
-		void successPrivate() {
-			// given
-			Member member = createMember(1L);
-			QuoteCreateQuery query = createCreateQuery(QuoteType.PRIVATE);
-
-			when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-			when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(true);
-			when(quoteProfileCalculator.calculate(anyString(), any(QuoteLanguage.class)))
-							.thenReturn(QuoteProfile.create());
-			when(globalQuoteStatisticsService.getByLanguage(any(QuoteLanguage.class)))
-							.thenReturn(GlobalQuoteStatistics.createKoreanDefault());
-			when(difficultySeedCalculator.calculate(any(), any(), any())).thenReturn(0f);
-
-			// when
-			Quote result = quoteService.create(1L, query);
-
-			// then
-			assertThat(result.getType()).isEqualTo(QuoteType.PRIVATE);
-			assertThat(result.getStatus()).isEqualTo(QuoteStatus.ACTIVE);
-			verify(quoteRepository).save(any(Quote.class));
-		}
-
-		@Test
-		@DisplayName("PUBLIC 문장 생성 성공 - PENDING 상태")
-		void successPublic() {
-			// given
-			Member member = createMember(1L);
-			QuoteCreateQuery query = createCreateQuery(QuoteType.PUBLIC);
-
-			when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-			when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(true);
-			when(quoteProfileCalculator.calculate(anyString(), any(QuoteLanguage.class)))
-							.thenReturn(QuoteProfile.create());
-			when(globalQuoteStatisticsService.getByLanguage(any(QuoteLanguage.class)))
-							.thenReturn(GlobalQuoteStatistics.createKoreanDefault());
-			when(difficultySeedCalculator.calculate(any(), any(), any())).thenReturn(0f);
-
-			// when
-			Quote result = quoteService.create(1L, query);
-
-			// then
-			assertThat(result.getType()).isEqualTo(QuoteType.PUBLIC);
-			assertThat(result.getStatus()).isEqualTo(QuoteStatus.PENDING);
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 회원 - 예외 발생")
-		void memberNotFound() {
-			// given
-			QuoteCreateQuery query = createCreateQuery(QuoteType.PUBLIC);
-
-			when(memberRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.create(1L, query))
-							.isInstanceOf(MemberNotFoundException.class);
-		}
-
-		@Test
-		@DisplayName("일일 업로드 제한 초과 - 예외 발생")
-		void dailyLimitExceeded() {
-			// given
-			Member member = createMember(1L);
-			QuoteCreateQuery query = createCreateQuery(QuoteType.PUBLIC);
-
-			when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-			when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(false);
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.create(1L, query))
-							.isInstanceOf(DailyQuoteUploadLimitException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("updatePrivateQuote")
-	class UpdatePrivateQuote {
-		@Test
-		@DisplayName("수정 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-			QuoteUpdateQuery query = createUpdateQuery("수정된 문장입니다.", "수정된 저자");
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when
-			Quote result = quoteService.updatePrivateQuote(1L, 1L, query);
-
-			// then
-			assertThat(result.getSentence()).isEqualTo("수정된 문장입니다.");
-			assertThat(result.getAuthor()).isEqualTo("수정된 저자");
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 문장 - 예외 발생")
-		void quoteNotFound() {
-			// given
-			QuoteUpdateQuery query = createUpdateQuery("수정된 문장", "수정된 저자");
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.updatePrivateQuote(1L, 1L, query))
-							.isInstanceOf(QuoteNotFoundException.class);
-		}
-
-		@Test
-		@DisplayName("본인 문장이 아님 - 예외 발생")
-		void notOwned() {
-			// given
-			Member otherMember = createMember(2L);
-			Quote quote = createQuote(otherMember, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-			QuoteUpdateQuery query = createUpdateQuery("수정된 문장", "수정된 저자");
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.updatePrivateQuote(1L, 1L, query))
-							.isInstanceOf(QuoteNotOwnedException.class);
-		}
-
-		@Test
-		@DisplayName("PUBLIC 문장 수정 시도 - 예외 발생")
-		void publicNotProcessable() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
-			QuoteUpdateQuery query = createUpdateQuery("수정된 문장", "수정된 저자");
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.updatePrivateQuote(1L, 1L, query))
-							.isInstanceOf(QuoteNotProcessableException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("deleteQuote")
-	class DeleteQuote {
-		@Test
-		@DisplayName("삭제 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when
-			quoteService.deleteQuote(1L, 1L);
-
-			// then
-			verify(quoteRepository).deleteQuote(quote);
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 문장 - 예외 발생")
-		void quoteNotFound() {
-			// given
-			when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & given
-			assertThatThrownBy(() -> quoteService.deleteQuote(1L, 1L))
-							.isInstanceOf(QuoteNotFoundException.class);
-		}
-
-		@Test
-		@DisplayName("본인 문장이 아님 - 예외 발생")
-		void notOwned() {
-			// given
-			Member otherMember = createMember(2L);
-			Quote quote = createQuote(otherMember, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.deleteQuote(1L, 1L))
-							.isInstanceOf(QuoteNotOwnedException.class);
-		}
-
-		@Test
-		@DisplayName("PUBLIC 문장 삭제 시도 - 예외 발생")
-		void publicNotProcessable() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.deleteQuote(1L, 1L))
-							.isInstanceOf(QuoteNotProcessableException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("getMyQuotes")
-	class GetMyQuotes {
-		@Test
-		@DisplayName("조회 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-			QuotePaginationQuery query = createPaginationQuery();
-
-			when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-			when(quoteRepository.findByMember(member, query)).thenReturn(List.of(quote));
-
-			// when
-			PageResult<Quote> result = quoteService.getMyQuotes(1L, query);
-
-			// then
-			assertThat(result.getContent()).hasSize(1);
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 회원 - 예외 발생")
-		void memberNotFound() {
-			// given
-			QuotePaginationQuery query = createPaginationQuery();
-
-			when(memberRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.getMyQuotes(1L, query))
-							.isInstanceOf(MemberNotFoundException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("publishQuote")
-	class PublishQuote {
-		@Test
-		@DisplayName("공개 전환 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when
-			Quote result = quoteService.publishQuote(1L, 1L);
-
-			// then
-			assertThat(result.getType()).isEqualTo(QuoteType.PUBLIC);
-			assertThat(result.getStatus()).isEqualTo(QuoteStatus.PENDING);
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 문장 - 예외 발생")
-		void quoteNotFound() {
-			// given
-			when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.publishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotFoundException.class);
-		}
-
-		@Test
-		@DisplayName("본인 문장이 아님 - 예외 발생")
-		void notOwned() {
-			// given
-			Member otherMember = createMember(2L);
-			Quote quote = createQuote(otherMember, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.publishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotOwnedException.class);
-		}
-
-		@Test
-		@DisplayName("이미 PUBLIC 문장 - 예외 발생")
-		void alreadyPublic() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.publishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotProcessableException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("cancelPublishQuote")
-	class CancelPublishQuote {
-		@Test
-		@DisplayName("공개 전환 취소 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.PENDING);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-			// when
-			Quote result = quoteService.cancelPublishQuote(1L, 1L);
-
-			// then
-			assertThat(result.getType()).isEqualTo(QuoteType.PRIVATE);
-			assertThat(result.getStatus()).isEqualTo(QuoteStatus.ACTIVE);
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 문장 - 예외 발생")
-		void quoteNotFound() {
-			// given
-			when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotFoundException.class);
-		}
-
-		@Test
-		@DisplayName("본인 문장이 아님 - 예외 발생")
-		void notOwned() {
-			// given
-			Member otherMember = createMember(2L);
-			Quote quote = createQuote(otherMember, QuoteType.PUBLIC, QuoteStatus.PENDING);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotOwnedException.class);
-		}
-
-		@Test
-		@DisplayName("PENDING 상태가 아님 - 예외 발생")
-		void notPending() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotProcessableException.class);
-		}
-
-		@Test
-		@DisplayName("PRIVATE 문장 취소 시도 - 예외 발생")
-		void privateNotProcessable() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotProcessableException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("findRandomPublicQuotes")
-	class FindRandomPublicQuotes {
-
-		@Test
-		@DisplayName("조회 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote1 = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
-			Quote quote2 = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
-			PublicQuoteRequest request = new PublicQuoteRequest(1, 10, false, 0.5f, QuoteLanguage.KOREAN);
-			PublicQuoteQuery query = PublicQuoteQuery.from(1L, request);
-
-			when(quoteRepository.findPublicQuotes(query)).thenReturn(List.of(quote1, quote2));
-
-			// when
-			PageResult<Quote> result = quoteService.findRandomPublicQuotes(query);
-
-			// then
-			assertThat(result.getContent()).hasSize(2);
-			verify(quoteRepository).findPublicQuotes(query);
-		}
-	}
+  @Mock private QuoteRepository quoteRepository;
+  @Mock private MemberRepository memberRepository;
+  @Mock private DailyLimitService dailyLimitService;
+
+  @Mock private QuoteLanguageValidator quoteLanguageValidator;
+  @Mock private QuoteProfileCalculator quoteProfileCalculator;
+  @Mock private DifficultySeedCalculator difficultySeedCalculator;
+  @Mock private GlobalQuoteStatisticsService globalQuoteStatisticsService;
+
+  @InjectMocks private QuoteService quoteService;
+
+  private Member createMember(Long id) {
+    Member member = Member.createMember("test-provider-id", "test@test.com", "testMember");
+    setId(member, id);
+    return member;
+  }
+
+  private void setId(Object entity, Long id) {
+    try {
+      Field idField = entity.getClass().getDeclaredField("id");
+      idField.setAccessible(true);
+      idField.set(entity, id);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private Quote createQuote(Member member, QuoteType type, QuoteStatus status) {
+    Quote quote =
+        Quote.create(member, "테스트 문장입니다.", "저자", type, QuoteLanguage.KOREAN, null, 0f, "hash");
+    if (type == QuoteType.PUBLIC && status == QuoteStatus.ACTIVE) {
+      quote.approvePublish();
+    }
+
+    return quote;
+  }
+
+  private QuoteCreateQuery createCreateQuery(QuoteType type) {
+    QuoteCreateRequest request =
+        QuoteCreateRequest.create("테스트 문장입니다.", "저자", QuoteLanguage.KOREAN);
+    return QuoteCreateQuery.from(request, type, QuoteLanguage.KOREAN);
+  }
+
+  private QuoteUpdateQuery createUpdateQuery(String sentence, String author) {
+    QuoteUpdateRequest request = QuoteUpdateRequest.create(sentence, author);
+    return QuoteUpdateQuery.from(request);
+  }
+
+  private QuotePaginationQuery createPaginationQuery() {
+    QuotePaginationRequest request =
+        new QuotePaginationRequest(1, 10, SortDirection.DESC, null, null, QuoteOrderBy.id);
+    return QuotePaginationQuery.from(request);
+  }
+
+  @Nested
+  @DisplayName("findById")
+  class FindById {
+    @Test
+    @DisplayName("조회 성공")
+    void success() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when
+      Quote result = quoteService.findById(1L);
+
+      // then
+      assertThat(result).isEqualTo(quote);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문장 - 예외 발생")
+    void notFound() {
+      // given
+      when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.findById(1L))
+          .isInstanceOf(QuoteNotFoundException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("create")
+  class Create {
+    @Test
+    @DisplayName("PRIVATE 문장 생성 성공")
+    void successPrivate() {
+      // given
+      Member member = createMember(1L);
+      QuoteCreateQuery query = createCreateQuery(QuoteType.PRIVATE);
+
+      when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+      when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(true);
+      when(quoteProfileCalculator.calculate(anyString(), any(QuoteLanguage.class)))
+          .thenReturn(QuoteProfile.create());
+      when(globalQuoteStatisticsService.getByLanguage(any(QuoteLanguage.class)))
+          .thenReturn(GlobalQuoteStatistics.createKoreanDefault());
+      when(difficultySeedCalculator.calculate(any(), any(), any())).thenReturn(0f);
+
+      // when
+      Quote result = quoteService.create(1L, query);
+
+      // then
+      assertThat(result.getType()).isEqualTo(QuoteType.PRIVATE);
+      assertThat(result.getStatus()).isEqualTo(QuoteStatus.ACTIVE);
+      verify(quoteRepository).save(any(Quote.class));
+    }
+
+    @Test
+    @DisplayName("PUBLIC 문장 생성 성공 - PENDING 상태")
+    void successPublic() {
+      // given
+      Member member = createMember(1L);
+      QuoteCreateQuery query = createCreateQuery(QuoteType.PUBLIC);
+
+      when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+      when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(true);
+      when(quoteProfileCalculator.calculate(anyString(), any(QuoteLanguage.class)))
+          .thenReturn(QuoteProfile.create());
+      when(globalQuoteStatisticsService.getByLanguage(any(QuoteLanguage.class)))
+          .thenReturn(GlobalQuoteStatistics.createKoreanDefault());
+      when(difficultySeedCalculator.calculate(any(), any(), any())).thenReturn(0f);
+
+      // when
+      Quote result = quoteService.create(1L, query);
+
+      // then
+      assertThat(result.getType()).isEqualTo(QuoteType.PUBLIC);
+      assertThat(result.getStatus()).isEqualTo(QuoteStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원 - 예외 발생")
+    void memberNotFound() {
+      // given
+      QuoteCreateQuery query = createCreateQuery(QuoteType.PUBLIC);
+
+      when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.create(1L, query))
+          .isInstanceOf(MemberNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("일일 업로드 제한 초과 - 예외 발생")
+    void dailyLimitExceeded() {
+      // given
+      Member member = createMember(1L);
+      QuoteCreateQuery query = createCreateQuery(QuoteType.PUBLIC);
+
+      when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+      when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(false);
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.create(1L, query))
+          .isInstanceOf(DailyQuoteUploadLimitException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("updatePrivateQuote")
+  class UpdatePrivateQuote {
+    @Test
+    @DisplayName("수정 성공")
+    void success() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+      QuoteUpdateQuery query = createUpdateQuery("수정된 문장입니다.", "수정된 저자");
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when
+      Quote result = quoteService.updatePrivateQuote(1L, 1L, query);
+
+      // then
+      assertThat(result.getSentence()).isEqualTo("수정된 문장입니다.");
+      assertThat(result.getAuthor()).isEqualTo("수정된 저자");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문장 - 예외 발생")
+    void quoteNotFound() {
+      // given
+      QuoteUpdateQuery query = createUpdateQuery("수정된 문장", "수정된 저자");
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.updatePrivateQuote(1L, 1L, query))
+          .isInstanceOf(QuoteNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("본인 문장이 아님 - 예외 발생")
+    void notOwned() {
+      // given
+      Member otherMember = createMember(2L);
+      Quote quote = createQuote(otherMember, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+      QuoteUpdateQuery query = createUpdateQuery("수정된 문장", "수정된 저자");
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.updatePrivateQuote(1L, 1L, query))
+          .isInstanceOf(QuoteNotOwnedException.class);
+    }
+
+    @Test
+    @DisplayName("PUBLIC 문장 수정 시도 - 예외 발생")
+    void publicNotProcessable() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
+      QuoteUpdateQuery query = createUpdateQuery("수정된 문장", "수정된 저자");
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.updatePrivateQuote(1L, 1L, query))
+          .isInstanceOf(QuoteNotProcessableException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("deleteQuote")
+  class DeleteQuote {
+    @Test
+    @DisplayName("삭제 성공")
+    void success() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when
+      quoteService.deleteQuote(1L, 1L);
+
+      // then
+      verify(quoteRepository).deleteQuote(quote);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문장 - 예외 발생")
+    void quoteNotFound() {
+      // given
+      when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & given
+      assertThatThrownBy(() -> quoteService.deleteQuote(1L, 1L))
+          .isInstanceOf(QuoteNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("본인 문장이 아님 - 예외 발생")
+    void notOwned() {
+      // given
+      Member otherMember = createMember(2L);
+      Quote quote = createQuote(otherMember, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.deleteQuote(1L, 1L))
+          .isInstanceOf(QuoteNotOwnedException.class);
+    }
+
+    @Test
+    @DisplayName("PUBLIC 문장 삭제 시도 - 예외 발생")
+    void publicNotProcessable() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.deleteQuote(1L, 1L))
+          .isInstanceOf(QuoteNotProcessableException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("getMyQuotes")
+  class GetMyQuotes {
+    @Test
+    @DisplayName("조회 성공")
+    void success() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+      QuotePaginationQuery query = createPaginationQuery();
+
+      when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+      when(quoteRepository.findByMember(member, query)).thenReturn(List.of(quote));
+
+      // when
+      PageResult<Quote> result = quoteService.getMyQuotes(1L, query);
+
+      // then
+      assertThat(result.getContent()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원 - 예외 발생")
+    void memberNotFound() {
+      // given
+      QuotePaginationQuery query = createPaginationQuery();
+
+      when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.getMyQuotes(1L, query))
+          .isInstanceOf(MemberNotFoundException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("publishQuote")
+  class PublishQuote {
+    @Test
+    @DisplayName("공개 전환 성공")
+    void success() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when
+      Quote result = quoteService.publishQuote(1L, 1L);
+
+      // then
+      assertThat(result.getType()).isEqualTo(QuoteType.PUBLIC);
+      assertThat(result.getStatus()).isEqualTo(QuoteStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문장 - 예외 발생")
+    void quoteNotFound() {
+      // given
+      when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.publishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("본인 문장이 아님 - 예외 발생")
+    void notOwned() {
+      // given
+      Member otherMember = createMember(2L);
+      Quote quote = createQuote(otherMember, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.publishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotOwnedException.class);
+    }
+
+    @Test
+    @DisplayName("이미 PUBLIC 문장 - 예외 발생")
+    void alreadyPublic() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.publishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotProcessableException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("cancelPublishQuote")
+  class CancelPublishQuote {
+    @Test
+    @DisplayName("공개 전환 취소 성공")
+    void success() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.PENDING);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+      // when
+      Quote result = quoteService.cancelPublishQuote(1L, 1L);
+
+      // then
+      assertThat(result.getType()).isEqualTo(QuoteType.PRIVATE);
+      assertThat(result.getStatus()).isEqualTo(QuoteStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문장 - 예외 발생")
+    void quoteNotFound() {
+      // given
+      when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("본인 문장이 아님 - 예외 발생")
+    void notOwned() {
+      // given
+      Member otherMember = createMember(2L);
+      Quote quote = createQuote(otherMember, QuoteType.PUBLIC, QuoteStatus.PENDING);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotOwnedException.class);
+    }
+
+    @Test
+    @DisplayName("PENDING 상태가 아님 - 예외 발생")
+    void notPending() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotProcessableException.class);
+    }
+
+    @Test
+    @DisplayName("PRIVATE 문장 취소 시도 - 예외 발생")
+    void privateNotProcessable() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotProcessableException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("findRandomPublicQuotes")
+  class FindRandomPublicQuotes {
+
+    /*@Test
+    @DisplayName("조회 성공")
+    void success() {
+    	// given
+    	Member member = createMember(1L);
+    	Quote quote1 = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
+    	Quote quote2 = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
+    	PublicQuoteRequest request = new PublicQuoteRequest(1, 10, false, 0.5f, QuoteLanguage.KOREAN);
+    	PublicQuoteQuery query = PublicQuoteQuery.from(1L, request);
+
+    	when(quoteRepository.findPublicQuotes(query)).thenReturn(List.of(quote1, quote2));
+
+    	// when
+    	PageResult<Quote> result = quoteService.findRandomPublicQuotes(query);
+
+    	// then
+    	assertThat(result.getContent()).hasSize(2);
+    	verify(quoteRepository).findPublicQuotes(query);
+    }*/
+  }
 }


### PR DESCRIPTION
## 주요 내용
- 커서 기반 페이지네이션을 위한 공통 CursorPage DTO 추가
- 공지사항 등록/수정/조회/삭제를 위한 DTO와 Service 계층 구현
- 어드민/사용자 용도를 분리해 Repository 메서드 재작성

## 세부 내용
### 공통
- CursorPage<T, C> 추가 (content/nextCursor/hasNext 구조)

### Announcement 엔티티
- pinned 필드 추가
- create 시그니처 변경 (published, pinned 파라미터 추가)
- update 메서드를 PATCH 부분 수정 패턴으로 변경 (null = 미변경)
- publish/unpublish 메서드 제거 (PATCH 통합으로 사용처 없음)

### Request DTO
- LocalizedTextRequest 추가 (ko @NotBlank, en/ja nullable)
- CreateAnnouncementRequest 추가
- UpdateAnnouncementRequest 추가 (모든 필드 nullable, null = 미변경)

### Response DTO
- AnnouncementSummary 추가 (목록용, content 제외)
- AnnouncementDetail 추가 (단건용, content 포함)
- AnnouncementIdResponse 추가 (등록 응답용)
- AnnouncementCursor record 추가 ((postedAt, id) 복합 커서)

### Repository
- findById를 JPQL 기반으로 변경 (soft delete 일관성)
- findLatestPublished, findPublishedPinned, findAllPinned 추가
- findPublishedNonPinnedByCursor, findAllNonPinnedByCursor 추가
- 커서 조건: postedAt 우선, 동일 시 id 비교
- size+1 조회로 hasNext 판정

### Service
- AnnouncementService 추가 (사용자용)
  - findLatest: 팝업용 최신 1건
  - findPinned: 게시된 고정 공지 전체
  - findList: 게시된 일반 공지 커서 페이지네이션
- AdminAnnouncementService 추가 (어드민용)
  - create, update, delete, findOne
  - findPinned: 고정 공지 전체 (게시 여부 무관)
  - findList: 일반 공지 커서 페이지네이션 (게시 여부 무관)

### Controller (스텁)
- AnnouncementController 라우트 변경 및 추가 (/announcements/{latest,pinned,{id}})
- AdminAnnouncementController 신규, 라우트만 정의 (실제 로직은 다음 단계)