### PR TITLE
feat: 업데이트 노트 도메인 기반 구조 추가

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -46,7 +46,9 @@ public enum ErrorCode {
   DAILY_REPORT_LIMIT(HttpStatus.CONFLICT, "하루 신고 제한 횟수에 도달했습니다."),
   DAILY_QUOTE_UPLOAD_LIMIT(HttpStatus.CONFLICT, "하루 업로드 제한 횟수에 도달했습니다."),
 
-  ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다.");
+  ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다."),
+  UPDATE_NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "업데이트 노트를 찾을 수 없습니다."),
+  UPDATE_NOTE_VERSION_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 버전입니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/utils/TimeUtils.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/utils/TimeUtils.java
@@ -42,4 +42,9 @@ public class TimeUtils {
         .withZoneSameInstant(ZoneOffset.UTC)
         .toLocalDateTime();
   }
+
+  // KST LocalDateTime을 UTC LocalDateTime으로
+  public static LocalDateTime kstToUtc(LocalDateTime kstDateTime) {
+    return kstDateTime.atZone(KST).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/CreateAnnouncementRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/CreateAnnouncementRequest.java
@@ -1,23 +1,23 @@
 package com.typingpractice.typing_practice_be.notice.announcement.dto;
 
 import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
 public record CreateAnnouncementRequest(
-				@NotNull LocalDateTime postedAt,
-				@NotNull @Valid LocalizedTextRequest title,
-				@NotNull @Valid LocalizedTextRequest content,
-				@NotNull Boolean published,
-				@NotNull Boolean pinned
-) {
-	public LocalizedText titleAsValue() {
-		return title.toValue();
-	}
+    @NotNull LocalDateTime postedAt,
+    @NotNull @Valid LocalizedTextRequest title,
+    @NotNull @Valid LocalizedTextRequest content,
+    @NotNull Boolean published,
+    @NotNull Boolean pinned) {
+  public LocalizedText titleAsValue() {
+    return title.toValue();
+  }
 
-	public LocalizedText contentAsValue() {
-		return content.toValue();
-	}
+  public LocalizedText contentAsValue() {
+    return content.toValue();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/UpdateAnnouncementRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/UpdateAnnouncementRequest.java
@@ -1,21 +1,22 @@
 package com.typingpractice.typing_practice_be.notice.announcement.dto;
 
 import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
 import jakarta.validation.Valid;
 
 import java.time.LocalDateTime;
 
 public record UpdateAnnouncementRequest(
-				LocalDateTime postedAt,
-				@Valid LocalizedTextRequest title,
-				@Valid LocalizedTextRequest content,
-				Boolean published,
-				Boolean pinned) {
-	public LocalizedText titleAsValue() {
-		return title == null ? null : title.toValue();
-	}
+    LocalDateTime postedAt,
+    @Valid LocalizedTextRequest title,
+    @Valid LocalizedTextRequest content,
+    Boolean published,
+    Boolean pinned) {
+  public LocalizedText titleAsValue() {
+    return title == null ? null : title.toValue();
+  }
 
-	public LocalizedText contentAsValue() {
-		return content == null ? null : content.toValue();
-	}
+  public LocalizedText contentAsValue() {
+    return content == null ? null : content.toValue();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/dto/LocalizedTextRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/dto/LocalizedTextRequest.java
@@ -1,10 +1,10 @@
-package com.typingpractice.typing_practice_be.notice.announcement.dto;
+package com.typingpractice.typing_practice_be.notice.dto;
 
 import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
 import jakarta.validation.constraints.NotBlank;
 
 public record LocalizedTextRequest(@NotBlank String ko, String en, String ja) {
-	public LocalizedText toValue() {
-		return new LocalizedText(ko, en, ja);
-	}
+  public LocalizedText toValue() {
+    return new LocalizedText(ko, en, ja);
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/domain/UpdateNote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/domain/UpdateNote.java
@@ -1,0 +1,87 @@
+package com.typingpractice.typing_practice_be.notice.update.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Entity
+@Getter
+@SQLRestriction("deleted = false")
+@SQLDelete(
+    sql = "UPDATE update_note SET deleted = true, deleted_at = NOW() WHERE update_note_id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateNote extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "update_note_id")
+  private Long id;
+
+  @Column(nullable = false, length = 32, unique = true)
+  private String version;
+
+  @Column(columnDefinition = "timestamp with time zone", nullable = false)
+  private LocalDateTime releasedAt;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private List<LocalizedText> newFeatures = new ArrayList<>();
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private List<LocalizedText> improvements = new ArrayList<>();
+
+  @Column(nullable = false)
+  private boolean published;
+
+  public static UpdateNote create(
+      String version,
+      LocalDateTime releasedAt,
+      List<LocalizedText> newFeatures,
+      List<LocalizedText> improvements,
+      boolean published) {
+    UpdateNote note = new UpdateNote();
+    note.version = version;
+    note.releasedAt = releasedAt;
+    note.newFeatures = (newFeatures != null) ? new ArrayList<>(newFeatures) : new ArrayList<>();
+    note.improvements = (improvements != null) ? new ArrayList<>(improvements) : new ArrayList<>();
+    note.published = published;
+    return note;
+  }
+
+  /** PATCH 부분 수정. null = 미변경. */
+  public void update(
+      String version,
+      LocalDateTime releasedAt,
+      List<LocalizedText> newFeatures,
+      List<LocalizedText> improvements,
+      Boolean published) {
+    if (version != null) this.version = version;
+    if (releasedAt != null) this.releasedAt = releasedAt;
+    if (newFeatures != null) this.newFeatures = new ArrayList<>(newFeatures);
+    if (improvements != null) this.improvements = new ArrayList<>(improvements);
+    if (published != null) this.published = published;
+  }
+
+  public List<LocalizedText> getNewFeatures() {
+    return Collections.unmodifiableList(newFeatures);
+  }
+
+  public List<LocalizedText> getImprovements() {
+    return Collections.unmodifiableList(improvements);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/CreateUpdateNoteRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/CreateUpdateNoteRequest.java
@@ -1,0 +1,26 @@
+package com.typingpractice.typing_practice_be.notice.update.dto;
+
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CreateUpdateNoteRequest(
+    @NotBlank String version,
+    @NotNull LocalDateTime releasedAt,
+    @NotNull @Valid List<LocalizedTextRequest> newFeatures,
+    @NotNull @Valid List<LocalizedTextRequest> improvements,
+    @NotNull Boolean published) {
+
+  public List<LocalizedText> newFeaturesAsValue() {
+    return newFeatures.stream().map(LocalizedTextRequest::toValue).toList();
+  }
+
+  public List<LocalizedText> improvementsAsValue() {
+    return improvements.stream().map(LocalizedTextRequest::toValue).toList();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteCursor.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteCursor.java
@@ -1,0 +1,5 @@
+package com.typingpractice.typing_practice_be.notice.update.dto;
+
+import java.time.LocalDateTime;
+
+public record UpdateNoteCursor(LocalDateTime releasedAt, Long id) {}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteCursorRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteCursorRequest.java
@@ -1,0 +1,25 @@
+package com.typingpractice.typing_practice_be.notice.update.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+import java.time.LocalDateTime;
+
+public record UpdateNoteCursorRequest(
+    LocalDateTime cursorReleasedAt, Long cursorId, @Min(1) @Max(100) Integer size) {
+
+  @AssertTrue(message = "cursorReleasedAt 과 cursorId 는 모두 있거나 모두 없어야 합니다.")
+  public boolean isCursorValid() {
+    return (cursorReleasedAt == null) == (cursorId == null);
+  }
+
+  public UpdateNoteCursor toCursor() {
+    if (cursorReleasedAt == null) return null;
+    return new UpdateNoteCursor(cursorReleasedAt, cursorId);
+  }
+
+  public int sizeOrDefault() {
+    return size != null ? size : 20;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteIdResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteIdResponse.java
@@ -1,0 +1,3 @@
+package com.typingpractice.typing_practice_be.notice.update.dto;
+
+public record UpdateNoteIdResponse(Long id) {}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteResponse.java
@@ -1,0 +1,30 @@
+package com.typingpractice.typing_practice_be.notice.update.dto;
+
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import com.typingpractice.typing_practice_be.notice.update.domain.UpdateNote;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record UpdateNoteResponse(
+    Long id,
+    String version,
+    LocalDateTime releasedAt,
+    List<LocalizedText> newFeatures,
+    List<LocalizedText> improvements,
+    boolean published,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt) {
+
+  public static UpdateNoteResponse from(UpdateNote note) {
+    return new UpdateNoteResponse(
+        note.getId(),
+        note.getVersion(),
+        note.getReleasedAt(),
+        note.getNewFeatures(),
+        note.getImprovements(),
+        note.isPublished(),
+        note.getCreatedAt(),
+        note.getUpdatedAt());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateUpdateNoteRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateUpdateNoteRequest.java
@@ -1,0 +1,28 @@
+package com.typingpractice.typing_practice_be.notice.update.dto;
+
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record UpdateUpdateNoteRequest(
+    String version,
+    LocalDateTime releasedAt,
+    @Valid List<LocalizedTextRequest> newFeatures,
+    @Valid List<LocalizedTextRequest> improvements,
+    Boolean published) {
+
+  public List<LocalizedText> newFeaturesAsValue() {
+    return newFeatures == null
+        ? null
+        : newFeatures.stream().map(LocalizedTextRequest::toValue).toList();
+  }
+
+  public List<LocalizedText> improvementsAsValue() {
+    return improvements == null
+        ? null
+        : improvements.stream().map(LocalizedTextRequest::toValue).toList();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/exception/UpdateNoteNotFoundException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/exception/UpdateNoteNotFoundException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.notice.update.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class UpdateNoteNotFoundException extends BusinessException {
+  public UpdateNoteNotFoundException() {
+    super(ErrorCode.UPDATE_NOTE_NOT_FOUND);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/exception/UpdateNoteVersionConflictException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/exception/UpdateNoteVersionConflictException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.notice.update.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class UpdateNoteVersionConflictException extends BusinessException {
+  public UpdateNoteVersionConflictException() {
+    super(ErrorCode.UPDATE_NOTE_VERSION_CONFLICT);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/repository/UpdateNoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/repository/UpdateNoteRepository.java
@@ -1,0 +1,93 @@
+package com.typingpractice.typing_practice_be.notice.update.repository;
+
+import com.typingpractice.typing_practice_be.notice.update.domain.UpdateNote;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteCursor;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UpdateNoteRepository {
+  private final EntityManager em;
+
+  public UpdateNote save(UpdateNote updateNote) {
+    em.persist(updateNote);
+    return updateNote;
+  }
+
+  public Optional<UpdateNote> findById(Long id) {
+    return em.createQuery("select u from UpdateNote u where u.id = :id", UpdateNote.class)
+        .setParameter("id", id)
+        .getResultStream()
+        .findFirst();
+  }
+
+  public void delete(UpdateNote updateNote) {
+    em.remove(updateNote);
+  }
+
+  /** version 중복 체크. 자기 자신 제외 옵션 (수정 시 사용). */
+  public boolean existsByVersion(String version, Long excludeId) {
+    StringBuilder jpql =
+        new StringBuilder("select count(u) from UpdateNote u where u.version = :version");
+    if (excludeId != null) {
+      jpql.append(" and u.id <> :excludeId");
+    }
+    TypedQuery<Long> query = em.createQuery(jpql.toString(), Long.class);
+    query.setParameter("version", version);
+    if (excludeId != null) {
+      query.setParameter("excludeId", excludeId);
+    }
+    return query.getSingleResult() > 0;
+  }
+
+  /** 사용자: 게시된 업데이트 노트 중 가장 최신 1건. 팝업용. */
+  public Optional<UpdateNote> findLatestPublished() {
+    return em.createQuery(
+            "select u from UpdateNote u "
+                + "where u.published = true "
+                + "order by u.releasedAt desc, u.id desc",
+            UpdateNote.class)
+        .setMaxResults(1)
+        .getResultStream()
+        .findFirst();
+  }
+
+  /** 사용자: 게시된 업데이트 노트 커서 페이지네이션. size+1 조회로 hasNext 판정용. */
+  public List<UpdateNote> findPublishedByCursor(UpdateNoteCursor cursor, int size) {
+    return findByCursor(cursor, size, true);
+  }
+
+  /** 어드민: 업데이트 노트 커서 페이지네이션 (게시 여부 무관). size+1 조회로 hasNext 판정용. */
+  public List<UpdateNote> findAllByCursor(UpdateNoteCursor cursor, int size) {
+    return findByCursor(cursor, size, false);
+  }
+
+  private List<UpdateNote> findByCursor(UpdateNoteCursor cursor, int size, boolean publishedOnly) {
+    StringBuilder jpql = new StringBuilder("select u from UpdateNote u");
+    boolean hasWhere = false;
+    if (publishedOnly) {
+      jpql.append(" where u.published = true");
+      hasWhere = true;
+    }
+    if (cursor != null) {
+      jpql.append(hasWhere ? " and" : " where");
+      jpql.append(
+          " (u.releasedAt < :cursorReleasedAt"
+              + "      or (u.releasedAt = :cursorReleasedAt and u.id < :cursorId))");
+    }
+    jpql.append(" order by u.releasedAt desc, u.id desc");
+
+    TypedQuery<UpdateNote> query = em.createQuery(jpql.toString(), UpdateNote.class);
+    if (cursor != null) {
+      query.setParameter("cursorReleasedAt", cursor.releasedAt());
+      query.setParameter("cursorId", cursor.id());
+    }
+    return query.setMaxResults(size + 1).getResultList();
+  }
+}

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AdminAnnouncementE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AdminAnnouncementE2ETest.java
@@ -9,6 +9,7 @@ import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AnnouncementE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AnnouncementE2ETest.java
@@ -9,6 +9,7 @@ import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementServiceTest.java
@@ -13,6 +13,8 @@ import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
## 주요 내용
- LocalizedTextRequest 를 notice 패키지로 이동하여 announcement/update 가 공유
- update 도메인 신설 (도메인/DTO/Repository/Exception)
- TimeUtils 에 KST→UTC 변환 메서드 추가

## 세부 내용
### 공통
- ErrorCode 에 UPDATE_NOTE_NOT_FOUND, UPDATE_NOTE_VERSION_CONFLICT 추가
- TimeUtils.kstToUtc(LocalDateTime) 추가
- LocalizedTextRequest 위치 이동: notice/announcement/dto → notice/dto
- Announcement 의 Create/Update Request 의 import 경로 갱신

### Update 도메인
- UpdateNote 엔티티 추가
  - version (unique, length 32), releasedAt, newFeatures/improvements (JSONB)
  - published 플래그
  - BaseEntity 상속, soft delete 적용
  - PATCH 부분 수정 패턴 (null = 미변경)
  - newFeatures/improvements 방어적 복사 + unmodifiableList getter
- DTO
  - CreateUpdateNoteRequest (version @NotBlank, releasedAt @NotNull, 리스트 @NotNull @Valid)
  - UpdateUpdateNoteRequest (모든 필드 nullable, null = 미변경)
  - UpdateNoteResponse (단일 응답 DTO, Summary/Detail 분리 없음)
  - UpdateNoteIdResponse, UpdateNoteCursor, UpdateNoteCursorRequest
- Exception
  - UpdateNoteNotFoundException
  - UpdateNoteVersionConflict
- Repository
  - JPQL 기반 findById (em.find 미사용)
  - existsByVersion(version, excludeId) — 등록/수정 시 중복 체크
  - findLatestPublished — 사용자 팝업용
  - findPublishedByCursor — 사용자 목록 (게시된 것만)
  - findAllByCursor — 어드민 목록 (게시 여부 무관)
  - 정렬: releasedAt desc, id desc
  - 커서 조건: releasedAt 우선, 동일 시 id 비교
  - size+1 조회로 hasNext 판정