### PR TITLE
feat: 업데이트 노트 Service/Controller 추가

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -68,6 +68,8 @@ public class SecurityConfig {
                   .permitAll()
                   .requestMatchers(HttpMethod.GET, "/announcements", "/announcements/**")
                   .permitAll()
+                  .requestMatchers(HttpMethod.GET, "/update-notes", "/update-notes/**")
+                  .permitAll()
                   .requestMatchers("/error")
                   .permitAll()
                   .requestMatchers(HttpMethod.POST, "/typing-records")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/controller/AdminUpdateNoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/controller/AdminUpdateNoteController.java
@@ -1,0 +1,49 @@
+package com.typingpractice.typing_practice_be.notice.update.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.update.dto.*;
+import com.typingpractice.typing_practice_be.notice.update.service.AdminUpdateNoteService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/update-notes")
+@RequiredArgsConstructor
+public class AdminUpdateNoteController {
+  private final AdminUpdateNoteService adminUpdateNoteService;
+
+  @PostMapping
+  public ApiResponse<UpdateNoteIdResponse> postUpdateNote(
+      @RequestBody @Valid CreateUpdateNoteRequest request) {
+    Long id = adminUpdateNoteService.create(request);
+    return ApiResponse.ok(new UpdateNoteIdResponse(id));
+  }
+
+  @PatchMapping("/{id}")
+  public ApiResponse<Void> patchUpdateNote(
+      @PathVariable Long id, @RequestBody @Valid UpdateUpdateNoteRequest request) {
+    adminUpdateNoteService.update(id, request);
+    return ApiResponse.ok(null);
+  }
+
+  @DeleteMapping("/{id}")
+  public ApiResponse<Void> deleteUpdateNote(@PathVariable Long id) {
+    adminUpdateNoteService.delete(id);
+    return ApiResponse.ok(null);
+  }
+
+  @GetMapping
+  public ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>> getUpdateNotes(
+      @ModelAttribute @Valid UpdateNoteCursorRequest request) {
+    CursorPage<UpdateNoteResponse, UpdateNoteCursor> result =
+        adminUpdateNoteService.findList(request.toCursor(), request.sizeOrDefault());
+    return ApiResponse.ok(result);
+  }
+
+  @GetMapping("/{id}")
+  public ApiResponse<UpdateNoteResponse> getUpdateNoteById(@PathVariable Long id) {
+    return ApiResponse.ok(adminUpdateNoteService.findOne(id));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/controller/UpdateNoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/controller/UpdateNoteController.java
@@ -1,0 +1,37 @@
+package com.typingpractice.typing_practice_be.notice.update.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteCursor;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteCursorRequest;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteResponse;
+import com.typingpractice.typing_practice_be.notice.update.service.UpdateNoteService;
+import java.awt.*;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/update-notes")
+@RequiredArgsConstructor
+public class UpdateNoteController {
+  private final UpdateNoteService updateNoteService;
+
+  @GetMapping
+  public ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>> getUpdateNotes(
+      @ModelAttribute @Valid UpdateNoteCursorRequest request) {
+    CursorPage<UpdateNoteResponse, UpdateNoteCursor> result =
+        updateNoteService.findList(request.toCursor(), request.sizeOrDefault());
+
+    return ApiResponse.ok(result);
+  }
+
+  @GetMapping("/latest")
+  public ApiResponse<UpdateNoteResponse> getLatestUpdateNote() {
+    return ApiResponse.ok(updateNoteService.findLatest());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/service/AdminUpdateNoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/service/AdminUpdateNoteService.java
@@ -1,0 +1,95 @@
+package com.typingpractice.typing_practice_be.notice.update.service;
+
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.notice.update.domain.UpdateNote;
+import com.typingpractice.typing_practice_be.notice.update.dto.CreateUpdateNoteRequest;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteCursor;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteResponse;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateUpdateNoteRequest;
+import com.typingpractice.typing_practice_be.notice.update.exception.UpdateNoteNotFoundException;
+import com.typingpractice.typing_practice_be.notice.update.exception.UpdateNoteVersionConflictException;
+import com.typingpractice.typing_practice_be.notice.update.repository.UpdateNoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUpdateNoteService {
+  private final UpdateNoteRepository updateNoteRepository;
+
+  @Transactional
+  public Long create(CreateUpdateNoteRequest request) {
+    if (updateNoteRepository.existsByVersion(request.version(), null)) {
+      throw new UpdateNoteVersionConflictException();
+    }
+
+    LocalDateTime releasedAtUtc = TimeUtils.kstToUtc(request.releasedAt());
+
+    UpdateNote note =
+        UpdateNote.create(
+            request.version(),
+            releasedAtUtc,
+            request.newFeaturesAsValue(),
+            request.improvementsAsValue(),
+            request.published());
+    return updateNoteRepository.save(note).getId();
+  }
+
+  @Transactional
+  public void update(Long id, UpdateUpdateNoteRequest request) {
+    UpdateNote note =
+        updateNoteRepository.findById(id).orElseThrow(UpdateNoteNotFoundException::new);
+
+    if (request.version() != null && updateNoteRepository.existsByVersion(request.version(), id)) {
+      throw new UpdateNoteVersionConflictException();
+    }
+
+    LocalDateTime releasedAtUtc =
+        request.releasedAt() == null ? null : TimeUtils.kstToUtc(request.releasedAt());
+
+    note.update(
+        request.version(),
+        releasedAtUtc,
+        request.newFeaturesAsValue(),
+        request.improvementsAsValue(),
+        request.published());
+  }
+
+  @Transactional
+  public void delete(Long id) {
+    UpdateNote note =
+        updateNoteRepository.findById(id).orElseThrow(UpdateNoteNotFoundException::new);
+    updateNoteRepository.delete(note);
+  }
+
+  public UpdateNoteResponse findOne(Long id) {
+    return updateNoteRepository
+        .findById(id)
+        .map(UpdateNoteResponse::from)
+        .orElseThrow(UpdateNoteNotFoundException::new);
+  }
+
+  /** 어드민: 업데이트 노트 커서 페이지네이션 (게시 여부 무관). */
+  public CursorPage<UpdateNoteResponse, UpdateNoteCursor> findList(
+      UpdateNoteCursor cursor, int size) {
+    List<UpdateNote> fetched = updateNoteRepository.findAllByCursor(cursor, size);
+
+    boolean hasNext = fetched.size() > size;
+    List<UpdateNote> page = hasNext ? fetched.subList(0, size) : fetched;
+
+    List<UpdateNoteResponse> content = page.stream().map(UpdateNoteResponse::from).toList();
+
+    UpdateNoteCursor nextCursor =
+        hasNext
+            ? new UpdateNoteCursor(page.getLast().getReleasedAt(), page.getLast().getId())
+            : null;
+
+    return new CursorPage<>(content, nextCursor, hasNext);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/service/UpdateNoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/service/UpdateNoteService.java
@@ -1,0 +1,40 @@
+package com.typingpractice.typing_practice_be.notice.update.service;
+
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.update.domain.UpdateNote;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteCursor;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteResponse;
+import com.typingpractice.typing_practice_be.notice.update.repository.UpdateNoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UpdateNoteService {
+  private final UpdateNoteRepository updateNoteRepository;
+
+  public UpdateNoteResponse findLatest() {
+    return updateNoteRepository.findLatestPublished().map(UpdateNoteResponse::from).orElse(null);
+  }
+
+  public CursorPage<UpdateNoteResponse, UpdateNoteCursor> findList(
+      UpdateNoteCursor cursor, int size) {
+    List<UpdateNote> fetched = updateNoteRepository.findPublishedByCursor(cursor, size);
+
+    boolean hasNext = fetched.size() > size;
+    List<UpdateNote> page = hasNext ? fetched.subList(0, size) : fetched;
+
+    List<UpdateNoteResponse> content = page.stream().map(UpdateNoteResponse::from).toList();
+
+    UpdateNoteCursor nextCursor =
+        hasNext
+            ? new UpdateNoteCursor(page.getLast().getReleasedAt(), page.getLast().getId())
+            : null;
+
+    return new CursorPage<>(content, nextCursor, hasNext);
+  }
+}


### PR DESCRIPTION
## 주요 내용
- 사용자/어드민 Service 분리 구현
- 사용자/어드민 Controller 구현
- SecurityConfig에 사용자 GET 경로 permitAll 추가

## 세부 내용
### Service
- UpdateNoteService 추가 (사용자용)
  - findLatest: 팝업용 최신 게시 1건
  - findList: 게시된 노트 커서 페이지네이션
- AdminUpdateNoteService 추가 (어드민용)
  - create: version 중복 체크 + KST→UTC 변환 후 등록
  - update: PATCH 부분 수정 + version 중복 체크 (자기 자신 제외) + KST→UTC 변환
  - delete, findOne
  - findList: 게시 여부 무관 커서 페이지네이션

### Controller
- UpdateNoteController 추가 (사용자용 2개 엔드포인트)
  - GET /update-notes (목록)
  - GET /update-notes/latest (팝업용)
- AdminUpdateNoteController 추가 (어드민용 5개 엔드포인트)
  - POST, PATCH /{id}, DELETE /{id}, GET, GET /{id}

### Security
- /update-notes, /update-notes/** GET 요청 permitAll 추가