### PR TITLE
feat: 공지사항 API 엔드포인트 및 보안 설정 추가

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -66,6 +66,8 @@ public class SecurityConfig {
                   .permitAll()
                   .requestMatchers(HttpMethod.GET, "/words")
                   .permitAll()
+                  .requestMatchers(HttpMethod.GET, "/announcements", "/announcements/**")
+                  .permitAll()
                   .requestMatchers("/error")
                   .permitAll()
                   .requestMatchers(HttpMethod.POST, "/typing-records")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AdminAnnouncementController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AdminAnnouncementController.java
@@ -1,6 +1,11 @@
 package com.typingpractice.typing_practice_be.notice.announcement.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
+import com.typingpractice.typing_practice_be.notice.announcement.service.AdminAnnouncementService;
+import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -8,33 +13,47 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/admin/announcements")
 @RequiredArgsConstructor
 public class AdminAnnouncementController {
+  private final AdminAnnouncementService adminAnnouncementService;
+
   @PostMapping
-  public ApiResponse<Void> postAnnouncement() {
-    return ApiResponse.ok(null);
+  public ApiResponse<AnnouncementIdResponse> postAnnouncement(
+      @RequestBody @Valid CreateAnnouncementRequest request) {
+    Long id = adminAnnouncementService.create(request);
+    return ApiResponse.ok(new AnnouncementIdResponse(id));
   }
 
   @PatchMapping("/{id}")
-  public ApiResponse<Void> patchAnnouncement(@PathVariable Long id) {
+  public ApiResponse<Void> patchAnnouncement(
+      @PathVariable Long id, @RequestBody @Valid UpdateAnnouncementRequest request) {
+    adminAnnouncementService.update(id, request);
     return ApiResponse.ok(null);
   }
 
   @DeleteMapping("/{id}")
   public ApiResponse<Void> deleteAnnouncement(@PathVariable Long id) {
+    adminAnnouncementService.delete(id);
     return ApiResponse.ok(null);
   }
 
   @GetMapping
-  public ApiResponse<Void> getAnnouncements() {
-    return ApiResponse.ok(null);
+  public ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>> getAnnouncements(
+      @ModelAttribute @Valid AnnouncementCursorRequest request) {
+    CursorPage<AnnouncementSummary, AnnouncementCursor> result =
+        adminAnnouncementService.findList(request.toCursor(), request.sizeOrDefault());
+
+    return ApiResponse.ok(result);
   }
 
   @GetMapping("/pinned")
-  public ApiResponse<Void> getPinnedAnnouncements() {
-    return ApiResponse.ok(null);
+  public ApiResponse<AnnouncementListResponse> getPinnedAnnouncements() {
+
+    List<AnnouncementSummary> items = adminAnnouncementService.findPinned();
+
+    return ApiResponse.ok(new AnnouncementListResponse(items));
   }
 
   @GetMapping("/{id}")
-  public ApiResponse<Void> getAnnouncementById(@PathVariable Long id) {
-    return ApiResponse.ok(null);
+  public ApiResponse<AnnouncementDetail> getAnnouncementById(@PathVariable Long id) {
+    return ApiResponse.ok(adminAnnouncementService.findOne(id));
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AnnouncementController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AnnouncementController.java
@@ -1,31 +1,45 @@
 package com.typingpractice.typing_practice_be.notice.announcement.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
+import com.typingpractice.typing_practice_be.notice.announcement.service.AnnouncementService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/announcements")
+@RequiredArgsConstructor
 public class AnnouncementController {
-	@GetMapping
-	public ApiResponse<Void> getAnnouncements() {
-		return ApiResponse.ok(null);
-	}
+  private final AnnouncementService announcementService;
 
-	@GetMapping("/latest")
-	public ApiResponse<Void> getLatestAnnouncement() {
-		return ApiResponse.ok(null);
-	}
+  @GetMapping
+  public ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>> getAnnouncements(
+      @ModelAttribute @Valid AnnouncementCursorRequest request) {
 
-	@GetMapping("/pinned")
-	public ApiResponse<Void> getPinnedAnnouncement() {
-		return ApiResponse.ok(null);
-	}
+    CursorPage<AnnouncementSummary, AnnouncementCursor> result =
+        announcementService.findList(request.toCursor(), request.sizeOrDefault());
 
-	@GetMapping("/{id}")
-	public ApiResponse<Void> getAnnouncementById(@PathVariable Long id) {
-		return ApiResponse.ok(null);
-	}
+    return ApiResponse.ok(result);
+  }
+
+  @GetMapping("/latest")
+  public ApiResponse<AnnouncementDetail> getLatestAnnouncement() {
+    return ApiResponse.ok(announcementService.findLatest());
+  }
+
+  @GetMapping("/pinned")
+  public ApiResponse<AnnouncementListResponse> getPinnedAnnouncement() {
+    List<AnnouncementSummary> items = announcementService.findPinned();
+
+    return ApiResponse.ok(new AnnouncementListResponse(items));
+  }
+
+  @GetMapping("/{id}")
+  public ApiResponse<AnnouncementDetail> getAnnouncementById(@PathVariable Long id) {
+    return ApiResponse.ok(announcementService.findOne(id));
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/domain/Announcement.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/domain/Announcement.java
@@ -20,58 +20,56 @@ import java.time.LocalDateTime;
 @Getter
 @SQLRestriction("deleted = false")
 @SQLDelete(
-				sql = "UPDATE announcement SET deleted = true, deleted_at = NOW() WHERE announcement_id = ?")
+    sql = "UPDATE announcement SET deleted = true, deleted_at = NOW() WHERE announcement_id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Announcement extends BaseEntity {
-	@Id
-	@GeneratedValue
-	@Column(name = "announcement_id")
-	private Long id;
+  @Id
+  @GeneratedValue
+  @Column(name = "announcement_id")
+  private Long id;
 
-	@Column(columnDefinition = "timestamp with time zone", nullable = false)
-	private LocalDateTime postedAt;
+  @Column(columnDefinition = "timestamp with time zone", nullable = false)
+  private LocalDateTime postedAt;
 
-	@JdbcTypeCode(SqlTypes.JSON)
-	@Column(columnDefinition = "jsonb", nullable = false)
-	private LocalizedText title;
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private LocalizedText title;
 
-	@JdbcTypeCode(SqlTypes.JSON)
-	@Column(columnDefinition = "jsonb", nullable = false)
-	private LocalizedText content;
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private LocalizedText content;
 
-	@Column(nullable = false)
-	private boolean published = true;
+  @Column(nullable = false)
+  private boolean published;
 
-	@Column(nullable = false)
-	private boolean pinned;
+  @Column(nullable = false)
+  private boolean pinned;
 
-	public static Announcement create(
-					LocalDateTime postedAt,
-					LocalizedText title,
-					LocalizedText content,
-					boolean published,
-					boolean pinned) {
-		Announcement a = new Announcement();
-		a.postedAt = postedAt;
-		a.title = title;
-		a.content = content;
-		a.published = published;
-		a.pinned = pinned;
-		return a;
-	}
+  public static Announcement create(
+      LocalDateTime postedAt,
+      LocalizedText title,
+      LocalizedText content,
+      boolean published,
+      boolean pinned) {
+    Announcement a = new Announcement();
+    a.postedAt = postedAt;
+    a.title = title;
+    a.content = content;
+    a.published = published;
+    a.pinned = pinned;
+    return a;
+  }
 
-	public void update(
-					LocalDateTime postedAt,
-					LocalizedText title,
-					LocalizedText content,
-					Boolean published,
-					Boolean pinned) {
-		if (postedAt != null) this.postedAt = postedAt;
-		if (title != null) this.title = title;
-		if (content != null) this.content = content;
-		if (published != null) this.published = published;
-		if (pinned != null) this.pinned = pinned;
-	}
-
-
+  public void update(
+      LocalDateTime postedAt,
+      LocalizedText title,
+      LocalizedText content,
+      Boolean published,
+      Boolean pinned) {
+    if (postedAt != null) this.postedAt = postedAt;
+    if (title != null) this.title = title;
+    if (content != null) this.content = content;
+    if (published != null) this.published = published;
+    if (pinned != null) this.pinned = pinned;
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementCursorRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementCursorRequest.java
@@ -1,0 +1,24 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+import java.time.LocalDateTime;
+
+public record AnnouncementCursorRequest(
+    LocalDateTime cursorPostedAt, Long cursorId, @Min(1) @Max(100) Integer size) {
+  @AssertTrue(message = "cursorPostedAt 과 cursorId 는 모두 있거나 모두 없어야 합니다.")
+  public boolean isCursorValid() {
+    return (cursorPostedAt == null) == (cursorId == null);
+  }
+
+  public AnnouncementCursor toCursor() {
+    if (cursorPostedAt == null) return null;
+    return new AnnouncementCursor(cursorPostedAt, cursorId);
+  }
+
+  public int sizeOrDefault() {
+    return size != null ? size : 20;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementListResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementListResponse.java
@@ -1,0 +1,5 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import java.util.List;
+
+public record AnnouncementListResponse(List<AnnouncementSummary> items) {}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/repository/AnnouncementRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/repository/AnnouncementRepository.java
@@ -13,83 +13,81 @@ import java.util.Optional;
 @Repository
 @RequiredArgsConstructor
 public class AnnouncementRepository {
-	private final EntityManager em;
+  private final EntityManager em;
 
-	public Announcement save(Announcement announcement) {
-		em.persist(announcement);
-		return announcement;
-	}
+  public Announcement save(Announcement announcement) {
+    em.persist(announcement);
+    return announcement;
+  }
 
-	public Optional<Announcement> findById(Long id) {
-		return em.createQuery("select a from Announcement a where a.id = :id", Announcement.class)
-						.setParameter("id", id)
-						.getResultStream()
-						.findFirst();
-	}
+  public Optional<Announcement> findById(Long id) {
+    return em.createQuery("select a from Announcement a where a.id = :id", Announcement.class)
+        .setParameter("id", id)
+        .getResultStream()
+        .findFirst();
+  }
 
-	public void delete(Announcement announcement) {
-		em.remove(announcement);
-	}
+  public void delete(Announcement announcement) {
+    em.remove(announcement);
+  }
 
-	// 사용자: 게시된 공지 중 가장 최신 1건 (pinned 무관). 팝업용.
-	public Optional<Announcement> findLatestPublished() {
-		return em.createQuery(
-										"select a from Announcement a "
-														+ "where a.published = true "
-														+ "order by a.postedAt desc, a.id desc",
-										Announcement.class)
-						.setMaxResults(1)
-						.getResultStream()
-						.findFirst();
-	}
+  // 사용자: 게시된 공지 중 가장 최신 1건 (pinned 무관). 팝업용.
+  public Optional<Announcement> findLatestPublished() {
+    return em.createQuery(
+            "select a from Announcement a "
+                + "where a.published = true "
+                + "order by a.postedAt desc, a.id desc",
+            Announcement.class)
+        .setMaxResults(1)
+        .getResultStream()
+        .findFirst();
+  }
 
-	/**
-	 * 사용자: 게시된 고정 공지 전체
-	 */
-	public List<Announcement> findPublishedPinned() {
-		return em.createQuery(
-										"select a from Announcement a "
-														+ "where a.published = true and a.pinned = true "
-														+ "order by a.postedAt desc, a.id desc",
-										Announcement.class)
-						.getResultList();
-	}
+  /** 사용자: 게시된 고정 공지 전체 */
+  public List<Announcement> findPublishedPinned() {
+    return em.createQuery(
+            "select a from Announcement a "
+                + "where a.published = true and a.pinned = true "
+                + "order by a.postedAt desc, a.id desc",
+            Announcement.class)
+        .getResultList();
+  }
 
-	public List<Announcement> findAllPinned() {
-		return em.createQuery(
-						"select a from Announcement a " +
-										"where a.pinned = true " +
-										"order by a.postedAt, a.id desc", Announcement.class
-		).getResultList();
-	}
+  public List<Announcement> findAllPinned() {
+    return em.createQuery(
+            "select a from Announcement a "
+                + "where a.pinned = true "
+                + "order by a.postedAt desc, a.id desc",
+            Announcement.class)
+        .getResultList();
+  }
 
-	public List<Announcement> findPublishedNonPinnedByCursor(AnnouncementCursor cursor, int size) {
-		return findByCursor(cursor, size, true);
-	}
+  public List<Announcement> findPublishedNonPinnedByCursor(AnnouncementCursor cursor, int size) {
+    return findByCursor(cursor, size, true);
+  }
 
-	public List<Announcement> findAllNonPinnedByCursor(AnnouncementCursor cursor, int size) {
-		return findByCursor(cursor, size, false);
-	}
+  public List<Announcement> findAllNonPinnedByCursor(AnnouncementCursor cursor, int size) {
+    return findByCursor(cursor, size, false);
+  }
 
-	private List<Announcement> findByCursor(AnnouncementCursor cursor, int size, boolean publishedOnly) {
-		StringBuilder jpql =
-						new StringBuilder("select a from Announcement a where a.pinned = false");
-		if (publishedOnly) {
-			jpql.append(" and a.published = true");
-		}
-		if (cursor != null) {
-			jpql.append(
-							" and (a.postedAt < :cursorPostedAt" +
-											" or (a.postedAt = :cursorPostedAt and a.id < :cursorId))"
-			);
-		}
-		jpql.append(" order by a.postedAt desc, a.id desc");
+  private List<Announcement> findByCursor(
+      AnnouncementCursor cursor, int size, boolean publishedOnly) {
+    StringBuilder jpql = new StringBuilder("select a from Announcement a where a.pinned = false");
+    if (publishedOnly) {
+      jpql.append(" and a.published = true");
+    }
+    if (cursor != null) {
+      jpql.append(
+          " and (a.postedAt < :cursorPostedAt"
+              + " or (a.postedAt = :cursorPostedAt and a.id < :cursorId))");
+    }
+    jpql.append(" order by a.postedAt desc, a.id desc");
 
-		TypedQuery<Announcement> query = em.createQuery(jpql.toString(), Announcement.class);
-		if (cursor != null) {
-			query.setParameter("cursorPostedAt", cursor.postedAt());
-			query.setParameter("cursorId", cursor.id());
-		}
-		return query.setMaxResults(size + 1).getResultList();
-	}
+    TypedQuery<Announcement> query = em.createQuery(jpql.toString(), Announcement.class);
+    if (cursor != null) {
+      query.setParameter("cursorPostedAt", cursor.postedAt());
+      query.setParameter("cursorId", cursor.id());
+    }
+    return query.setMaxResults(size + 1).getResultList();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementService.java
@@ -57,8 +57,8 @@ public class AdminAnnouncementService {
         .orElseThrow(AnnouncementNotFoundException::new);
   }
 
-  public List<AnnouncementDetail> findPinned() {
-    return announcementRepository.findAllPinned().stream().map(AnnouncementDetail::from).toList();
+  public List<AnnouncementSummary> findPinned() {
+    return announcementRepository.findAllPinned().stream().map(AnnouncementSummary::from).toList();
   }
 
   /** 어드민: 일반 공지 커서 페이지네이션 (게시 여부 무관). */

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AnnouncementService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AnnouncementService.java
@@ -5,6 +5,7 @@ import com.typingpractice.typing_practice_be.notice.announcement.domain.Announce
 import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementCursor;
 import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementDetail;
 import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementSummary;
+import com.typingpractice.typing_practice_be.notice.announcement.exception.AnnouncementNotFoundException;
 import com.typingpractice.typing_practice_be.notice.announcement.repository.AnnouncementRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class AnnouncementService {
   private final AnnouncementRepository announcementRepository;
+
+  public AnnouncementDetail findOne(Long id) {
+    Announcement announcement =
+        announcementRepository.findById(id).orElseThrow(AnnouncementNotFoundException::new);
+
+    if (!announcement.isPublished()) {
+      throw new AnnouncementNotFoundException();
+    }
+
+    return AnnouncementDetail.from(announcement);
+  }
 
   /** 팝업용: 최신 게시 공지 1건 (없으면 null) */
   public AnnouncementDetail findLatest() {


### PR DESCRIPTION
## 주요 내용
- 사용자/어드민 공지사항 컨트롤러 실구현
- 커서 페이지네이션 요청 DTO와 고정 공지 응답 wrapper 추가
- SecurityConfig에 사용자용 공지사항 GET 경로 permitAll 추가
- 직전 단계에서 누락된 사용자 단건 조회 메서드 보완 및 일부 결함 수정

## 세부 내용
### Controller
- AnnouncementController: 목록/최신/고정/단건 4개 엔드포인트 실구현
- AdminAnnouncementController: 등록/수정/삭제/목록/고정/단건 6개 엔드포인트 실구현

### DTO
- AnnouncementCursorRequest 추가
  - cursorPostedAt/cursorId/size 파라미터
  - cursor 두 값이 동시에 있거나 동시에 없도록 @AssertTrue 검증
  - size 미지정 시 기본값 20
- AnnouncementListResponse 추가 (고정 공지 응답 wrapper)

### Security
- /announcements, /announcements/** GET 요청 permitAll 추가

### Service
- AnnouncementService.findOne 추가 (사용자 단건 조회, 미게시 시 404)
- AdminAnnouncementService.findPinned 반환 타입 수정 (Detail → Summary)

### Repository
- findAllPinned ORDER BY 절 수정 (postedAt desc 누락 버그)

### Entity
- Announcement.published 기본값 제거 (생성 시 항상 명시적으로 받음)