### PR TITLE
feat: 공지사항/업데이트 노트 도메인 추가 및 Quote 영구 삭제 기능

### DIFF
--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/TestAuthController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/auth/controller/TestAuthController.java
@@ -1,0 +1,46 @@
+package com.typingpractice.typing_practice_be.auth.controller;
+
+import com.typingpractice.typing_practice_be.auth.dto.LoginResponse;
+import com.typingpractice.typing_practice_be.auth.dto.TestLoginRequest;
+import com.typingpractice.typing_practice_be.auth.dto.google.GoogleUserInfo;
+import com.typingpractice.typing_practice_be.auth.service.AuthService;
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.jwt.JwtTokenProvider;
+import com.typingpractice.typing_practice_be.member.domain.Member;
+import com.typingpractice.typing_practice_be.member.dto.LoginResult;
+import com.typingpractice.typing_practice_be.member.service.MemberService;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@Profile("local")
+public class TestAuthController {
+
+  private final AuthService authService;
+  private final MemberService memberService;
+  private final JwtTokenProvider jwtTokenProvider;
+
+  @PostMapping("/auth/test")
+  public ApiResponse<LoginResponse> testLogin(@RequestBody TestLoginRequest request) {
+
+    LoginResult loginResult =
+        memberService.loginOrSignIn(
+            GoogleUserInfo.create(
+                request.getProviderId(),
+                "email",
+                "user_" + UUID.randomUUID().toString().substring(0, 8),
+                "picture"));
+
+    Member member = loginResult.getMember();
+
+    String token = jwtTokenProvider.createToken(member.getId(), member.getRole());
+    String refreshToken = authService.createRefreshToken(member);
+
+    return ApiResponse.ok(LoginResponse.from(loginResult, token, refreshToken));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/dto/CursorPage.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/dto/CursorPage.java
@@ -1,0 +1,16 @@
+package com.typingpractice.typing_practice_be.common.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.List;
+
+@Getter
+@ToString
+@AllArgsConstructor
+public class CursorPage<T, C> {
+	private final List<T> content;
+	private final C nextCursor;
+	private final boolean hasNext;
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -46,7 +46,9 @@ public enum ErrorCode {
   DAILY_REPORT_LIMIT(HttpStatus.CONFLICT, "하루 신고 제한 횟수에 도달했습니다."),
   DAILY_QUOTE_UPLOAD_LIMIT(HttpStatus.CONFLICT, "하루 업로드 제한 횟수에 도달했습니다."),
 
-  ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다.");
+  ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다."),
+  UPDATE_NOTE_NOT_FOUND(HttpStatus.NOT_FOUND, "업데이트 노트를 찾을 수 없습니다."),
+  UPDATE_NOTE_VERSION_CONFLICT(HttpStatus.CONFLICT, "이미 존재하는 버전입니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/exception/ErrorCode.java
@@ -44,7 +44,9 @@ public enum ErrorCode {
   REPORT_NOT_PROCESSABLE(HttpStatus.BAD_REQUEST, "처리할 수 없는 신고 내역입니다."),
 
   DAILY_REPORT_LIMIT(HttpStatus.CONFLICT, "하루 신고 제한 횟수에 도달했습니다."),
-  DAILY_QUOTE_UPLOAD_LIMIT(HttpStatus.CONFLICT, "하루 업로드 제한 횟수에 도달했습니다.");
+  DAILY_QUOTE_UPLOAD_LIMIT(HttpStatus.CONFLICT, "하루 업로드 제한 횟수에 도달했습니다."),
+
+  ANNOUNCEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "공지사항을 찾을 수 없습니다.");
 
   private final HttpStatus status;
   private final String message;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/utils/TimeUtils.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/common/utils/TimeUtils.java
@@ -42,4 +42,9 @@ public class TimeUtils {
         .withZoneSameInstant(ZoneOffset.UTC)
         .toLocalDateTime();
   }
+
+  // KST LocalDateTime을 UTC LocalDateTime으로
+  public static LocalDateTime kstToUtc(LocalDateTime kstDateTime) {
+    return kstDateTime.atZone(KST).withZoneSameInstant(ZoneOffset.UTC).toLocalDateTime();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -8,6 +8,7 @@ import com.typingpractice.typing_practice_be.common.security.CustomAuthenticatio
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
 import org.springframework.http.HttpMethod;
 import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -20,6 +21,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
 import java.util.List;
 
 @Configuration
@@ -31,6 +33,7 @@ public class SecurityConfig {
   private final AuthService authService;
   private final CustomAuthenticationEntryPoint authenticationEntryPoint;
   private final CustomAccessDeniedHandler accessDeniedHandler;
+  private final Environment environment;
 
   @Bean
   public JwtAuthenticationFilter jwtAuthenticationFilter(
@@ -40,48 +43,51 @@ public class SecurityConfig {
 
   @Bean
   public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    boolean isLocal = Arrays.asList(environment.getActiveProfiles()).contains("local");
+
     http.cors(Customizer.withDefaults())
         .csrf(AbstractHttpConfigurer::disable)
         .sessionManagement(
             session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 안 씀
         .authorizeHttpRequests(
-            auth ->
-                auth
-                    // 인증 불필요
-                    .requestMatchers("/swagger-ui/**", "/api-docs/**")
+            auth -> {
+              if (isLocal) {
+                // 인증 불필요
+                auth.requestMatchers("/swagger-ui/**", "/api-docs/**")
                     .permitAll()
                     .requestMatchers("/auth/test")
-                    .permitAll()
-                    //
-                    .requestMatchers("/auth/google")
-                    .permitAll()
-                    .requestMatchers("/auth/refresh")
-                    .permitAll()
-                    .requestMatchers(HttpMethod.GET, "/quotes")
-                    .permitAll()
-                    .requestMatchers(HttpMethod.GET, "/words")
-                    .permitAll()
-                    .requestMatchers("/error")
-                    .permitAll()
-                    .requestMatchers(HttpMethod.POST, "/typing-records")
-                    .permitAll()
-                    .requestMatchers(HttpMethod.POST, "/word-typing-records")
-                    .permitAll()
-                    .requestMatchers("/actuator/prometheus")
-                    .permitAll()
-                    // 관리자 전용
-                    .requestMatchers("/admin/**")
-                    .hasRole("ADMIN")
+                    .permitAll();
+              }
+              auth.requestMatchers("/auth/google")
+                  .permitAll()
+                  .requestMatchers("/auth/refresh")
+                  .permitAll()
+                  .requestMatchers(HttpMethod.GET, "/quotes")
+                  .permitAll()
+                  .requestMatchers(HttpMethod.GET, "/words")
+                  .permitAll()
+                  .requestMatchers("/error")
+                  .permitAll()
+                  .requestMatchers(HttpMethod.POST, "/typing-records")
+                  .permitAll()
+                  .requestMatchers(HttpMethod.POST, "/word-typing-records")
+                  .permitAll()
+                  .requestMatchers("/actuator/prometheus")
+                  .permitAll()
+                  // 관리자 전용
+                  .requestMatchers("/admin/**")
+                  .hasRole("ADMIN")
 
-                    // BANNED 제외 (USER, ADMIN만)
-                    .requestMatchers(HttpMethod.POST, "/quotes/public")
-                    .hasAnyRole("USER", "ADMIN")
-                    .requestMatchers(HttpMethod.POST, "/quotes/*/publish")
-                    .hasAnyRole("USER", "ADMIN")
-                    .requestMatchers(HttpMethod.POST, "/reports")
-                    .hasAnyRole("USER", "ADMIN")
-                    .anyRequest()
-                    .authenticated())
+                  // BANNED 제외 (USER, ADMIN만)
+                  .requestMatchers(HttpMethod.POST, "/quotes/public")
+                  .hasAnyRole("USER", "ADMIN")
+                  .requestMatchers(HttpMethod.POST, "/quotes/*/publish")
+                  .hasAnyRole("USER", "ADMIN")
+                  .requestMatchers(HttpMethod.POST, "/reports")
+                  .hasAnyRole("USER", "ADMIN")
+                  .anyRequest()
+                  .authenticated();
+            })
         .exceptionHandling(
             ex ->
                 ex.authenticationEntryPoint(authenticationEntryPoint)

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -66,6 +66,8 @@ public class SecurityConfig {
                   .permitAll()
                   .requestMatchers(HttpMethod.GET, "/words")
                   .permitAll()
+                  .requestMatchers(HttpMethod.GET, "/announcements", "/announcements/**")
+                  .permitAll()
                   .requestMatchers("/error")
                   .permitAll()
                   .requestMatchers(HttpMethod.POST, "/typing-records")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/config/SecurityConfig.java
@@ -68,6 +68,8 @@ public class SecurityConfig {
                   .permitAll()
                   .requestMatchers(HttpMethod.GET, "/announcements", "/announcements/**")
                   .permitAll()
+                  .requestMatchers(HttpMethod.GET, "/update-notes", "/update-notes/**")
+                  .permitAll()
                   .requestMatchers("/error")
                   .permitAll()
                   .requestMatchers(HttpMethod.POST, "/typing-records")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AdminAnnouncementController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AdminAnnouncementController.java
@@ -1,6 +1,11 @@
 package com.typingpractice.typing_practice_be.notice.announcement.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
+import com.typingpractice.typing_practice_be.notice.announcement.service.AdminAnnouncementService;
+import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -8,33 +13,47 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/admin/announcements")
 @RequiredArgsConstructor
 public class AdminAnnouncementController {
+  private final AdminAnnouncementService adminAnnouncementService;
+
   @PostMapping
-  public ApiResponse<Void> postAnnouncement() {
-    return ApiResponse.ok(null);
+  public ApiResponse<AnnouncementIdResponse> postAnnouncement(
+      @RequestBody @Valid CreateAnnouncementRequest request) {
+    Long id = adminAnnouncementService.create(request);
+    return ApiResponse.ok(new AnnouncementIdResponse(id));
   }
 
   @PatchMapping("/{id}")
-  public ApiResponse<Void> patchAnnouncement(@PathVariable Long id) {
+  public ApiResponse<Void> patchAnnouncement(
+      @PathVariable Long id, @RequestBody @Valid UpdateAnnouncementRequest request) {
+    adminAnnouncementService.update(id, request);
     return ApiResponse.ok(null);
   }
 
   @DeleteMapping("/{id}")
   public ApiResponse<Void> deleteAnnouncement(@PathVariable Long id) {
+    adminAnnouncementService.delete(id);
     return ApiResponse.ok(null);
   }
 
   @GetMapping
-  public ApiResponse<Void> getAnnouncements() {
-    return ApiResponse.ok(null);
+  public ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>> getAnnouncements(
+      @ModelAttribute @Valid AnnouncementCursorRequest request) {
+    CursorPage<AnnouncementSummary, AnnouncementCursor> result =
+        adminAnnouncementService.findList(request.toCursor(), request.sizeOrDefault());
+
+    return ApiResponse.ok(result);
   }
 
   @GetMapping("/pinned")
-  public ApiResponse<Void> getPinnedAnnouncements() {
-    return ApiResponse.ok(null);
+  public ApiResponse<AnnouncementListResponse> getPinnedAnnouncements() {
+
+    List<AnnouncementSummary> items = adminAnnouncementService.findPinned();
+
+    return ApiResponse.ok(new AnnouncementListResponse(items));
   }
 
   @GetMapping("/{id}")
-  public ApiResponse<Void> getAnnouncementById(@PathVariable Long id) {
-    return ApiResponse.ok(null);
+  public ApiResponse<AnnouncementDetail> getAnnouncementById(@PathVariable Long id) {
+    return ApiResponse.ok(adminAnnouncementService.findOne(id));
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AdminAnnouncementController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AdminAnnouncementController.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.notice.announcement.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
 import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
 import com.typingpractice.typing_practice_be.notice.announcement.service.AdminAnnouncementService;
 import jakarta.validation.Valid;
@@ -16,17 +17,16 @@ public class AdminAnnouncementController {
   private final AdminAnnouncementService adminAnnouncementService;
 
   @PostMapping
-  public ApiResponse<AnnouncementIdResponse> postAnnouncement(
+  public ApiResponse<AnnouncementDetail> postAnnouncement(
       @RequestBody @Valid CreateAnnouncementRequest request) {
-    Long id = adminAnnouncementService.create(request);
-    return ApiResponse.ok(new AnnouncementIdResponse(id));
+    return ApiResponse.ok(AnnouncementDetail.from(adminAnnouncementService.create(request)));
   }
 
   @PatchMapping("/{id}")
-  public ApiResponse<Void> patchAnnouncement(
+  public ApiResponse<AnnouncementDetail> patchAnnouncement(
       @PathVariable Long id, @RequestBody @Valid UpdateAnnouncementRequest request) {
-    adminAnnouncementService.update(id, request);
-    return ApiResponse.ok(null);
+    Announcement update = adminAnnouncementService.update(id, request);
+    return ApiResponse.ok(AnnouncementDetail.from(update));
   }
 
   @DeleteMapping("/{id}")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AdminAnnouncementController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AdminAnnouncementController.java
@@ -1,0 +1,40 @@
+package com.typingpractice.typing_practice_be.notice.announcement.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/announcements")
+@RequiredArgsConstructor
+public class AdminAnnouncementController {
+  @PostMapping
+  public ApiResponse<Void> postAnnouncement() {
+    return ApiResponse.ok(null);
+  }
+
+  @PatchMapping("/{id}")
+  public ApiResponse<Void> patchAnnouncement(@PathVariable Long id) {
+    return ApiResponse.ok(null);
+  }
+
+  @DeleteMapping("/{id}")
+  public ApiResponse<Void> deleteAnnouncement(@PathVariable Long id) {
+    return ApiResponse.ok(null);
+  }
+
+  @GetMapping
+  public ApiResponse<Void> getAnnouncements() {
+    return ApiResponse.ok(null);
+  }
+
+  @GetMapping("/pinned")
+  public ApiResponse<Void> getPinnedAnnouncements() {
+    return ApiResponse.ok(null);
+  }
+
+  @GetMapping("/{id}")
+  public ApiResponse<Void> getAnnouncementById(@PathVariable Long id) {
+    return ApiResponse.ok(null);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AnnouncementController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AnnouncementController.java
@@ -1,0 +1,20 @@
+package com.typingpractice.typing_practice_be.notice.announcement.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/notice/announcement")
+public class AnnouncementController {
+  @GetMapping("")
+  public ApiResponse<Void> getAnnouncements() {
+    return ApiResponse.ok(null);
+  }
+
+  @GetMapping("/recent")
+  public ApiResponse<Void> getRecentAnnouncement() {
+    return ApiResponse.ok(null);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AnnouncementController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AnnouncementController.java
@@ -2,19 +2,30 @@ package com.typingpractice.typing_practice_be.notice.announcement.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
-@RequestMapping("/notice/announcement")
+@RequestMapping("/announcements")
 public class AnnouncementController {
-  @GetMapping("")
-  public ApiResponse<Void> getAnnouncements() {
-    return ApiResponse.ok(null);
-  }
+	@GetMapping
+	public ApiResponse<Void> getAnnouncements() {
+		return ApiResponse.ok(null);
+	}
 
-  @GetMapping("/recent")
-  public ApiResponse<Void> getRecentAnnouncement() {
-    return ApiResponse.ok(null);
-  }
+	@GetMapping("/latest")
+	public ApiResponse<Void> getLatestAnnouncement() {
+		return ApiResponse.ok(null);
+	}
+
+	@GetMapping("/pinned")
+	public ApiResponse<Void> getPinnedAnnouncement() {
+		return ApiResponse.ok(null);
+	}
+
+	@GetMapping("/{id}")
+	public ApiResponse<Void> getAnnouncementById(@PathVariable Long id) {
+		return ApiResponse.ok(null);
+	}
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AnnouncementController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/controller/AnnouncementController.java
@@ -1,31 +1,45 @@
 package com.typingpractice.typing_practice_be.notice.announcement.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
+import com.typingpractice.typing_practice_be.notice.announcement.service.AnnouncementService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/announcements")
+@RequiredArgsConstructor
 public class AnnouncementController {
-	@GetMapping
-	public ApiResponse<Void> getAnnouncements() {
-		return ApiResponse.ok(null);
-	}
+  private final AnnouncementService announcementService;
 
-	@GetMapping("/latest")
-	public ApiResponse<Void> getLatestAnnouncement() {
-		return ApiResponse.ok(null);
-	}
+  @GetMapping
+  public ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>> getAnnouncements(
+      @ModelAttribute @Valid AnnouncementCursorRequest request) {
 
-	@GetMapping("/pinned")
-	public ApiResponse<Void> getPinnedAnnouncement() {
-		return ApiResponse.ok(null);
-	}
+    CursorPage<AnnouncementSummary, AnnouncementCursor> result =
+        announcementService.findList(request.toCursor(), request.sizeOrDefault());
 
-	@GetMapping("/{id}")
-	public ApiResponse<Void> getAnnouncementById(@PathVariable Long id) {
-		return ApiResponse.ok(null);
-	}
+    return ApiResponse.ok(result);
+  }
+
+  @GetMapping("/latest")
+  public ApiResponse<AnnouncementDetail> getLatestAnnouncement() {
+    return ApiResponse.ok(announcementService.findLatest());
+  }
+
+  @GetMapping("/pinned")
+  public ApiResponse<AnnouncementListResponse> getPinnedAnnouncement() {
+    List<AnnouncementSummary> items = announcementService.findPinned();
+
+    return ApiResponse.ok(new AnnouncementListResponse(items));
+  }
+
+  @GetMapping("/{id}")
+  public ApiResponse<AnnouncementDetail> getAnnouncementById(@PathVariable Long id) {
+    return ApiResponse.ok(announcementService.findOne(id));
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/domain/Announcement.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/domain/Announcement.java
@@ -20,58 +20,56 @@ import java.time.LocalDateTime;
 @Getter
 @SQLRestriction("deleted = false")
 @SQLDelete(
-				sql = "UPDATE announcement SET deleted = true, deleted_at = NOW() WHERE announcement_id = ?")
+    sql = "UPDATE announcement SET deleted = true, deleted_at = NOW() WHERE announcement_id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Announcement extends BaseEntity {
-	@Id
-	@GeneratedValue
-	@Column(name = "announcement_id")
-	private Long id;
+  @Id
+  @GeneratedValue
+  @Column(name = "announcement_id")
+  private Long id;
 
-	@Column(columnDefinition = "timestamp with time zone", nullable = false)
-	private LocalDateTime postedAt;
+  @Column(columnDefinition = "timestamp with time zone", nullable = false)
+  private LocalDateTime postedAt;
 
-	@JdbcTypeCode(SqlTypes.JSON)
-	@Column(columnDefinition = "jsonb", nullable = false)
-	private LocalizedText title;
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private LocalizedText title;
 
-	@JdbcTypeCode(SqlTypes.JSON)
-	@Column(columnDefinition = "jsonb", nullable = false)
-	private LocalizedText content;
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private LocalizedText content;
 
-	@Column(nullable = false)
-	private boolean published = true;
+  @Column(nullable = false)
+  private boolean published;
 
-	@Column(nullable = false)
-	private boolean pinned;
+  @Column(nullable = false)
+  private boolean pinned;
 
-	public static Announcement create(
-					LocalDateTime postedAt,
-					LocalizedText title,
-					LocalizedText content,
-					boolean published,
-					boolean pinned) {
-		Announcement a = new Announcement();
-		a.postedAt = postedAt;
-		a.title = title;
-		a.content = content;
-		a.published = published;
-		a.pinned = pinned;
-		return a;
-	}
+  public static Announcement create(
+      LocalDateTime postedAt,
+      LocalizedText title,
+      LocalizedText content,
+      boolean published,
+      boolean pinned) {
+    Announcement a = new Announcement();
+    a.postedAt = postedAt;
+    a.title = title;
+    a.content = content;
+    a.published = published;
+    a.pinned = pinned;
+    return a;
+  }
 
-	public void update(
-					LocalDateTime postedAt,
-					LocalizedText title,
-					LocalizedText content,
-					Boolean published,
-					Boolean pinned) {
-		if (postedAt != null) this.postedAt = postedAt;
-		if (title != null) this.title = title;
-		if (content != null) this.content = content;
-		if (published != null) this.published = published;
-		if (pinned != null) this.pinned = pinned;
-	}
-
-
+  public void update(
+      LocalDateTime postedAt,
+      LocalizedText title,
+      LocalizedText content,
+      Boolean published,
+      Boolean pinned) {
+    if (postedAt != null) this.postedAt = postedAt;
+    if (title != null) this.title = title;
+    if (content != null) this.content = content;
+    if (published != null) this.published = published;
+    if (pinned != null) this.pinned = pinned;
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/domain/Announcement.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/domain/Announcement.java
@@ -1,0 +1,68 @@
+package com.typingpractice.typing_practice_be.notice.announcement.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@SQLRestriction("deleted = false")
+@SQLDelete(
+    sql = "UPDATE announcement SET deleted = true, deleted_at = NOW() WHERE announcement_id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Announcement extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "announcement_id")
+  private Long id;
+
+  @Column(columnDefinition = "timestamp with time zone", nullable = false)
+  private LocalDateTime postedAt;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private LocalizedText title;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private LocalizedText content;
+
+  @Column(nullable = false)
+  private boolean published = true;
+
+  public static Announcement create(
+      LocalDateTime postedAt, LocalizedText title, LocalizedText content) {
+    Announcement a = new Announcement();
+    a.postedAt = postedAt;
+    a.title = title;
+    a.content = content;
+    a.published = true;
+    return a;
+  }
+
+  public void update(LocalDateTime postedAt, LocalizedText title, LocalizedText content) {
+    this.postedAt = postedAt;
+    this.title = title;
+    this.content = content;
+  }
+
+  public void publish() {
+    this.published = true;
+  }
+
+  public void unpublish() {
+    this.published = false;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/domain/Announcement.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/domain/Announcement.java
@@ -20,49 +20,58 @@ import java.time.LocalDateTime;
 @Getter
 @SQLRestriction("deleted = false")
 @SQLDelete(
-    sql = "UPDATE announcement SET deleted = true, deleted_at = NOW() WHERE announcement_id = ?")
+				sql = "UPDATE announcement SET deleted = true, deleted_at = NOW() WHERE announcement_id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Announcement extends BaseEntity {
-  @Id
-  @GeneratedValue
-  @Column(name = "announcement_id")
-  private Long id;
+	@Id
+	@GeneratedValue
+	@Column(name = "announcement_id")
+	private Long id;
 
-  @Column(columnDefinition = "timestamp with time zone", nullable = false)
-  private LocalDateTime postedAt;
+	@Column(columnDefinition = "timestamp with time zone", nullable = false)
+	private LocalDateTime postedAt;
 
-  @JdbcTypeCode(SqlTypes.JSON)
-  @Column(columnDefinition = "jsonb", nullable = false)
-  private LocalizedText title;
+	@JdbcTypeCode(SqlTypes.JSON)
+	@Column(columnDefinition = "jsonb", nullable = false)
+	private LocalizedText title;
 
-  @JdbcTypeCode(SqlTypes.JSON)
-  @Column(columnDefinition = "jsonb", nullable = false)
-  private LocalizedText content;
+	@JdbcTypeCode(SqlTypes.JSON)
+	@Column(columnDefinition = "jsonb", nullable = false)
+	private LocalizedText content;
 
-  @Column(nullable = false)
-  private boolean published = true;
+	@Column(nullable = false)
+	private boolean published = true;
 
-  public static Announcement create(
-      LocalDateTime postedAt, LocalizedText title, LocalizedText content) {
-    Announcement a = new Announcement();
-    a.postedAt = postedAt;
-    a.title = title;
-    a.content = content;
-    a.published = true;
-    return a;
-  }
+	@Column(nullable = false)
+	private boolean pinned;
 
-  public void update(LocalDateTime postedAt, LocalizedText title, LocalizedText content) {
-    this.postedAt = postedAt;
-    this.title = title;
-    this.content = content;
-  }
+	public static Announcement create(
+					LocalDateTime postedAt,
+					LocalizedText title,
+					LocalizedText content,
+					boolean published,
+					boolean pinned) {
+		Announcement a = new Announcement();
+		a.postedAt = postedAt;
+		a.title = title;
+		a.content = content;
+		a.published = published;
+		a.pinned = pinned;
+		return a;
+	}
 
-  public void publish() {
-    this.published = true;
-  }
+	public void update(
+					LocalDateTime postedAt,
+					LocalizedText title,
+					LocalizedText content,
+					Boolean published,
+					Boolean pinned) {
+		if (postedAt != null) this.postedAt = postedAt;
+		if (title != null) this.title = title;
+		if (content != null) this.content = content;
+		if (published != null) this.published = published;
+		if (pinned != null) this.pinned = pinned;
+	}
 
-  public void unpublish() {
-    this.published = false;
-  }
+
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementCursor.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementCursor.java
@@ -1,0 +1,6 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import java.time.LocalDateTime;
+
+public record AnnouncementCursor(LocalDateTime postedAt, Long id) {
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementCursorRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementCursorRequest.java
@@ -1,0 +1,24 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+import java.time.LocalDateTime;
+
+public record AnnouncementCursorRequest(
+    LocalDateTime cursorPostedAt, Long cursorId, @Min(1) @Max(100) Integer size) {
+  @AssertTrue(message = "cursorPostedAt 과 cursorId 는 모두 있거나 모두 없어야 합니다.")
+  public boolean isCursorValid() {
+    return (cursorPostedAt == null) == (cursorId == null);
+  }
+
+  public AnnouncementCursor toCursor() {
+    if (cursorPostedAt == null) return null;
+    return new AnnouncementCursor(cursorPostedAt, cursorId);
+  }
+
+  public int sizeOrDefault() {
+    return size != null ? size : 20;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementDetail.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementDetail.java
@@ -1,0 +1,29 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+
+import java.time.LocalDateTime;
+
+public record AnnouncementDetail(
+				Long id,
+				LocalDateTime postedAt,
+				LocalizedText title,
+				LocalizedText content,
+				boolean published,
+				boolean pinned,
+				LocalDateTime createdAt,
+				LocalDateTime updatedAt) {
+
+	public static AnnouncementDetail from(Announcement a) {
+		return new AnnouncementDetail(
+						a.getId(),
+						a.getPostedAt(),
+						a.getTitle(),
+						a.getContent(),
+						a.isPublished(),
+						a.isPinned(),
+						a.getCreatedAt(),
+						a.getUpdatedAt());
+	}
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementIdResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementIdResponse.java
@@ -1,5 +1,0 @@
-package com.typingpractice.typing_practice_be.notice.announcement.dto;
-
-public record AnnouncementIdResponse(Long id) {
-
-}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementIdResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementIdResponse.java
@@ -1,0 +1,5 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+public record AnnouncementIdResponse(Long id) {
+
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementListResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementListResponse.java
@@ -1,0 +1,5 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import java.util.List;
+
+public record AnnouncementListResponse(List<AnnouncementSummary> items) {}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementSummary.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/AnnouncementSummary.java
@@ -1,0 +1,27 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+
+import java.time.LocalDateTime;
+
+public record AnnouncementSummary(
+				Long id,
+				LocalDateTime postedAt,
+				LocalizedText title,
+				boolean published,
+				boolean pinned,
+				LocalDateTime createdAt,
+				LocalDateTime updatedAt) {
+
+	public static AnnouncementSummary from(Announcement a) {
+		return new AnnouncementSummary(
+						a.getId(),
+						a.getPostedAt(),
+						a.getTitle(),
+						a.isPublished(),
+						a.isPinned(),
+						a.getCreatedAt(),
+						a.getUpdatedAt());
+	}
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/CreateAnnouncementRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/CreateAnnouncementRequest.java
@@ -1,23 +1,23 @@
 package com.typingpractice.typing_practice_be.notice.announcement.dto;
 
 import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDateTime;
 
 public record CreateAnnouncementRequest(
-				@NotNull LocalDateTime postedAt,
-				@NotNull @Valid LocalizedTextRequest title,
-				@NotNull @Valid LocalizedTextRequest content,
-				@NotNull Boolean published,
-				@NotNull Boolean pinned
-) {
-	public LocalizedText titleAsValue() {
-		return title.toValue();
-	}
+    @NotNull LocalDateTime postedAt,
+    @NotNull @Valid LocalizedTextRequest title,
+    @NotNull @Valid LocalizedTextRequest content,
+    @NotNull Boolean published,
+    @NotNull Boolean pinned) {
+  public LocalizedText titleAsValue() {
+    return title.toValue();
+  }
 
-	public LocalizedText contentAsValue() {
-		return content.toValue();
-	}
+  public LocalizedText contentAsValue() {
+    return content.toValue();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/CreateAnnouncementRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/CreateAnnouncementRequest.java
@@ -1,0 +1,23 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+
+public record CreateAnnouncementRequest(
+				@NotNull LocalDateTime postedAt,
+				@NotNull @Valid LocalizedTextRequest title,
+				@NotNull @Valid LocalizedTextRequest content,
+				@NotNull Boolean published,
+				@NotNull Boolean pinned
+) {
+	public LocalizedText titleAsValue() {
+		return title.toValue();
+	}
+
+	public LocalizedText contentAsValue() {
+		return content.toValue();
+	}
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/LocalizedTextRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/LocalizedTextRequest.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import jakarta.validation.constraints.NotBlank;
+
+public record LocalizedTextRequest(@NotBlank String ko, String en, String ja) {
+	public LocalizedText toValue() {
+		return new LocalizedText(ko, en, ja);
+	}
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/UpdateAnnouncementRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/UpdateAnnouncementRequest.java
@@ -1,0 +1,21 @@
+package com.typingpractice.typing_practice_be.notice.announcement.dto;
+
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+
+public record UpdateAnnouncementRequest(
+				LocalDateTime postedAt,
+				@Valid LocalizedTextRequest title,
+				@Valid LocalizedTextRequest content,
+				Boolean published,
+				Boolean pinned) {
+	public LocalizedText titleAsValue() {
+		return title == null ? null : title.toValue();
+	}
+
+	public LocalizedText contentAsValue() {
+		return content == null ? null : content.toValue();
+	}
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/UpdateAnnouncementRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/dto/UpdateAnnouncementRequest.java
@@ -1,21 +1,22 @@
 package com.typingpractice.typing_practice_be.notice.announcement.dto;
 
 import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
 import jakarta.validation.Valid;
 
 import java.time.LocalDateTime;
 
 public record UpdateAnnouncementRequest(
-				LocalDateTime postedAt,
-				@Valid LocalizedTextRequest title,
-				@Valid LocalizedTextRequest content,
-				Boolean published,
-				Boolean pinned) {
-	public LocalizedText titleAsValue() {
-		return title == null ? null : title.toValue();
-	}
+    LocalDateTime postedAt,
+    @Valid LocalizedTextRequest title,
+    @Valid LocalizedTextRequest content,
+    Boolean published,
+    Boolean pinned) {
+  public LocalizedText titleAsValue() {
+    return title == null ? null : title.toValue();
+  }
 
-	public LocalizedText contentAsValue() {
-		return content == null ? null : content.toValue();
-	}
+  public LocalizedText contentAsValue() {
+    return content == null ? null : content.toValue();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/exception/AnnouncementNotFoundException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/exception/AnnouncementNotFoundException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.notice.announcement.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class AnnouncementNotFoundException extends BusinessException {
+  public AnnouncementNotFoundException() {
+    super(ErrorCode.ANNOUNCEMENT_NOT_FOUND);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/repository/AnnouncementRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/repository/AnnouncementRepository.java
@@ -13,83 +13,81 @@ import java.util.Optional;
 @Repository
 @RequiredArgsConstructor
 public class AnnouncementRepository {
-	private final EntityManager em;
+  private final EntityManager em;
 
-	public Announcement save(Announcement announcement) {
-		em.persist(announcement);
-		return announcement;
-	}
+  public Announcement save(Announcement announcement) {
+    em.persist(announcement);
+    return announcement;
+  }
 
-	public Optional<Announcement> findById(Long id) {
-		return em.createQuery("select a from Announcement a where a.id = :id", Announcement.class)
-						.setParameter("id", id)
-						.getResultStream()
-						.findFirst();
-	}
+  public Optional<Announcement> findById(Long id) {
+    return em.createQuery("select a from Announcement a where a.id = :id", Announcement.class)
+        .setParameter("id", id)
+        .getResultStream()
+        .findFirst();
+  }
 
-	public void delete(Announcement announcement) {
-		em.remove(announcement);
-	}
+  public void delete(Announcement announcement) {
+    em.remove(announcement);
+  }
 
-	// 사용자: 게시된 공지 중 가장 최신 1건 (pinned 무관). 팝업용.
-	public Optional<Announcement> findLatestPublished() {
-		return em.createQuery(
-										"select a from Announcement a "
-														+ "where a.published = true "
-														+ "order by a.postedAt desc, a.id desc",
-										Announcement.class)
-						.setMaxResults(1)
-						.getResultStream()
-						.findFirst();
-	}
+  // 사용자: 게시된 공지 중 가장 최신 1건 (pinned 무관). 팝업용.
+  public Optional<Announcement> findLatestPublished() {
+    return em.createQuery(
+            "select a from Announcement a "
+                + "where a.published = true "
+                + "order by a.postedAt desc, a.id desc",
+            Announcement.class)
+        .setMaxResults(1)
+        .getResultStream()
+        .findFirst();
+  }
 
-	/**
-	 * 사용자: 게시된 고정 공지 전체
-	 */
-	public List<Announcement> findPublishedPinned() {
-		return em.createQuery(
-										"select a from Announcement a "
-														+ "where a.published = true and a.pinned = true "
-														+ "order by a.postedAt desc, a.id desc",
-										Announcement.class)
-						.getResultList();
-	}
+  /** 사용자: 게시된 고정 공지 전체 */
+  public List<Announcement> findPublishedPinned() {
+    return em.createQuery(
+            "select a from Announcement a "
+                + "where a.published = true and a.pinned = true "
+                + "order by a.postedAt desc, a.id desc",
+            Announcement.class)
+        .getResultList();
+  }
 
-	public List<Announcement> findAllPinned() {
-		return em.createQuery(
-						"select a from Announcement a " +
-										"where a.pinned = true " +
-										"order by a.postedAt, a.id desc", Announcement.class
-		).getResultList();
-	}
+  public List<Announcement> findAllPinned() {
+    return em.createQuery(
+            "select a from Announcement a "
+                + "where a.pinned = true "
+                + "order by a.postedAt desc, a.id desc",
+            Announcement.class)
+        .getResultList();
+  }
 
-	public List<Announcement> findPublishedNonPinnedByCursor(AnnouncementCursor cursor, int size) {
-		return findByCursor(cursor, size, true);
-	}
+  public List<Announcement> findPublishedNonPinnedByCursor(AnnouncementCursor cursor, int size) {
+    return findByCursor(cursor, size, true);
+  }
 
-	public List<Announcement> findAllNonPinnedByCursor(AnnouncementCursor cursor, int size) {
-		return findByCursor(cursor, size, false);
-	}
+  public List<Announcement> findAllNonPinnedByCursor(AnnouncementCursor cursor, int size) {
+    return findByCursor(cursor, size, false);
+  }
 
-	private List<Announcement> findByCursor(AnnouncementCursor cursor, int size, boolean publishedOnly) {
-		StringBuilder jpql =
-						new StringBuilder("select a from Announcement a where a.pinned = false");
-		if (publishedOnly) {
-			jpql.append(" and a.published = true");
-		}
-		if (cursor != null) {
-			jpql.append(
-							" and (a.postedAt < :cursorPostedAt" +
-											" or (a.postedAt = :cursorPostedAt and a.id < :cursorId))"
-			);
-		}
-		jpql.append(" order by a.postedAt desc, a.id desc");
+  private List<Announcement> findByCursor(
+      AnnouncementCursor cursor, int size, boolean publishedOnly) {
+    StringBuilder jpql = new StringBuilder("select a from Announcement a where a.pinned = false");
+    if (publishedOnly) {
+      jpql.append(" and a.published = true");
+    }
+    if (cursor != null) {
+      jpql.append(
+          " and (a.postedAt < :cursorPostedAt"
+              + " or (a.postedAt = :cursorPostedAt and a.id < :cursorId))");
+    }
+    jpql.append(" order by a.postedAt desc, a.id desc");
 
-		TypedQuery<Announcement> query = em.createQuery(jpql.toString(), Announcement.class);
-		if (cursor != null) {
-			query.setParameter("cursorPostedAt", cursor.postedAt());
-			query.setParameter("cursorId", cursor.id());
-		}
-		return query.setMaxResults(size + 1).getResultList();
-	}
+    TypedQuery<Announcement> query = em.createQuery(jpql.toString(), Announcement.class);
+    if (cursor != null) {
+      query.setParameter("cursorPostedAt", cursor.postedAt());
+      query.setParameter("cursorId", cursor.id());
+    }
+    return query.setMaxResults(size + 1).getResultList();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/repository/AnnouncementRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/repository/AnnouncementRepository.java
@@ -1,0 +1,57 @@
+package com.typingpractice.typing_practice_be.notice.announcement.repository;
+
+import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class AnnouncementRepository {
+  private final EntityManager em;
+
+  public Announcement save(Announcement announcement) {
+    em.persist(announcement);
+    return announcement;
+  }
+
+  public Optional<Announcement> findById(Long id) {
+    return Optional.ofNullable(em.find(Announcement.class, id));
+  }
+
+  public Optional<Announcement> findLatestPublished() {
+    return em.createQuery(
+            "select a from Announcement a "
+                + "where a.published = true "
+                + "order by a.postedAt desc",
+            Announcement.class)
+        .setMaxResults(1)
+        .getResultStream()
+        .findFirst();
+  }
+
+  public List<Announcement> findPublishedRecent(int limit) {
+    return em.createQuery(
+            "select a from Announcement a "
+                + "where a.published = true "
+                + "order by a.postedAt desc",
+            Announcement.class)
+        .setMaxResults(limit)
+        .getResultList();
+  }
+
+  public List<Announcement> findAllForAdmin(int page, int size) {
+    return em.createQuery(
+            "select a from Announcement a order by a.postedAt desc", Announcement.class)
+        .setFirstResult((page - 1) * size)
+        .setMaxResults(size)
+        .getResultList();
+  }
+
+  public void delete(Announcement announcement) {
+    em.remove(announcement);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/repository/AnnouncementRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/repository/AnnouncementRepository.java
@@ -1,7 +1,9 @@
 package com.typingpractice.typing_practice_be.notice.announcement.repository;
 
 import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementCursor;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -11,47 +13,83 @@ import java.util.Optional;
 @Repository
 @RequiredArgsConstructor
 public class AnnouncementRepository {
-  private final EntityManager em;
+	private final EntityManager em;
 
-  public Announcement save(Announcement announcement) {
-    em.persist(announcement);
-    return announcement;
-  }
+	public Announcement save(Announcement announcement) {
+		em.persist(announcement);
+		return announcement;
+	}
 
-  public Optional<Announcement> findById(Long id) {
-    return Optional.ofNullable(em.find(Announcement.class, id));
-  }
+	public Optional<Announcement> findById(Long id) {
+		return em.createQuery("select a from Announcement a where a.id = :id", Announcement.class)
+						.setParameter("id", id)
+						.getResultStream()
+						.findFirst();
+	}
 
-  public Optional<Announcement> findLatestPublished() {
-    return em.createQuery(
-            "select a from Announcement a "
-                + "where a.published = true "
-                + "order by a.postedAt desc",
-            Announcement.class)
-        .setMaxResults(1)
-        .getResultStream()
-        .findFirst();
-  }
+	public void delete(Announcement announcement) {
+		em.remove(announcement);
+	}
 
-  public List<Announcement> findPublishedRecent(int limit) {
-    return em.createQuery(
-            "select a from Announcement a "
-                + "where a.published = true "
-                + "order by a.postedAt desc",
-            Announcement.class)
-        .setMaxResults(limit)
-        .getResultList();
-  }
+	// 사용자: 게시된 공지 중 가장 최신 1건 (pinned 무관). 팝업용.
+	public Optional<Announcement> findLatestPublished() {
+		return em.createQuery(
+										"select a from Announcement a "
+														+ "where a.published = true "
+														+ "order by a.postedAt desc, a.id desc",
+										Announcement.class)
+						.setMaxResults(1)
+						.getResultStream()
+						.findFirst();
+	}
 
-  public List<Announcement> findAllForAdmin(int page, int size) {
-    return em.createQuery(
-            "select a from Announcement a order by a.postedAt desc", Announcement.class)
-        .setFirstResult((page - 1) * size)
-        .setMaxResults(size)
-        .getResultList();
-  }
+	/**
+	 * 사용자: 게시된 고정 공지 전체
+	 */
+	public List<Announcement> findPublishedPinned() {
+		return em.createQuery(
+										"select a from Announcement a "
+														+ "where a.published = true and a.pinned = true "
+														+ "order by a.postedAt desc, a.id desc",
+										Announcement.class)
+						.getResultList();
+	}
 
-  public void delete(Announcement announcement) {
-    em.remove(announcement);
-  }
+	public List<Announcement> findAllPinned() {
+		return em.createQuery(
+						"select a from Announcement a " +
+										"where a.pinned = true " +
+										"order by a.postedAt, a.id desc", Announcement.class
+		).getResultList();
+	}
+
+	public List<Announcement> findPublishedNonPinnedByCursor(AnnouncementCursor cursor, int size) {
+		return findByCursor(cursor, size, true);
+	}
+
+	public List<Announcement> findAllNonPinnedByCursor(AnnouncementCursor cursor, int size) {
+		return findByCursor(cursor, size, false);
+	}
+
+	private List<Announcement> findByCursor(AnnouncementCursor cursor, int size, boolean publishedOnly) {
+		StringBuilder jpql =
+						new StringBuilder("select a from Announcement a where a.pinned = false");
+		if (publishedOnly) {
+			jpql.append(" and a.published = true");
+		}
+		if (cursor != null) {
+			jpql.append(
+							" and (a.postedAt < :cursorPostedAt" +
+											" or (a.postedAt = :cursorPostedAt and a.id < :cursorId))"
+			);
+		}
+		jpql.append(" order by a.postedAt desc, a.id desc");
+
+		TypedQuery<Announcement> query = em.createQuery(jpql.toString(), Announcement.class);
+		if (cursor != null) {
+			query.setParameter("cursorPostedAt", cursor.postedAt());
+			query.setParameter("cursorId", cursor.id());
+		}
+		return query.setMaxResults(size + 1).getResultList();
+	}
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementService.java
@@ -1,0 +1,81 @@
+package com.typingpractice.typing_practice_be.notice.announcement.service;
+
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
+import com.typingpractice.typing_practice_be.notice.announcement.exception.AnnouncementNotFoundException;
+import com.typingpractice.typing_practice_be.notice.announcement.repository.AnnouncementRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminAnnouncementService {
+  private final AnnouncementRepository announcementRepository;
+
+  @Transactional
+  public Long create(CreateAnnouncementRequest request) {
+    Announcement announcement =
+        Announcement.create(
+            request.postedAt(),
+            request.titleAsValue(),
+            request.contentAsValue(),
+            request.published(),
+            request.pinned());
+
+    return announcementRepository.save(announcement).getId();
+  }
+
+  @Transactional
+  public void update(Long id, UpdateAnnouncementRequest request) {
+    Announcement announcement =
+        announcementRepository.findById(id).orElseThrow(AnnouncementNotFoundException::new);
+
+    announcement.update(
+        request.postedAt(),
+        request.titleAsValue(),
+        request.contentAsValue(),
+        request.published(),
+        request.pinned());
+  }
+
+  @Transactional
+  public void delete(Long id) {
+    Announcement announcement =
+        announcementRepository.findById(id).orElseThrow(AnnouncementNotFoundException::new);
+
+    announcementRepository.delete(announcement);
+  }
+
+  public AnnouncementDetail findOne(Long id) {
+    return announcementRepository
+        .findById(id)
+        .map(AnnouncementDetail::from)
+        .orElseThrow(AnnouncementNotFoundException::new);
+  }
+
+  public List<AnnouncementDetail> findPinned() {
+    return announcementRepository.findAllPinned().stream().map(AnnouncementDetail::from).toList();
+  }
+
+  /** 어드민: 일반 공지 커서 페이지네이션 (게시 여부 무관). */
+  public CursorPage<AnnouncementSummary, AnnouncementCursor> findList(
+      AnnouncementCursor cursor, int size) {
+    List<Announcement> fetched = announcementRepository.findAllNonPinnedByCursor(cursor, size);
+
+    boolean hasNext = fetched.size() > size;
+    List<Announcement> page = hasNext ? fetched.subList(0, size) : fetched;
+
+    List<AnnouncementSummary> content = page.stream().map(AnnouncementSummary::from).toList();
+
+    AnnouncementCursor nextCursor =
+        hasNext
+            ? new AnnouncementCursor(page.getLast().getPostedAt(), page.getLast().getId())
+            : null;
+
+    return new CursorPage<>(content, nextCursor, hasNext);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementService.java
@@ -57,8 +57,8 @@ public class AdminAnnouncementService {
         .orElseThrow(AnnouncementNotFoundException::new);
   }
 
-  public List<AnnouncementDetail> findPinned() {
-    return announcementRepository.findAllPinned().stream().map(AnnouncementDetail::from).toList();
+  public List<AnnouncementSummary> findPinned() {
+    return announcementRepository.findAllPinned().stream().map(AnnouncementSummary::from).toList();
   }
 
   /** 어드민: 일반 공지 커서 페이지네이션 (게시 여부 무관). */

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementService.java
@@ -17,7 +17,8 @@ public class AdminAnnouncementService {
   private final AnnouncementRepository announcementRepository;
 
   @Transactional
-  public Long create(CreateAnnouncementRequest request) {
+  public Announcement create(CreateAnnouncementRequest request) {
+
     Announcement announcement =
         Announcement.create(
             request.postedAt(),
@@ -26,11 +27,11 @@ public class AdminAnnouncementService {
             request.published(),
             request.pinned());
 
-    return announcementRepository.save(announcement).getId();
+    return announcementRepository.save(announcement);
   }
 
   @Transactional
-  public void update(Long id, UpdateAnnouncementRequest request) {
+  public Announcement update(Long id, UpdateAnnouncementRequest request) {
     Announcement announcement =
         announcementRepository.findById(id).orElseThrow(AnnouncementNotFoundException::new);
 
@@ -40,6 +41,8 @@ public class AdminAnnouncementService {
         request.contentAsValue(),
         request.published(),
         request.pinned());
+
+    return announcement;
   }
 
   @Transactional

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementService.java
@@ -1,10 +1,12 @@
 package com.typingpractice.typing_practice_be.notice.announcement.service;
 
 import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
 import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
 import com.typingpractice.typing_practice_be.notice.announcement.exception.AnnouncementNotFoundException;
 import com.typingpractice.typing_practice_be.notice.announcement.repository.AnnouncementRepository;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,10 +20,11 @@ public class AdminAnnouncementService {
 
   @Transactional
   public Announcement create(CreateAnnouncementRequest request) {
+    LocalDateTime postedAtUtc = TimeUtils.kstToUtc(request.postedAt());
 
     Announcement announcement =
         Announcement.create(
-            request.postedAt(),
+            postedAtUtc,
             request.titleAsValue(),
             request.contentAsValue(),
             request.published(),
@@ -35,8 +38,11 @@ public class AdminAnnouncementService {
     Announcement announcement =
         announcementRepository.findById(id).orElseThrow(AnnouncementNotFoundException::new);
 
+    LocalDateTime postedAtUtc =
+        request.postedAt() == null ? null : TimeUtils.kstToUtc(request.postedAt());
+
     announcement.update(
-        request.postedAt(),
+        postedAtUtc,
         request.titleAsValue(),
         request.contentAsValue(),
         request.published(),

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AnnouncementService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AnnouncementService.java
@@ -5,6 +5,7 @@ import com.typingpractice.typing_practice_be.notice.announcement.domain.Announce
 import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementCursor;
 import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementDetail;
 import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementSummary;
+import com.typingpractice.typing_practice_be.notice.announcement.exception.AnnouncementNotFoundException;
 import com.typingpractice.typing_practice_be.notice.announcement.repository.AnnouncementRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,17 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class AnnouncementService {
   private final AnnouncementRepository announcementRepository;
+
+  public AnnouncementDetail findOne(Long id) {
+    Announcement announcement =
+        announcementRepository.findById(id).orElseThrow(AnnouncementNotFoundException::new);
+
+    if (!announcement.isPublished()) {
+      throw new AnnouncementNotFoundException();
+    }
+
+    return AnnouncementDetail.from(announcement);
+  }
 
   /** 팝업용: 최신 게시 공지 1건 (없으면 null) */
   public AnnouncementDetail findLatest() {

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AnnouncementService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/announcement/service/AnnouncementService.java
@@ -1,0 +1,55 @@
+package com.typingpractice.typing_practice_be.notice.announcement.service;
+
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementCursor;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementDetail;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementSummary;
+import com.typingpractice.typing_practice_be.notice.announcement.repository.AnnouncementRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AnnouncementService {
+  private final AnnouncementRepository announcementRepository;
+
+  /** 팝업용: 최신 게시 공지 1건 (없으면 null) */
+  public AnnouncementDetail findLatest() {
+    return announcementRepository.findLatestPublished().map(AnnouncementDetail::from).orElse(null);
+  }
+
+  /** 게시된 고정 공지 전체 */
+  public List<AnnouncementSummary> findPinned() {
+    return announcementRepository.findPublishedPinned().stream()
+        .map(AnnouncementSummary::from)
+        .toList();
+  }
+
+  /** 게시된 일반 공지 커서 페이지네이션 */
+  public CursorPage<AnnouncementSummary, AnnouncementCursor> findList(
+      AnnouncementCursor cursor, int size) {
+    List<Announcement> fetched =
+        announcementRepository.findPublishedNonPinnedByCursor(cursor, size);
+
+    return toCursorPage(fetched, size);
+  }
+
+  private CursorPage<AnnouncementSummary, AnnouncementCursor> toCursorPage(
+      List<Announcement> fetched, int size) {
+    boolean hasNext = fetched.size() > size;
+    List<Announcement> page = hasNext ? fetched.subList(0, size) : fetched;
+
+    List<AnnouncementSummary> content = page.stream().map(AnnouncementSummary::from).toList();
+
+    AnnouncementCursor nextCursor =
+        hasNext
+            ? new AnnouncementCursor(content.getLast().postedAt(), content.getLast().id())
+            : null;
+
+    return new CursorPage<>(content, nextCursor, hasNext);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/domain/LocalizedText.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/domain/LocalizedText.java
@@ -1,0 +1,3 @@
+package com.typingpractice.typing_practice_be.notice.domain;
+
+public record LocalizedText(String ko, String en, String ja) {}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/dto/LocalizedTextRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/dto/LocalizedTextRequest.java
@@ -1,10 +1,10 @@
-package com.typingpractice.typing_practice_be.notice.announcement.dto;
+package com.typingpractice.typing_practice_be.notice.dto;
 
 import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
 import jakarta.validation.constraints.NotBlank;
 
 public record LocalizedTextRequest(@NotBlank String ko, String en, String ja) {
-	public LocalizedText toValue() {
-		return new LocalizedText(ko, en, ja);
-	}
+  public LocalizedText toValue() {
+    return new LocalizedText(ko, en, ja);
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/controller/AdminUpdateNoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/controller/AdminUpdateNoteController.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.notice.update.controller;
 
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.update.domain.UpdateNote;
 import com.typingpractice.typing_practice_be.notice.update.dto.*;
 import com.typingpractice.typing_practice_be.notice.update.service.AdminUpdateNoteService;
 import jakarta.validation.Valid;
@@ -15,17 +16,17 @@ public class AdminUpdateNoteController {
   private final AdminUpdateNoteService adminUpdateNoteService;
 
   @PostMapping
-  public ApiResponse<UpdateNoteIdResponse> postUpdateNote(
+  public ApiResponse<UpdateNoteResponse> postUpdateNote(
       @RequestBody @Valid CreateUpdateNoteRequest request) {
-    Long id = adminUpdateNoteService.create(request);
-    return ApiResponse.ok(new UpdateNoteIdResponse(id));
+    UpdateNote note = adminUpdateNoteService.create(request);
+    return ApiResponse.ok(UpdateNoteResponse.from(note));
   }
 
   @PatchMapping("/{id}")
-  public ApiResponse<Void> patchUpdateNote(
+  public ApiResponse<UpdateNoteResponse> patchUpdateNote(
       @PathVariable Long id, @RequestBody @Valid UpdateUpdateNoteRequest request) {
-    adminUpdateNoteService.update(id, request);
-    return ApiResponse.ok(null);
+    UpdateNote note = adminUpdateNoteService.update(id, request);
+    return ApiResponse.ok(UpdateNoteResponse.from(note));
   }
 
   @DeleteMapping("/{id}")

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/controller/AdminUpdateNoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/controller/AdminUpdateNoteController.java
@@ -1,0 +1,49 @@
+package com.typingpractice.typing_practice_be.notice.update.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.update.dto.*;
+import com.typingpractice.typing_practice_be.notice.update.service.AdminUpdateNoteService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin/update-notes")
+@RequiredArgsConstructor
+public class AdminUpdateNoteController {
+  private final AdminUpdateNoteService adminUpdateNoteService;
+
+  @PostMapping
+  public ApiResponse<UpdateNoteIdResponse> postUpdateNote(
+      @RequestBody @Valid CreateUpdateNoteRequest request) {
+    Long id = adminUpdateNoteService.create(request);
+    return ApiResponse.ok(new UpdateNoteIdResponse(id));
+  }
+
+  @PatchMapping("/{id}")
+  public ApiResponse<Void> patchUpdateNote(
+      @PathVariable Long id, @RequestBody @Valid UpdateUpdateNoteRequest request) {
+    adminUpdateNoteService.update(id, request);
+    return ApiResponse.ok(null);
+  }
+
+  @DeleteMapping("/{id}")
+  public ApiResponse<Void> deleteUpdateNote(@PathVariable Long id) {
+    adminUpdateNoteService.delete(id);
+    return ApiResponse.ok(null);
+  }
+
+  @GetMapping
+  public ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>> getUpdateNotes(
+      @ModelAttribute @Valid UpdateNoteCursorRequest request) {
+    CursorPage<UpdateNoteResponse, UpdateNoteCursor> result =
+        adminUpdateNoteService.findList(request.toCursor(), request.sizeOrDefault());
+    return ApiResponse.ok(result);
+  }
+
+  @GetMapping("/{id}")
+  public ApiResponse<UpdateNoteResponse> getUpdateNoteById(@PathVariable Long id) {
+    return ApiResponse.ok(adminUpdateNoteService.findOne(id));
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/controller/UpdateNoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/controller/UpdateNoteController.java
@@ -1,0 +1,37 @@
+package com.typingpractice.typing_practice_be.notice.update.controller;
+
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteCursor;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteCursorRequest;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteResponse;
+import com.typingpractice.typing_practice_be.notice.update.service.UpdateNoteService;
+import java.awt.*;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/update-notes")
+@RequiredArgsConstructor
+public class UpdateNoteController {
+  private final UpdateNoteService updateNoteService;
+
+  @GetMapping
+  public ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>> getUpdateNotes(
+      @ModelAttribute @Valid UpdateNoteCursorRequest request) {
+    CursorPage<UpdateNoteResponse, UpdateNoteCursor> result =
+        updateNoteService.findList(request.toCursor(), request.sizeOrDefault());
+
+    return ApiResponse.ok(result);
+  }
+
+  @GetMapping("/latest")
+  public ApiResponse<UpdateNoteResponse> getLatestUpdateNote() {
+    return ApiResponse.ok(updateNoteService.findLatest());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/domain/UpdateNote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/domain/UpdateNote.java
@@ -2,10 +2,7 @@ package com.typingpractice.typing_practice_be.notice.update.domain;
 
 import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
 import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -21,6 +18,8 @@ import java.util.List;
 
 @Entity
 @Getter
+@Table(
+    uniqueConstraints = @UniqueConstraint(name = "uq_update_note_version", columnNames = "version"))
 @SQLRestriction("deleted = false")
 @SQLDelete(
     sql = "UPDATE update_note SET deleted = true, deleted_at = NOW() WHERE update_note_id = ?")
@@ -31,7 +30,7 @@ public class UpdateNote extends BaseEntity {
   @Column(name = "update_note_id")
   private Long id;
 
-  @Column(nullable = false, length = 32, unique = true)
+  @Column(nullable = false, length = 32)
   private String version;
 
   @Column(columnDefinition = "timestamp with time zone", nullable = false)

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/domain/UpdateNote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/domain/UpdateNote.java
@@ -1,0 +1,87 @@
+package com.typingpractice.typing_practice_be.notice.update.domain;
+
+import com.typingpractice.typing_practice_be.common.domain.BaseEntity;
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Entity
+@Getter
+@SQLRestriction("deleted = false")
+@SQLDelete(
+    sql = "UPDATE update_note SET deleted = true, deleted_at = NOW() WHERE update_note_id = ?")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UpdateNote extends BaseEntity {
+  @Id
+  @GeneratedValue
+  @Column(name = "update_note_id")
+  private Long id;
+
+  @Column(nullable = false, length = 32, unique = true)
+  private String version;
+
+  @Column(columnDefinition = "timestamp with time zone", nullable = false)
+  private LocalDateTime releasedAt;
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private List<LocalizedText> newFeatures = new ArrayList<>();
+
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(columnDefinition = "jsonb", nullable = false)
+  private List<LocalizedText> improvements = new ArrayList<>();
+
+  @Column(nullable = false)
+  private boolean published;
+
+  public static UpdateNote create(
+      String version,
+      LocalDateTime releasedAt,
+      List<LocalizedText> newFeatures,
+      List<LocalizedText> improvements,
+      boolean published) {
+    UpdateNote note = new UpdateNote();
+    note.version = version;
+    note.releasedAt = releasedAt;
+    note.newFeatures = (newFeatures != null) ? new ArrayList<>(newFeatures) : new ArrayList<>();
+    note.improvements = (improvements != null) ? new ArrayList<>(improvements) : new ArrayList<>();
+    note.published = published;
+    return note;
+  }
+
+  /** PATCH 부분 수정. null = 미변경. */
+  public void update(
+      String version,
+      LocalDateTime releasedAt,
+      List<LocalizedText> newFeatures,
+      List<LocalizedText> improvements,
+      Boolean published) {
+    if (version != null) this.version = version;
+    if (releasedAt != null) this.releasedAt = releasedAt;
+    if (newFeatures != null) this.newFeatures = new ArrayList<>(newFeatures);
+    if (improvements != null) this.improvements = new ArrayList<>(improvements);
+    if (published != null) this.published = published;
+  }
+
+  public List<LocalizedText> getNewFeatures() {
+    return Collections.unmodifiableList(newFeatures);
+  }
+
+  public List<LocalizedText> getImprovements() {
+    return Collections.unmodifiableList(improvements);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/CreateUpdateNoteRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/CreateUpdateNoteRequest.java
@@ -5,12 +5,17 @@ import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record CreateUpdateNoteRequest(
-    @NotBlank String version,
+    @NotBlank
+        @Pattern(
+            regexp = "^v\\d+\\.\\d+\\.\\d+$",
+            message = "버전은 v{major}.{minor}.{fix} 형식이어야 합니다. (예: v1.8.1)")
+        String version,
     @NotNull LocalDateTime releasedAt,
     @NotNull @Valid List<LocalizedTextRequest> newFeatures,
     @NotNull @Valid List<LocalizedTextRequest> improvements,

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/CreateUpdateNoteRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/CreateUpdateNoteRequest.java
@@ -1,0 +1,26 @@
+package com.typingpractice.typing_practice_be.notice.update.dto;
+
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record CreateUpdateNoteRequest(
+    @NotBlank String version,
+    @NotNull LocalDateTime releasedAt,
+    @NotNull @Valid List<LocalizedTextRequest> newFeatures,
+    @NotNull @Valid List<LocalizedTextRequest> improvements,
+    @NotNull Boolean published) {
+
+  public List<LocalizedText> newFeaturesAsValue() {
+    return newFeatures.stream().map(LocalizedTextRequest::toValue).toList();
+  }
+
+  public List<LocalizedText> improvementsAsValue() {
+    return improvements.stream().map(LocalizedTextRequest::toValue).toList();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteCursor.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteCursor.java
@@ -1,0 +1,5 @@
+package com.typingpractice.typing_practice_be.notice.update.dto;
+
+import java.time.LocalDateTime;
+
+public record UpdateNoteCursor(LocalDateTime releasedAt, Long id) {}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteCursorRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteCursorRequest.java
@@ -1,0 +1,25 @@
+package com.typingpractice.typing_practice_be.notice.update.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+
+import java.time.LocalDateTime;
+
+public record UpdateNoteCursorRequest(
+    LocalDateTime cursorReleasedAt, Long cursorId, @Min(1) @Max(100) Integer size) {
+
+  @AssertTrue(message = "cursorReleasedAt 과 cursorId 는 모두 있거나 모두 없어야 합니다.")
+  public boolean isCursorValid() {
+    return (cursorReleasedAt == null) == (cursorId == null);
+  }
+
+  public UpdateNoteCursor toCursor() {
+    if (cursorReleasedAt == null) return null;
+    return new UpdateNoteCursor(cursorReleasedAt, cursorId);
+  }
+
+  public int sizeOrDefault() {
+    return size != null ? size : 20;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteIdResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteIdResponse.java
@@ -1,3 +1,0 @@
-package com.typingpractice.typing_practice_be.notice.update.dto;
-
-public record UpdateNoteIdResponse(Long id) {}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteIdResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteIdResponse.java
@@ -1,0 +1,3 @@
+package com.typingpractice.typing_practice_be.notice.update.dto;
+
+public record UpdateNoteIdResponse(Long id) {}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateNoteResponse.java
@@ -1,0 +1,30 @@
+package com.typingpractice.typing_practice_be.notice.update.dto;
+
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import com.typingpractice.typing_practice_be.notice.update.domain.UpdateNote;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record UpdateNoteResponse(
+    Long id,
+    String version,
+    LocalDateTime releasedAt,
+    List<LocalizedText> newFeatures,
+    List<LocalizedText> improvements,
+    boolean published,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt) {
+
+  public static UpdateNoteResponse from(UpdateNote note) {
+    return new UpdateNoteResponse(
+        note.getId(),
+        note.getVersion(),
+        note.getReleasedAt(),
+        note.getNewFeatures(),
+        note.getImprovements(),
+        note.isPublished(),
+        note.getCreatedAt(),
+        note.getUpdatedAt());
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateUpdateNoteRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateUpdateNoteRequest.java
@@ -3,12 +3,16 @@ package com.typingpractice.typing_practice_be.notice.update.dto;
 import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
 import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Pattern;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public record UpdateUpdateNoteRequest(
-    String version,
+    @Pattern(
+            regexp = "^v\\d+\\.\\d+\\.\\d+$",
+            message = "버전은 v{major}.{minor}.{fix} 형식이어야 합니다. (예: v1.8.1)")
+        String version,
     LocalDateTime releasedAt,
     @Valid List<LocalizedTextRequest> newFeatures,
     @Valid List<LocalizedTextRequest> improvements,

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateUpdateNoteRequest.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/dto/UpdateUpdateNoteRequest.java
@@ -1,0 +1,28 @@
+package com.typingpractice.typing_practice_be.notice.update.dto;
+
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
+import jakarta.validation.Valid;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record UpdateUpdateNoteRequest(
+    String version,
+    LocalDateTime releasedAt,
+    @Valid List<LocalizedTextRequest> newFeatures,
+    @Valid List<LocalizedTextRequest> improvements,
+    Boolean published) {
+
+  public List<LocalizedText> newFeaturesAsValue() {
+    return newFeatures == null
+        ? null
+        : newFeatures.stream().map(LocalizedTextRequest::toValue).toList();
+  }
+
+  public List<LocalizedText> improvementsAsValue() {
+    return improvements == null
+        ? null
+        : improvements.stream().map(LocalizedTextRequest::toValue).toList();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/exception/UpdateNoteExceptionHandler.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/exception/UpdateNoteExceptionHandler.java
@@ -1,0 +1,30 @@
+package com.typingpractice.typing_practice_be.notice.update.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.ProblemDetail;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice(basePackages = "com.typingpractice.typing_practice_be.notice.update")
+public class UpdateNoteExceptionHandler {
+  private ProblemDetail createProblemDetail(ErrorCode errorCode) {
+    ProblemDetail pd =
+        ProblemDetail.forStatusAndDetail(errorCode.getStatus(), errorCode.getMessage());
+    pd.setTitle("UpdateNote Domain Error");
+    return pd;
+  }
+
+  @ExceptionHandler(DataIntegrityViolationException.class)
+  public ProblemDetail handleDuplicateVersion(DataIntegrityViolationException e) {
+    String message = e.getMessage();
+
+    if (message != null && message.contains("uq_update_note_version")) {
+      return createProblemDetail(ErrorCode.UPDATE_NOTE_VERSION_CONFLICT);
+    }
+
+    return createProblemDetail(ErrorCode.DATA_INTEGRITY_VIOLATION);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/exception/UpdateNoteNotFoundException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/exception/UpdateNoteNotFoundException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.notice.update.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class UpdateNoteNotFoundException extends BusinessException {
+  public UpdateNoteNotFoundException() {
+    super(ErrorCode.UPDATE_NOTE_NOT_FOUND);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/exception/UpdateNoteVersionConflictException.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/exception/UpdateNoteVersionConflictException.java
@@ -1,0 +1,10 @@
+package com.typingpractice.typing_practice_be.notice.update.exception;
+
+import com.typingpractice.typing_practice_be.common.exception.BusinessException;
+import com.typingpractice.typing_practice_be.common.exception.ErrorCode;
+
+public class UpdateNoteVersionConflictException extends BusinessException {
+  public UpdateNoteVersionConflictException() {
+    super(ErrorCode.UPDATE_NOTE_VERSION_CONFLICT);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/repository/UpdateNoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/repository/UpdateNoteRepository.java
@@ -1,0 +1,93 @@
+package com.typingpractice.typing_practice_be.notice.update.repository;
+
+import com.typingpractice.typing_practice_be.notice.update.domain.UpdateNote;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteCursor;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class UpdateNoteRepository {
+  private final EntityManager em;
+
+  public UpdateNote save(UpdateNote updateNote) {
+    em.persist(updateNote);
+    return updateNote;
+  }
+
+  public Optional<UpdateNote> findById(Long id) {
+    return em.createQuery("select u from UpdateNote u where u.id = :id", UpdateNote.class)
+        .setParameter("id", id)
+        .getResultStream()
+        .findFirst();
+  }
+
+  public void delete(UpdateNote updateNote) {
+    em.remove(updateNote);
+  }
+
+  /** version 중복 체크. 자기 자신 제외 옵션 (수정 시 사용). */
+  public boolean existsByVersion(String version, Long excludeId) {
+    StringBuilder jpql =
+        new StringBuilder("select count(u) from UpdateNote u where u.version = :version");
+    if (excludeId != null) {
+      jpql.append(" and u.id <> :excludeId");
+    }
+    TypedQuery<Long> query = em.createQuery(jpql.toString(), Long.class);
+    query.setParameter("version", version);
+    if (excludeId != null) {
+      query.setParameter("excludeId", excludeId);
+    }
+    return query.getSingleResult() > 0;
+  }
+
+  /** 사용자: 게시된 업데이트 노트 중 가장 최신 1건. 팝업용. */
+  public Optional<UpdateNote> findLatestPublished() {
+    return em.createQuery(
+            "select u from UpdateNote u "
+                + "where u.published = true "
+                + "order by u.releasedAt desc, u.id desc",
+            UpdateNote.class)
+        .setMaxResults(1)
+        .getResultStream()
+        .findFirst();
+  }
+
+  /** 사용자: 게시된 업데이트 노트 커서 페이지네이션. size+1 조회로 hasNext 판정용. */
+  public List<UpdateNote> findPublishedByCursor(UpdateNoteCursor cursor, int size) {
+    return findByCursor(cursor, size, true);
+  }
+
+  /** 어드민: 업데이트 노트 커서 페이지네이션 (게시 여부 무관). size+1 조회로 hasNext 판정용. */
+  public List<UpdateNote> findAllByCursor(UpdateNoteCursor cursor, int size) {
+    return findByCursor(cursor, size, false);
+  }
+
+  private List<UpdateNote> findByCursor(UpdateNoteCursor cursor, int size, boolean publishedOnly) {
+    StringBuilder jpql = new StringBuilder("select u from UpdateNote u");
+    boolean hasWhere = false;
+    if (publishedOnly) {
+      jpql.append(" where u.published = true");
+      hasWhere = true;
+    }
+    if (cursor != null) {
+      jpql.append(hasWhere ? " and" : " where");
+      jpql.append(
+          " (u.releasedAt < :cursorReleasedAt"
+              + "      or (u.releasedAt = :cursorReleasedAt and u.id < :cursorId))");
+    }
+    jpql.append(" order by u.releasedAt desc, u.id desc");
+
+    TypedQuery<UpdateNote> query = em.createQuery(jpql.toString(), UpdateNote.class);
+    if (cursor != null) {
+      query.setParameter("cursorReleasedAt", cursor.releasedAt());
+      query.setParameter("cursorId", cursor.id());
+    }
+    return query.setMaxResults(size + 1).getResultList();
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/service/AdminUpdateNoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/service/AdminUpdateNoteService.java
@@ -1,0 +1,95 @@
+package com.typingpractice.typing_practice_be.notice.update.service;
+
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.notice.update.domain.UpdateNote;
+import com.typingpractice.typing_practice_be.notice.update.dto.CreateUpdateNoteRequest;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteCursor;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteResponse;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateUpdateNoteRequest;
+import com.typingpractice.typing_practice_be.notice.update.exception.UpdateNoteNotFoundException;
+import com.typingpractice.typing_practice_be.notice.update.exception.UpdateNoteVersionConflictException;
+import com.typingpractice.typing_practice_be.notice.update.repository.UpdateNoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminUpdateNoteService {
+  private final UpdateNoteRepository updateNoteRepository;
+
+  @Transactional
+  public Long create(CreateUpdateNoteRequest request) {
+    if (updateNoteRepository.existsByVersion(request.version(), null)) {
+      throw new UpdateNoteVersionConflictException();
+    }
+
+    LocalDateTime releasedAtUtc = TimeUtils.kstToUtc(request.releasedAt());
+
+    UpdateNote note =
+        UpdateNote.create(
+            request.version(),
+            releasedAtUtc,
+            request.newFeaturesAsValue(),
+            request.improvementsAsValue(),
+            request.published());
+    return updateNoteRepository.save(note).getId();
+  }
+
+  @Transactional
+  public void update(Long id, UpdateUpdateNoteRequest request) {
+    UpdateNote note =
+        updateNoteRepository.findById(id).orElseThrow(UpdateNoteNotFoundException::new);
+
+    if (request.version() != null && updateNoteRepository.existsByVersion(request.version(), id)) {
+      throw new UpdateNoteVersionConflictException();
+    }
+
+    LocalDateTime releasedAtUtc =
+        request.releasedAt() == null ? null : TimeUtils.kstToUtc(request.releasedAt());
+
+    note.update(
+        request.version(),
+        releasedAtUtc,
+        request.newFeaturesAsValue(),
+        request.improvementsAsValue(),
+        request.published());
+  }
+
+  @Transactional
+  public void delete(Long id) {
+    UpdateNote note =
+        updateNoteRepository.findById(id).orElseThrow(UpdateNoteNotFoundException::new);
+    updateNoteRepository.delete(note);
+  }
+
+  public UpdateNoteResponse findOne(Long id) {
+    return updateNoteRepository
+        .findById(id)
+        .map(UpdateNoteResponse::from)
+        .orElseThrow(UpdateNoteNotFoundException::new);
+  }
+
+  /** 어드민: 업데이트 노트 커서 페이지네이션 (게시 여부 무관). */
+  public CursorPage<UpdateNoteResponse, UpdateNoteCursor> findList(
+      UpdateNoteCursor cursor, int size) {
+    List<UpdateNote> fetched = updateNoteRepository.findAllByCursor(cursor, size);
+
+    boolean hasNext = fetched.size() > size;
+    List<UpdateNote> page = hasNext ? fetched.subList(0, size) : fetched;
+
+    List<UpdateNoteResponse> content = page.stream().map(UpdateNoteResponse::from).toList();
+
+    UpdateNoteCursor nextCursor =
+        hasNext
+            ? new UpdateNoteCursor(page.getLast().getReleasedAt(), page.getLast().getId())
+            : null;
+
+    return new CursorPage<>(content, nextCursor, hasNext);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/service/AdminUpdateNoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/service/AdminUpdateNoteService.java
@@ -24,7 +24,7 @@ public class AdminUpdateNoteService {
   private final UpdateNoteRepository updateNoteRepository;
 
   @Transactional
-  public Long create(CreateUpdateNoteRequest request) {
+  public UpdateNote create(CreateUpdateNoteRequest request) {
     if (updateNoteRepository.existsByVersion(request.version(), null)) {
       throw new UpdateNoteVersionConflictException();
     }
@@ -38,11 +38,11 @@ public class AdminUpdateNoteService {
             request.newFeaturesAsValue(),
             request.improvementsAsValue(),
             request.published());
-    return updateNoteRepository.save(note).getId();
+    return updateNoteRepository.save(note);
   }
 
   @Transactional
-  public void update(Long id, UpdateUpdateNoteRequest request) {
+  public UpdateNote update(Long id, UpdateUpdateNoteRequest request) {
     UpdateNote note =
         updateNoteRepository.findById(id).orElseThrow(UpdateNoteNotFoundException::new);
 
@@ -59,6 +59,8 @@ public class AdminUpdateNoteService {
         request.newFeaturesAsValue(),
         request.improvementsAsValue(),
         request.published());
+
+    return note;
   }
 
   @Transactional

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/service/UpdateNoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/notice/update/service/UpdateNoteService.java
@@ -1,0 +1,40 @@
+package com.typingpractice.typing_practice_be.notice.update.service;
+
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.update.domain.UpdateNote;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteCursor;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteResponse;
+import com.typingpractice.typing_practice_be.notice.update.repository.UpdateNoteRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UpdateNoteService {
+  private final UpdateNoteRepository updateNoteRepository;
+
+  public UpdateNoteResponse findLatest() {
+    return updateNoteRepository.findLatestPublished().map(UpdateNoteResponse::from).orElse(null);
+  }
+
+  public CursorPage<UpdateNoteResponse, UpdateNoteCursor> findList(
+      UpdateNoteCursor cursor, int size) {
+    List<UpdateNote> fetched = updateNoteRepository.findPublishedByCursor(cursor, size);
+
+    boolean hasNext = fetched.size() > size;
+    List<UpdateNote> page = hasNext ? fetched.subList(0, size) : fetched;
+
+    List<UpdateNoteResponse> content = page.stream().map(UpdateNoteResponse::from).toList();
+
+    UpdateNoteCursor nextCursor =
+        hasNext
+            ? new UpdateNoteCursor(page.getLast().getReleasedAt(), page.getLast().getId())
+            : null;
+
+    return new CursorPage<>(content, nextCursor, hasNext);
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/controller/AdminQuoteController.java
@@ -14,10 +14,11 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequiredArgsConstructor
 // @AdminOnly
+@RequestMapping("/admin/quotes")
 public class AdminQuoteController {
   private final AdminQuoteService adminQuoteService;
 
-  @GetMapping("/admin/quotes")
+  @GetMapping()
   public ApiResponse<AdminQuotePaginationResponse> getQuotes(
       @ModelAttribute @Valid QuotePaginationRequest request) {
 
@@ -28,7 +29,7 @@ public class AdminQuoteController {
     return ApiResponse.ok(AdminQuotePaginationResponse.from(result));
   }
 
-  @GetMapping("/admin/quotes/{quoteId}")
+  @GetMapping("/{quoteId}")
   public ApiResponse<AdminQuoteResponse> getQuoteById(@PathVariable Long quoteId) {
     Quote quote = adminQuoteService.findQuoteByIdWithTypingStats(quoteId);
 
@@ -36,7 +37,7 @@ public class AdminQuoteController {
   }
 
   // 승인
-  @PostMapping("/admin/quotes/{quoteId}/approve")
+  @PostMapping("/{quoteId}/approve")
   public ApiResponse<QuoteResponse> approvePendingQuote(@PathVariable Long quoteId) {
 
     Quote quote = adminQuoteService.approvePublish(quoteId);
@@ -45,7 +46,7 @@ public class AdminQuoteController {
   }
 
   // 거부
-  @PostMapping("/admin/quotes/{quoteId}/reject")
+  @PostMapping("/{quoteId}/reject")
   public ApiResponse<QuoteResponse> rejectPendingQuote(@PathVariable Long quoteId) {
 
     Quote quote = adminQuoteService.rejectPublish(quoteId);
@@ -54,7 +55,7 @@ public class AdminQuoteController {
   }
 
   // 공개 문장 수정
-  @PatchMapping("/admin/quotes/{quoteId}")
+  @PatchMapping("/{quoteId}")
   public ApiResponse<QuoteResponse> patchQuote(
       @PathVariable Long quoteId, @RequestBody QuoteUpdateRequest request) {
 
@@ -66,7 +67,7 @@ public class AdminQuoteController {
   }
 
   // 삭제
-  @DeleteMapping("/admin/quotes/{quoteId}")
+  @DeleteMapping("/{quoteId}")
   public ApiResponse<Void> deleteQuote(@PathVariable Long quoteId) {
 
     adminQuoteService.deleteQuote(quoteId);
@@ -74,7 +75,7 @@ public class AdminQuoteController {
     return ApiResponse.ok(null);
   }
 
-  @PatchMapping("/admin/quotes/{quoteId}/hide")
+  @PatchMapping("/{quoteId}/hide")
   public ApiResponse<QuoteResponse> hideQuote(@PathVariable Long quoteId) {
     Quote hideQuote = adminQuoteService.hideQuote(quoteId);
 
@@ -82,11 +83,28 @@ public class AdminQuoteController {
   }
 
   // 숨김 해제
-  @PostMapping("/admin/quotes/{quoteId}/restore")
+  @PostMapping("/{quoteId}/restore")
   public ApiResponse<QuoteResponse> restoreHiddenQuotes(@PathVariable Long quoteId) {
 
     Quote quote = adminQuoteService.cancelHidden(quoteId);
 
     return ApiResponse.ok(QuoteResponse.from(quote));
+  }
+
+  @GetMapping("/deleted")
+  public ApiResponse<DeletedQuotePaginationResponse> getDeletedQuotes(
+      @ModelAttribute @Valid QuotePaginationRequest request) {
+    QuotePaginationQuery query = QuotePaginationQuery.from(request);
+
+    PageResult<Quote> result = adminQuoteService.findDeletedQuotes(query);
+
+    return ApiResponse.ok(DeletedQuotePaginationResponse.from(result));
+  }
+
+  @DeleteMapping("/{quoteId}/permanent")
+  public ApiResponse<Void> permanentDeleteQuote(@PathVariable Long quoteId) {
+    adminQuoteService.permanentDeleteQuote(quoteId);
+
+    return ApiResponse.ok(null);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/domain/Quote.java
@@ -35,7 +35,11 @@ public class Quote extends BaseEntity {
 
   @Embedded private QuoteProfile profile;
 
-  @OneToOne(mappedBy = "quote", fetch = FetchType.LAZY)
+  @OneToOne(
+      mappedBy = "quote",
+      fetch = FetchType.LAZY,
+      cascade = CascadeType.REMOVE,
+      orphanRemoval = true)
   private QuoteTypingStats typingStats;
 
   private String sentence;

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/DeletedQuotePaginationResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/DeletedQuotePaginationResponse.java
@@ -1,0 +1,24 @@
+package com.typingpractice.typing_practice_be.quote.dto;
+
+import com.typingpractice.typing_practice_be.common.dto.PageResult;
+import com.typingpractice.typing_practice_be.common.dto.PaginationResponse;
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class DeletedQuotePaginationResponse extends PaginationResponse {
+  private List<DeletedQuoteResponse> content;
+
+  protected DeletedQuotePaginationResponse(int page, int size, boolean hasNext) {
+    super(page, size, hasNext);
+  }
+
+  public static DeletedQuotePaginationResponse from(PageResult<Quote> result) {
+    DeletedQuotePaginationResponse response =
+        new DeletedQuotePaginationResponse(result.getPage(), result.getSize(), result.isHasNext());
+
+    response.content = result.getContent().stream().map(DeletedQuoteResponse::from).toList();
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/DeletedQuoteResponse.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/dto/DeletedQuoteResponse.java
@@ -1,0 +1,21 @@
+package com.typingpractice.typing_practice_be.quote.dto;
+
+import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DeletedQuoteResponse extends QuoteResponse {
+  private LocalDateTime deletedAt;
+
+  public static DeletedQuoteResponse from(Quote quote) {
+    DeletedQuoteResponse response = new DeletedQuoteResponse();
+    response.fillFrom(quote);
+    response.deletedAt = quote.getDeletedAt();
+
+    return response;
+  }
+}

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
@@ -4,7 +4,6 @@ import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.quote.config.SimilarityThresholdProperties;
 import com.typingpractice.typing_practice_be.quote.domain.*;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteIdWithDifficulty;
-import com.typingpractice.typing_practice_be.quote.query.PublicQuoteQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.TypedQuery;
@@ -136,7 +135,7 @@ public class QuoteRepository {
     return typedQuery.getResultList();
   }
 
-  public List<Quote> findPublicQuotes(PublicQuoteQuery query) {
+  /*public List<Quote> findPublicQuotes(PublicQuoteQuery query) {
     // 랜덤 순서
     em.createNativeQuery("SELECT SETSEED(:seed)")
         .setParameter("seed", query.getSeed())
@@ -190,7 +189,7 @@ public class QuoteRepository {
 
       return typedQuery.getResultList();
     }
-  }
+  }*/
 
   public boolean existsBySentenceHash(String sentenceHash, Long memberId) {
     Long count =
@@ -336,7 +335,8 @@ public class QuoteRepository {
     int page = query.getPage();
     int size = query.getSize();
 
-    String jpql = "select q from Quote q join q.member m where m.id = :memberId";
+    String jpql =
+        "select q from Quote q join q.member m left join fetch q.typingStats where m.id = :memberId";
 
     if (query.getStatus() != null && query.getType() != null) {
       jpql += " and q.status = :status and q.type = :type";
@@ -372,7 +372,7 @@ public class QuoteRepository {
   public List<Quote> findPageByLanguageAndIdRange(
       QuoteLanguage language, Long cursorId, Long maxId, int size) {
     return em.createQuery(
-            "select q from Quote q where q.language = :language and q.id > :cursorId and q.id <= :maxId order by q.id ASC",
+            "select q from Quote q left join fetch q.typingStats where q.language = :language and q.id > :cursorId and q.id <= :maxId order by q.id ASC",
             Quote.class)
         .setParameter("language", language)
         .setParameter("cursorId", cursorId)

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/repository/QuoteRepository.java
@@ -392,4 +392,37 @@ public class QuoteRepository {
         .setParameter("language", language)
         .getSingleResult();
   }
+
+  public List<Quote> findDeletedQuotes(QuotePaginationQuery query) {
+    int page = query.getPage();
+    int size = query.getSize();
+
+    return em.createNativeQuery(
+            "SELECT * FROM quote WHERE deleted = true "
+                + "ORDER BY deleted_at DESC LIMIT :limit OFFSET :offset",
+            Quote.class)
+        .setParameter("limit", size + 1)
+        .setParameter("offset", (page - 1) * size)
+        .getResultList();
+  }
+
+  public Optional<Quote> findDeletedQuoteById(Long quoteId) {
+    List<Quote> results =
+        em.createNativeQuery(
+                "select * from quote where quote_id = :quoteId and deleted = true limit 1",
+                Quote.class)
+            .setParameter("quoteId", quoteId)
+            .getResultList();
+
+    return results.isEmpty() ? Optional.empty() : Optional.of(results.getFirst());
+  }
+
+  public void permanentDeleteQuote(Long quoteId) {
+    em.createNativeQuery("delete from quote_typing_stats where quote_id = :quoteId")
+        .setParameter("quoteId", quoteId)
+        .executeUpdate();
+    em.createNativeQuery("delete from quote where quote_id = :quoteId")
+        .setParameter("quoteId", quoteId)
+        .executeUpdate();
+  }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
@@ -10,10 +10,10 @@ import com.typingpractice.typing_practice_be.quote.exception.QuoteNotProcessable
 import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuoteUpdateQuery;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
-import java.util.List;
-
 import com.typingpractice.typing_practice_be.report.domain.Report;
 import com.typingpractice.typing_practice_be.report.repository.ReportRepository;
+import com.typingpractice.typing_practice_be.typingrecord.repository.TypingRecordRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,6 +25,7 @@ public class AdminQuoteService {
   private final QuoteRepository quoteRepository;
   private final ReportRepository reportRepository;
   private final QuoteIdCacheService quoteIdCacheService;
+  private final TypingRecordRepository typingRecordRepository;
 
   @Transactional
   public Quote approvePublish(Long quoteId) {
@@ -120,5 +121,28 @@ public class AdminQuoteService {
     quote.updateStatus(QuoteStatus.HIDDEN);
 
     return quote;
+  }
+
+  public PageResult<Quote> findDeletedQuotes(QuotePaginationQuery query) {
+    List<Quote> deletedQuotes = quoteRepository.findDeletedQuotes(query);
+    boolean hasNext = deletedQuotes.size() > query.getSize();
+    List<Quote> content = hasNext ? deletedQuotes.subList(0, query.getSize()) : deletedQuotes;
+
+    return new PageResult<>(content, query.getPage(), query.getSize(), hasNext);
+  }
+
+  @Transactional
+  public void permanentDeleteQuote(Long quoteId) {
+    Quote quote =
+        quoteRepository.findDeletedQuoteById(quoteId).orElseThrow(QuoteNotFoundException::new);
+
+    Long ownerId = quote.getMember().getId();
+    QuoteLanguage language = quote.getLanguage();
+
+    typingRecordRepository.deleteByQuoteId(quoteId);
+
+    quoteRepository.permanentDeleteQuote(quoteId);
+
+    quoteIdCacheService.invalidateMemberIds(ownerId, language);
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/quote/service/AdminQuoteService.java
@@ -2,6 +2,7 @@ package com.typingpractice.typing_practice_be.quote.service;
 
 import com.typingpractice.typing_practice_be.common.dto.PageResult;
 import com.typingpractice.typing_practice_be.quote.domain.Quote;
+import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteStatus;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteType;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
@@ -23,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminQuoteService {
   private final QuoteRepository quoteRepository;
   private final ReportRepository reportRepository;
+  private final QuoteIdCacheService quoteIdCacheService;
 
   @Transactional
   public Quote approvePublish(Long quoteId) {
@@ -75,7 +77,12 @@ public class AdminQuoteService {
 
     reports.forEach(report -> report.process(true));
 
+    Long ownerId = targetQuote.getMember().getId();
+    QuoteLanguage language = targetQuote.getLanguage();
+
     quoteRepository.deleteQuote(targetQuote);
+
+    quoteIdCacheService.invalidateMemberIds(ownerId, language);
   }
 
   @Transactional

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/repository/TypingRecordRepository.java
@@ -3,6 +3,8 @@ package com.typingpractice.typing_practice_be.typingrecord.repository;
 import com.typingpractice.typing_practice_be.adaptiveserving.dto.AdaptiveServingRecord;
 import com.typingpractice.typing_practice_be.quote.domain.QuoteLanguage;
 import com.typingpractice.typing_practice_be.typingrecord.domain.TypingRecord;
+import java.time.LocalDateTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.bson.Document;
 import org.springframework.data.domain.Sort;
@@ -11,9 +13,6 @@ import org.springframework.data.mongodb.core.aggregation.Aggregation;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
-
-import java.time.LocalDateTime;
-import java.util.List;
 
 @Repository
 @RequiredArgsConstructor
@@ -114,5 +113,11 @@ public class TypingRecordRepository {
         .include("cpm", "accuracy", "quoteDifficulty", "avgCpmSnapshot", "avgAccSnapshot");
 
     return mongoTemplate.find(query, AdaptiveServingRecord.class, "typingRecord");
+  }
+
+  public long deleteByQuoteId(Long quoteId) {
+    return mongoTemplate
+        .remove(Query.query(Criteria.where("quoteId").is(quoteId)), "typingRecord")
+        .getDeletedCount();
   }
 }

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/QuoteTypingStats.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/domain/QuoteTypingStats.java
@@ -7,9 +7,15 @@ import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @Getter
+@SQLRestriction("deleted = false")
+@SQLDelete(
+    sql =
+        "UPDATE quote_typing_stats SET deleted = true, deleted_at = NOW() where quote_typing_stats_id = ?")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class QuoteTypingStats extends BaseEntity {
   @Id

--- a/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/QuoteTypingStatsBatchService.java
+++ b/typing-practice-be/src/main/java/com/typingpractice/typing_practice_be/typingrecord/statistics/service/batch/QuoteTypingStatsBatchService.java
@@ -88,8 +88,8 @@ public class QuoteTypingStatsBatchService {
           Integer totalAttemptCount = totalAttemptsCount.get(quote.getId());
           if (agg == null) continue; // 통계값이 없는 경우
 
-          QuoteTypingStats stats =
-              quoteTypingStatsRepository.findByQuoteId(quote.getId()).orElse(null);
+          QuoteTypingStats stats = quote.getTypingStats();
+          // quoteTypingStatsRepository.findByQuoteId(quote.getId()).orElse(null);
 
           if (stats == null) {
             // 기존 타이핑 통계가 없으면 생성

--- a/typing-practice-be/src/main/resources/db/migration/README.md
+++ b/typing-practice-be/src/main/resources/db/migration/README.md
@@ -1,0 +1,26 @@
+# Database Migrations
+
+이 디렉토리는 Flyway 도입을 상정한 DB 마이그레이션 스크립트 보관소입니다.
+**현재 Flyway는 적용되어 있지 않으며, 운영 DB에는 SQL을 직접 실행해 적용합니다.**
+
+## 파일 명명 규칙
+
+V{YYYYMMDD}_{seq}__{description}.sql
+
+예: `V20260513_1__create_notice_tables.sql`
+
+- 같은 날 여러 마이그레이션이 있으면 `_1`, `_2` 순서로 증가
+- `description`은 스네이크 케이스, 영문
+- 더블 언더스코어 `__` 필수 (Flyway 표준)
+
+## 적용 절차
+
+1. 운영 DB에 `psql` 등으로 접속
+2. 트랜잭션 안에서 SQL 실행 후 commit
+3. 적용 후 결과를 운영 일지에 기록
+
+## Flyway 도입 시 계획
+
+- 현재 운영 DB의 전체 스키마를 `pg_dump --schema-only` 로 추출해 baseline 스크립트로 저장
+- `flyway baseline` 명령으로 baseline 표시 (실제 실행은 안 됨)
+- 새 환경 셋업 시에는 baseline 부터 차례로 적용

--- a/typing-practice-be/src/main/resources/db/migration/V20260513_1__create_notice_tables.sql
+++ b/typing-practice-be/src/main/resources/db/migration/V20260513_1__create_notice_tables.sql
@@ -1,0 +1,47 @@
+-- ============================================================
+-- 공지사항 / 업데이트 노트 테이블 생성
+--
+-- announcement: 사용자에게 노출되는 공지사항
+-- update_note: 사용자에게 노출되는 업데이트 이력
+-- ============================================================
+
+-- ============================================================
+-- announcement
+-- ============================================================
+CREATE TABLE announcement
+(
+    announcement_id BIGINT                   NOT NULL,
+    posted_at       TIMESTAMP WITH TIME ZONE NOT NULL,
+    title           JSONB                    NOT NULL,
+    content         JSONB                    NOT NULL,
+    published       BOOLEAN                  NOT NULL,
+    pinned          BOOLEAN                  NOT NULL,
+    created_at      TIMESTAMP WITH TIME ZONE,
+    updated_at      TIMESTAMP WITH TIME ZONE,
+    deleted         BOOLEAN                  NOT NULL,
+    deleted_at      TIMESTAMP WITH TIME ZONE,
+    PRIMARY KEY (announcement_id)
+);
+
+CREATE SEQUENCE announcement_seq START WITH 1 INCREMENT BY 50;
+
+-- ============================================================
+-- update_note
+-- ============================================================
+CREATE TABLE update_note
+(
+    update_note_id BIGINT                   NOT NULL,
+    version        VARCHAR(32)              NOT NULL,
+    released_at    TIMESTAMP WITH TIME ZONE NOT NULL,
+    new_features   JSONB                    NOT NULL,
+    improvements   JSONB                    NOT NULL,
+    published      BOOLEAN                  NOT NULL,
+    created_at     TIMESTAMP WITH TIME ZONE,
+    updated_at     TIMESTAMP WITH TIME ZONE,
+    deleted        BOOLEAN                  NOT NULL,
+    deleted_at     TIMESTAMP WITH TIME ZONE,
+    PRIMARY KEY (update_note_id),
+    CONSTRAINT uq_update_note_version UNIQUE (version)
+);
+
+CREATE SEQUENCE update_note_seq START WITH 1 INCREMENT BY 50;

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AdminAnnouncementE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AdminAnnouncementE2ETest.java
@@ -9,6 +9,7 @@ import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AdminAnnouncementE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AdminAnnouncementE2ETest.java
@@ -1,0 +1,676 @@
+package com.typingpractice.typing_practice_be.notice.announcement;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.typingpractice.typing_practice_be.BaseE2ETest;
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class AdminAnnouncementE2ETest extends BaseE2ETest {
+  private static final ParameterizedTypeReference<ApiResponse<AnnouncementIdResponse>> ID_RESPONSE =
+      new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<ApiResponse<AnnouncementDetail>> DETAIL_RESPONSE =
+      new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<ApiResponse<AnnouncementListResponse>>
+      LIST_RESPONSE = new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<
+          ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>>
+      PAGE_RESPONSE = new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<ApiResponse<Void>> VOID_RESPONSE =
+      new ParameterizedTypeReference<>() {};
+
+  private HttpHeaders getAdminHeaders() {
+    String adminToken = getAccessToken(ADMIN_PROVIDER_ID);
+    return createAuthHeader(adminToken);
+  }
+
+  private HttpHeaders getUserHeaders() {
+    String userToken = getAccessToken(USER_PROVIDER_ID);
+    return createAuthHeader(userToken);
+  }
+
+  /** 어드민으로 공지사항 등록 후 id 반환. */
+  private Long createAnnouncement(
+      LocalDateTime postedAt, String titleKo, boolean published, boolean pinned) {
+    HttpHeaders adminHeaders = getAdminHeaders();
+
+    CreateAnnouncementRequest request =
+        new CreateAnnouncementRequest(
+            postedAt,
+            new LocalizedTextRequest(titleKo, null, null),
+            new LocalizedTextRequest("내용", null, null),
+            published,
+            pinned);
+
+    ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+        restTemplate.exchange(
+            "/admin/announcements",
+            HttpMethod.POST,
+            new HttpEntity<>(request, adminHeaders),
+            ID_RESPONSE);
+
+    assert response.getBody() != null;
+    return response.getBody().data().id();
+  }
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    jdbcTemplate.execute("DELETE FROM announcement");
+  }
+
+  @Nested
+  @DisplayName("POST /admin/announcements - 공지사항 등록")
+  class PostAnnouncement {
+    @Test
+    @DisplayName("성공")
+    void success() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      CreateAnnouncementRequest request =
+          new CreateAnnouncementRequest(
+              LocalDateTime.now(),
+              new LocalizedTextRequest("저작권 안내", "Copyright Notice", null),
+              new LocalizedTextRequest("내용", "content", null),
+              true,
+              false);
+
+      ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+          restTemplate.exchange(
+              "/admin/announcements",
+              HttpMethod.POST,
+              new HttpEntity<>(request, adminHeaders),
+              ID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      assertThat(response.getBody().success()).isTrue();
+      assertThat(response.getBody().data().id()).isNotNull();
+    }
+
+    @Test()
+    @DisplayName("title.ko 빈 문자열 - 400")
+    void badRequestWhenTitleKoBlank() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      CreateAnnouncementRequest request =
+          new CreateAnnouncementRequest(
+              LocalDateTime.now(),
+              new LocalizedTextRequest("", null, null),
+              new LocalizedTextRequest("내용", null, null),
+              true,
+              false);
+
+      ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+          restTemplate.exchange(
+              "/admin/announcements",
+              HttpMethod.POST,
+              new HttpEntity<>(request, adminHeaders),
+              ID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("postedAt null - 400")
+    void badRequestWhenPostedAtNull() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      CreateAnnouncementRequest request =
+          new CreateAnnouncementRequest(
+              null,
+              new LocalizedTextRequest("제목", null, null),
+              new LocalizedTextRequest("내용", null, null),
+              true,
+              false);
+
+      ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+          restTemplate.exchange(
+              "/admin/announcements",
+              HttpMethod.POST,
+              new HttpEntity<>(request, adminHeaders),
+              ID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("관리자 아닌 유저 - 403")
+    void forbiddenWhenNotAdmin() {
+      HttpHeaders headers = getUserHeaders();
+
+      CreateAnnouncementRequest request =
+          new CreateAnnouncementRequest(
+              LocalDateTime.now(),
+              new LocalizedTextRequest("제목", null, null),
+              new LocalizedTextRequest("내용", null, null),
+              true,
+              false);
+
+      ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+          restTemplate.exchange(
+              "/admin/announcements",
+              HttpMethod.POST,
+              new HttpEntity<>(request, headers),
+              ID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("토큰 없이 요청 - 401")
+    void unauthorizedWithoutToken() {
+      CreateAnnouncementRequest request =
+          new CreateAnnouncementRequest(
+              LocalDateTime.now(),
+              new LocalizedTextRequest("제목", null, null),
+              new LocalizedTextRequest("내용", null, null),
+              true,
+              false);
+
+      ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+          restTemplate.exchange(
+              "/admin/announcements", HttpMethod.POST, new HttpEntity<>(request), ID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+  }
+
+  @Nested
+  @DisplayName("PATCH /admin/announcements/{id} - 공지사항 수정")
+  class PatchAnnouncement {
+    @Test
+    @DisplayName("성공 - 모든 필드 변경")
+    void successAllFields() {
+      LocalDateTime prevTime = LocalDateTime.now();
+      Long id = createAnnouncement(prevTime, "원래 제목", true, false);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      LocalDateTime newPostedAt = prevTime.plusDays(1);
+      UpdateAnnouncementRequest request =
+          new UpdateAnnouncementRequest(
+              newPostedAt,
+              new LocalizedTextRequest("바뀐 제목", null, null),
+              new LocalizedTextRequest("바뀐 내용", null, null),
+              false,
+              true);
+
+      ResponseEntity<ApiResponse<Void>> response =
+          restTemplate.exchange(
+              "/admin/announcements/" + id,
+              HttpMethod.PATCH,
+              new HttpEntity<>(request, adminHeaders),
+              VOID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+      // 변경 확인
+      ResponseEntity<ApiResponse<AnnouncementDetail>> getResponse =
+          restTemplate.exchange(
+              "/admin/announcements/" + id,
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              DETAIL_RESPONSE);
+
+      assert getResponse.getBody() != null;
+      AnnouncementDetail detail = getResponse.getBody().data();
+      assertThat(detail.title().ko()).isEqualTo("바뀐 제목");
+      assertThat(detail.content().ko()).isEqualTo("바뀐 내용");
+      assertThat(detail.published()).isFalse();
+      assertThat(detail.pinned()).isTrue();
+    }
+
+    @Test
+    @DisplayName("성공 - null 필드는 미변경")
+    void successPartial() {
+      Long id = createAnnouncement(LocalDateTime.now(), "원래 제목", true, false);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      UpdateAnnouncementRequest request =
+          new UpdateAnnouncementRequest(null, null, null, null, true);
+
+      ResponseEntity<ApiResponse<Void>> response =
+          restTemplate.exchange(
+              "/admin/announcements/" + id,
+              HttpMethod.PATCH,
+              new HttpEntity<>(request, adminHeaders),
+              VOID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+      ResponseEntity<ApiResponse<AnnouncementDetail>> getResponse =
+          restTemplate.exchange(
+              "/admin/announcements/" + id,
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              DETAIL_RESPONSE);
+
+      assert getResponse.getBody() != null;
+      AnnouncementDetail detail = getResponse.getBody().data();
+      assertThat(detail.title().ko()).isEqualTo("원래 제목"); // 미변경
+      assertThat(detail.published()).isTrue(); // 미변경
+      assertThat(detail.pinned()).isTrue(); // 변경
+    }
+
+    @Test
+    @DisplayName("미존재 - 404")
+    void notFound() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      UpdateAnnouncementRequest request =
+          new UpdateAnnouncementRequest(LocalDateTime.now(), null, null, null, null);
+
+      ResponseEntity<ApiResponse<Void>> response =
+          restTemplate.exchange(
+              "/admin/announcements/99999999",
+              HttpMethod.PATCH,
+              new HttpEntity<>(request, adminHeaders),
+              VOID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("관리자 아닌 유저 - 403")
+    void forbiddenWhenNotAdmin() {
+      String token = getAccessToken(USER_PROVIDER_ID);
+      HttpHeaders headers = createAuthHeader(token);
+
+      UpdateAnnouncementRequest request =
+          new UpdateAnnouncementRequest(LocalDateTime.now(), null, null, null, null);
+
+      ResponseEntity<ApiResponse<Void>> response =
+          restTemplate.exchange(
+              "/admin/announcements/1",
+              HttpMethod.PATCH,
+              new HttpEntity<>(request, headers),
+              VOID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("토큰 없이 요청 - 401")
+    void unauthorizedWithoutToken() {
+      UpdateAnnouncementRequest request =
+          new UpdateAnnouncementRequest(LocalDateTime.now(), null, null, null, null);
+
+      ResponseEntity<ApiResponse<Void>> response =
+          restTemplate.exchange(
+              "/admin/announcements/1", HttpMethod.PATCH, new HttpEntity<>(request), VOID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+  }
+
+  @Nested
+  @DisplayName("DELETE /admin/announcements/{id} - 공지사항 삭제")
+  class DeleteAnnouncement {
+    @Test
+    @DisplayName("성공 - 삭제 후 조회 시 404")
+    void success() {
+      Long id = createAnnouncement(LocalDateTime.now(), "삭제 대상", true, false);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      ResponseEntity<ApiResponse<Void>> deleteResponse =
+          restTemplate.exchange(
+              "/admin/announcements/" + id,
+              HttpMethod.DELETE,
+              new HttpEntity<>(adminHeaders),
+              VOID_RESPONSE);
+
+      assertThat(deleteResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+      ResponseEntity<ApiResponse<AnnouncementDetail>> getResponse =
+          restTemplate.exchange(
+              "/admin/announcements/" + id,
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(getResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("미존재 - 404")
+    void notFound() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      ResponseEntity<ApiResponse<Void>> deleteResponse =
+          restTemplate.exchange(
+              "/admin/announcements/999999",
+              HttpMethod.DELETE,
+              new HttpEntity<>(adminHeaders),
+              VOID_RESPONSE);
+
+      assertThat(deleteResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("관리자 아닌 유저 - 403")
+    void forbiddenWhenNotAdmin() {
+      HttpHeaders userHeaders = getUserHeaders();
+
+      ResponseEntity<ApiResponse<Void>> response =
+          restTemplate.exchange(
+              "/admin/announcements/1",
+              HttpMethod.DELETE,
+              new HttpEntity<>(userHeaders),
+              VOID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("토큰 없이 요청 - 401")
+    void unauthorizedWithoutToken() {
+      ResponseEntity<ApiResponse<Void>> response =
+          restTemplate.exchange("/admin/announcements/1", HttpMethod.DELETE, null, VOID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /admin/announcements - 어드민 목록 조회 (커서)")
+  class GetAnnouncements {
+    @Test
+    @DisplayName("성공 - 페이지네이션 정확성 검증")
+    void successPagination() {
+      // 5개 등록 (모두 비고정), postedAt 시간 순서
+      LocalDateTime base = LocalDateTime.now().minusHours(10);
+      Long id1 = createAnnouncement(base, "first", true, false);
+      Long id2 = createAnnouncement(base.plusHours(1), "second", true, false);
+      Long id3 = createAnnouncement(base.plusHours(2), "third", false, false);
+      Long id4 = createAnnouncement(base.plusHours(3), "fourth", true, false);
+      Long id5 = createAnnouncement(base.plusHours(4), "fifth", true, false);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> page1 =
+          restTemplate.exchange(
+              "/admin/announcements?size=2",
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              PAGE_RESPONSE);
+
+      assertThat(page1.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert page1.getBody() != null;
+      CursorPage<AnnouncementSummary, AnnouncementCursor> data1 = page1.getBody().data();
+      assertThat(data1.getContent()).hasSize(2);
+      assertThat(data1.getContent().getFirst().id()).isEqualTo(id5);
+      assertThat(data1.getContent().get(1).id()).isEqualTo(id4);
+      assertThat(data1.isHasNext()).isTrue();
+      assertThat(data1.getNextCursor()).isNotNull();
+      assertThat(data1.getNextCursor().id()).isEqualTo(id4);
+
+      // 두번째 페이지 - 미게시(id3)도 어드민에서는 노출되어야 함
+      AnnouncementCursor cursor = data1.getNextCursor();
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> page2 =
+          restTemplate.exchange(
+              "/admin/announcements?size=2&cursorPostedAt="
+                  + cursor.postedAt()
+                  + "&cursorId="
+                  + cursor.id(),
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              PAGE_RESPONSE);
+
+      assert page2.getBody() != null;
+      CursorPage<AnnouncementSummary, AnnouncementCursor> data2 = page2.getBody().data();
+      assertThat(data2.getContent()).hasSize(2);
+      assertThat(data2.getContent().getFirst().id()).isEqualTo(id3); // 미게시도 노출
+      assertThat(data2.getContent().get(1).id()).isEqualTo(id2);
+      assertThat(data2.isHasNext()).isTrue();
+
+      // 세번째 페이지 - 마지막 1개, hasNext=false
+      cursor = data2.getNextCursor();
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> page3 =
+          restTemplate.exchange(
+              "/admin/announcements?size=2&cursorPostedAt="
+                  + cursor.postedAt()
+                  + "&cursorId="
+                  + cursor.id(),
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              PAGE_RESPONSE);
+
+      assert page3.getBody() != null;
+      CursorPage<AnnouncementSummary, AnnouncementCursor> data3 = page3.getBody().data();
+      assertThat(data3.getContent()).hasSize(1);
+      assertThat(data3.getContent().getFirst().id()).isEqualTo(id1);
+      assertThat(data3.isHasNext()).isFalse();
+      assertThat(data3.getNextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("성공 - pinned 제외 검증")
+    void excludesPinned() {
+      Long pinnedId = createAnnouncement(LocalDateTime.now(), "고정", true, true);
+      Long normalId = createAnnouncement(LocalDateTime.now().minusHours(1), "일반", true, false);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> response =
+          restTemplate.exchange(
+              "/admin/announcements?size=20",
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              PAGE_RESPONSE);
+
+      assert response.getBody() != null;
+      List<AnnouncementSummary> content = response.getBody().data().getContent();
+      assertThat(content).extracting(AnnouncementSummary::id).contains(normalId);
+      assertThat(content).extracting(AnnouncementSummary::id).doesNotContain(pinnedId);
+    }
+
+    @Test
+    @DisplayName("cursor 한쪽만 - 400")
+    void badRequestWhenCursorIncomplete() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> response =
+          restTemplate.exchange(
+              "/admin/announcements?cursorId=1",
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              PAGE_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("size 범위 위반 - 400")
+    void badRequestWhenSizeOutOfRange() {
+      String adminToken = getAccessToken(ADMIN_PROVIDER_ID);
+      HttpHeaders adminHeaders = createAuthHeader(adminToken);
+
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> response =
+          restTemplate.exchange(
+              "/admin/announcements?size=101",
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              PAGE_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("관리자 아닌 유저 - 403")
+    void forbiddenWhenNotAdmin() {
+      String token = getAccessToken(USER_PROVIDER_ID);
+      HttpHeaders headers = createAuthHeader(token);
+
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> response =
+          restTemplate.exchange(
+              "/admin/announcements", HttpMethod.GET, new HttpEntity<>(headers), PAGE_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("토큰 없이 요청 - 401")
+    void unauthorizedWithoutToken() {
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> response =
+          restTemplate.exchange("/admin/announcements", HttpMethod.GET, null, PAGE_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /admin/announcements/pinned - 어드민 고정 공지 조회")
+  class GetPinned {
+    @Test
+    @DisplayName("성공 - 게시 여부 무관 고정만")
+    void success() {
+      Long publishedPinnedId = createAnnouncement(LocalDateTime.now(), "게시 고정", true, true);
+      Long unpublishedPinnedId =
+          createAnnouncement(LocalDateTime.now().minusHours(1), "미게시 고정", false, true);
+      Long normalId = createAnnouncement(LocalDateTime.now().minusHours(2), "일반", true, false);
+
+      String adminToken = getAccessToken(ADMIN_PROVIDER_ID);
+      HttpHeaders adminHeaders = createAuthHeader(adminToken);
+
+      ResponseEntity<ApiResponse<AnnouncementListResponse>> response =
+          restTemplate.exchange(
+              "/admin/announcements/pinned",
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              LIST_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      List<Long> ids =
+          response.getBody().data().items().stream().map(AnnouncementSummary::id).toList();
+      assertThat(ids).contains(publishedPinnedId, unpublishedPinnedId);
+      assertThat(ids).doesNotContain(normalId);
+    }
+
+    @Test
+    @DisplayName("관리자 아닌 유저 - 403")
+    void forbiddenWhenNotAdmin() {
+      String token = getAccessToken(USER_PROVIDER_ID);
+      HttpHeaders headers = createAuthHeader(token);
+
+      ResponseEntity<ApiResponse<AnnouncementListResponse>> response =
+          restTemplate.exchange(
+              "/admin/announcements/pinned",
+              HttpMethod.GET,
+              new HttpEntity<>(headers),
+              LIST_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("토큰 없이 요청 - 401")
+    void unauthorizedWithoutToken() {
+      ResponseEntity<ApiResponse<AnnouncementListResponse>> response =
+          restTemplate.exchange("/admin/announcements/pinned", HttpMethod.GET, null, LIST_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /admin/announcements/{id} - 어드민 단건 조회")
+  class GetById {
+    @Test
+    @DisplayName("성공 - 게시 공지")
+    void successPublished() {
+      Long id = createAnnouncement(LocalDateTime.now(), "게시", true, false);
+
+      String adminToken = getAccessToken(ADMIN_PROVIDER_ID);
+      HttpHeaders adminHeaders = createAuthHeader(adminToken);
+
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
+          restTemplate.exchange(
+              "/admin/announcements/" + id,
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      AnnouncementDetail detail = response.getBody().data();
+      assertThat(detail.id()).isEqualTo(id);
+      assertThat(detail.title().ko()).isEqualTo("게시");
+      assertThat(detail.published()).isTrue();
+    }
+
+    @Test
+    @DisplayName("성공 - 미게시 공지도 조회 (어드민)")
+    void successUnpublished() {
+      Long id = createAnnouncement(LocalDateTime.now(), "미게시", false, false);
+
+      String adminToken = getAccessToken(ADMIN_PROVIDER_ID);
+      HttpHeaders adminHeaders = createAuthHeader(adminToken);
+
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
+          restTemplate.exchange(
+              "/admin/announcements/" + id,
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      assertThat(response.getBody().data().published()).isFalse();
+    }
+
+    @Test
+    @DisplayName("미존재 - 404")
+    void notFound() {
+      String adminToken = getAccessToken(ADMIN_PROVIDER_ID);
+      HttpHeaders adminHeaders = createAuthHeader(adminToken);
+
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
+          restTemplate.exchange(
+              "/admin/announcements/999999",
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("관리자 아닌 유저 - 403")
+    void forbiddenWhenNotAdmin() {
+      String token = getAccessToken(USER_PROVIDER_ID);
+      HttpHeaders headers = createAuthHeader(token);
+
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
+          restTemplate.exchange(
+              "/admin/announcements/1", HttpMethod.GET, new HttpEntity<>(headers), DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("토큰 없이 요청 - 401")
+    void unauthorizedWithoutToken() {
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
+          restTemplate.exchange("/admin/announcements/1", HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+  }
+}

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AdminAnnouncementE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AdminAnnouncementE2ETest.java
@@ -20,8 +20,7 @@ import org.springframework.http.*;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 public class AdminAnnouncementE2ETest extends BaseE2ETest {
-  private static final ParameterizedTypeReference<ApiResponse<AnnouncementIdResponse>> ID_RESPONSE =
-      new ParameterizedTypeReference<>() {};
+
   private static final ParameterizedTypeReference<ApiResponse<AnnouncementDetail>> DETAIL_RESPONSE =
       new ParameterizedTypeReference<>() {};
   private static final ParameterizedTypeReference<ApiResponse<AnnouncementListResponse>>
@@ -55,12 +54,12 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
             published,
             pinned);
 
-    ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+    ResponseEntity<ApiResponse<AnnouncementDetail>> response =
         restTemplate.exchange(
             "/admin/announcements",
             HttpMethod.POST,
             new HttpEntity<>(request, adminHeaders),
-            ID_RESPONSE);
+            DETAIL_RESPONSE);
 
     assert response.getBody() != null;
     return response.getBody().data().id();
@@ -89,12 +88,12 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
               true,
               false);
 
-      ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
           restTemplate.exchange(
               "/admin/announcements",
               HttpMethod.POST,
               new HttpEntity<>(request, adminHeaders),
-              ID_RESPONSE);
+              DETAIL_RESPONSE);
 
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
       assert response.getBody() != null;
@@ -115,12 +114,12 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
               true,
               false);
 
-      ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
           restTemplate.exchange(
               "/admin/announcements",
               HttpMethod.POST,
               new HttpEntity<>(request, adminHeaders),
-              ID_RESPONSE);
+              DETAIL_RESPONSE);
 
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
@@ -138,12 +137,12 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
               true,
               false);
 
-      ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
           restTemplate.exchange(
               "/admin/announcements",
               HttpMethod.POST,
               new HttpEntity<>(request, adminHeaders),
-              ID_RESPONSE);
+              DETAIL_RESPONSE);
 
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
     }
@@ -161,12 +160,12 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
               true,
               false);
 
-      ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
           restTemplate.exchange(
               "/admin/announcements",
               HttpMethod.POST,
               new HttpEntity<>(request, headers),
-              ID_RESPONSE);
+              DETAIL_RESPONSE);
 
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
@@ -182,11 +181,19 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
               true,
               false);
 
-      ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
           restTemplate.exchange(
-              "/admin/announcements", HttpMethod.POST, new HttpEntity<>(request), ID_RESPONSE);
+              "/admin/announcements", HttpMethod.POST, new HttpEntity<>(request), DETAIL_RESPONSE);
 
-      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+      assertThat(
+              restTemplate
+                  .exchange(
+                      "/admin/announcements",
+                      HttpMethod.POST,
+                      new HttpEntity<>(request),
+                      DETAIL_RESPONSE)
+                  .getStatusCode())
+          .isEqualTo(HttpStatus.UNAUTHORIZED);
     }
   }
 
@@ -620,6 +627,7 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
     @DisplayName("성공 - 미게시 공지도 조회 (어드민)")
     void successUnpublished() {
       Long id = createAnnouncement(LocalDateTime.now(), "미게시", false, false);
+      System.out.println("id = " + id);
 
       String adminToken = getAccessToken(ADMIN_PROVIDER_ID);
       HttpHeaders adminHeaders = createAuthHeader(adminToken);

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AdminAnnouncementE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AdminAnnouncementE2ETest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import com.typingpractice.typing_practice_be.BaseE2ETest;
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -80,9 +81,10 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
     void success() {
       HttpHeaders adminHeaders = getAdminHeaders();
 
+      LocalDateTime kstPostedAt = LocalDateTime.of(2026, 5, 9, 15, 0);
       CreateAnnouncementRequest request =
           new CreateAnnouncementRequest(
-              LocalDateTime.now(),
+              kstPostedAt,
               new LocalizedTextRequest("저작권 안내", "Copyright Notice", null),
               new LocalizedTextRequest("내용", "content", null),
               true,
@@ -97,8 +99,10 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
 
       assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
       assert response.getBody() != null;
+      AnnouncementDetail data = response.getBody().data();
       assertThat(response.getBody().success()).isTrue();
-      assertThat(response.getBody().data().id()).isNotNull();
+      assertThat(data.id()).isNotNull();
+      assertThat(data.postedAt()).isEqualTo(TimeUtils.kstToUtc(kstPostedAt));
     }
 
     @Test()
@@ -236,6 +240,7 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
 
       assert getResponse.getBody() != null;
       AnnouncementDetail detail = getResponse.getBody().data();
+      assertThat(detail.postedAt()).isEqualTo(TimeUtils.kstToUtc(newPostedAt));
       assertThat(detail.title().ko()).isEqualTo("바뀐 제목");
       assertThat(detail.content().ko()).isEqualTo("바뀐 내용");
       assertThat(detail.published()).isFalse();
@@ -252,24 +257,16 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
       UpdateAnnouncementRequest request =
           new UpdateAnnouncementRequest(null, null, null, null, true);
 
-      ResponseEntity<ApiResponse<Void>> response =
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
           restTemplate.exchange(
               "/admin/announcements/" + id,
               HttpMethod.PATCH,
               new HttpEntity<>(request, adminHeaders),
-              VOID_RESPONSE);
-
-      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-
-      ResponseEntity<ApiResponse<AnnouncementDetail>> getResponse =
-          restTemplate.exchange(
-              "/admin/announcements/" + id,
-              HttpMethod.GET,
-              new HttpEntity<>(adminHeaders),
               DETAIL_RESPONSE);
 
-      assert getResponse.getBody() != null;
-      AnnouncementDetail detail = getResponse.getBody().data();
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      AnnouncementDetail detail = response.getBody().data();
       assertThat(detail.title().ko()).isEqualTo("원래 제목"); // 미변경
       assertThat(detail.published()).isTrue(); // 미변경
       assertThat(detail.pinned()).isTrue(); // 변경
@@ -489,6 +486,25 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
     }
 
     @Test
+    @DisplayName("응답의 postedAt이 UTC 형식")
+    void postedAtIsUtc() {
+      LocalDateTime kstPostedAt = LocalDateTime.of(2026, 5, 9, 15, 0);
+      createAnnouncement(kstPostedAt, "공지", true, false);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> response =
+          restTemplate.exchange(
+              "/admin/announcements",
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              PAGE_RESPONSE);
+
+      assert response.getBody() != null;
+      AnnouncementSummary first = response.getBody().data().getContent().getFirst();
+      assertThat(first.postedAt()).isEqualTo(TimeUtils.kstToUtc(kstPostedAt));
+    }
+
+    @Test
     @DisplayName("cursor 한쪽만 - 400")
     void badRequestWhenCursorIncomplete() {
       HttpHeaders adminHeaders = getAdminHeaders();
@@ -603,7 +619,8 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
     @Test
     @DisplayName("성공 - 게시 공지")
     void successPublished() {
-      Long id = createAnnouncement(LocalDateTime.now(), "게시", true, false);
+      LocalDateTime kstPostedAt = LocalDateTime.of(2026, 5, 9, 15, 0);
+      Long id = createAnnouncement(kstPostedAt, "게시", true, false);
 
       String adminToken = getAccessToken(ADMIN_PROVIDER_ID);
       HttpHeaders adminHeaders = createAuthHeader(adminToken);
@@ -620,6 +637,7 @@ public class AdminAnnouncementE2ETest extends BaseE2ETest {
       AnnouncementDetail detail = response.getBody().data();
       assertThat(detail.id()).isEqualTo(id);
       assertThat(detail.title().ko()).isEqualTo("게시");
+      assertThat(detail.postedAt()).isEqualTo(TimeUtils.kstToUtc(kstPostedAt));
       assertThat(detail.published()).isTrue();
     }
 

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AnnouncementE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AnnouncementE2ETest.java
@@ -17,8 +17,7 @@ import org.springframework.http.*;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 public class AnnouncementE2ETest extends BaseE2ETest {
-  private static final ParameterizedTypeReference<ApiResponse<AnnouncementIdResponse>> ID_RESPONSE =
-      new ParameterizedTypeReference<>() {};
+
   private static final ParameterizedTypeReference<ApiResponse<AnnouncementDetail>> DETAIL_RESPONSE =
       new ParameterizedTypeReference<>() {};
   private static final ParameterizedTypeReference<ApiResponse<AnnouncementListResponse>>
@@ -52,12 +51,12 @@ public class AnnouncementE2ETest extends BaseE2ETest {
             published,
             pinned);
 
-    ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+    ResponseEntity<ApiResponse<AnnouncementDetail>> response =
         restTemplate.exchange(
             "/admin/announcements",
             HttpMethod.POST,
             new HttpEntity<>(request, adminHeaders),
-            ID_RESPONSE);
+            DETAIL_RESPONSE);
 
     assert response.getBody() != null;
     return response.getBody().data().id();

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AnnouncementE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AnnouncementE2ETest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.*;
 import com.typingpractice.typing_practice_be.BaseE2ETest;
 import com.typingpractice.typing_practice_be.common.ApiResponse;
 import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -68,10 +69,11 @@ public class AnnouncementE2ETest extends BaseE2ETest {
     @Test
     @DisplayName("성공 - 최신 게시 공지 반환")
     void success() {
-      LocalDateTime base = LocalDateTime.now().minusHours(5);
+      LocalDateTime base = LocalDateTime.of(2026, 5, 1, 10, 0);
       createAnnouncement(base, "오래된", true, false);
       createAnnouncement(base.plusHours(1), "중간", true, false);
-      Long latestId = createAnnouncement(base.plusHours(2), "최신", true, false);
+      LocalDateTime latestKst = base.plusHours(2);
+      Long latestId = createAnnouncement(latestKst, "최신", true, false);
 
       ResponseEntity<ApiResponse<AnnouncementDetail>> response =
           restTemplate.exchange("/announcements/latest", HttpMethod.GET, null, DETAIL_RESPONSE);
@@ -82,6 +84,7 @@ public class AnnouncementE2ETest extends BaseE2ETest {
       assertThat(detail).isNotNull();
       assertThat(detail.id()).isEqualTo(latestId);
       assertThat(detail.title().ko()).isEqualTo("최신");
+      assertThat(detail.postedAt()).isEqualTo(TimeUtils.kstToUtc(latestKst));
     }
 
     @Test
@@ -217,6 +220,20 @@ public class AnnouncementE2ETest extends BaseE2ETest {
     }
 
     @Test
+    @DisplayName("응답의 postedAt이 UTC 형식")
+    void postedAtIsUtc() {
+      LocalDateTime kstPostedAt = LocalDateTime.of(2026, 5, 9, 15, 0);
+      createAnnouncement(kstPostedAt, "공지", true, false);
+
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> response =
+          restTemplate.exchange("/announcements", HttpMethod.GET, null, PAGE_RESPONSE);
+
+      assert response.getBody() != null;
+      AnnouncementSummary first = response.getBody().data().getContent().getFirst();
+      assertThat(first.postedAt()).isEqualTo(TimeUtils.kstToUtc(kstPostedAt));
+    }
+
+    @Test
     @DisplayName("cursor 한쪽만 - 400")
     void badRequestWhenCursorIncomplete() {
       ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> response =
@@ -239,9 +256,10 @@ public class AnnouncementE2ETest extends BaseE2ETest {
   @DisplayName("GET /announcements/{id} - 사용자 단건 조회")
   class GetById {
     @Test
-    @DisplayName("성공 - 게시 공지")
+    @DisplayName("성공 - 게시 공지 (KST→UTC 응답)")
     void successPublished() {
-      Long id = createAnnouncement(LocalDateTime.now(), "게시", true, false);
+      LocalDateTime kstPostedAt = LocalDateTime.of(2026, 5, 9, 15, 0);
+      Long id = createAnnouncement(kstPostedAt, "게시", true, false);
 
       ResponseEntity<ApiResponse<AnnouncementDetail>> response =
           restTemplate.exchange("/announcements/" + id, HttpMethod.GET, null, DETAIL_RESPONSE);
@@ -252,6 +270,7 @@ public class AnnouncementE2ETest extends BaseE2ETest {
       assertThat(detail.id()).isEqualTo(id);
       assertThat(detail.title().ko()).isEqualTo("게시");
       assertThat(detail.content().ko()).isEqualTo("내용");
+      assertThat(detail.postedAt()).isEqualTo(TimeUtils.kstToUtc(kstPostedAt));
       assertThat(detail.published()).isTrue();
     }
 

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AnnouncementE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AnnouncementE2ETest.java
@@ -9,6 +9,7 @@ import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.ParameterizedTypeReference;

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AnnouncementE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/AnnouncementE2ETest.java
@@ -1,0 +1,291 @@
+package com.typingpractice.typing_practice_be.notice.announcement;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.typingpractice.typing_practice_be.BaseE2ETest;
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class AnnouncementE2ETest extends BaseE2ETest {
+  private static final ParameterizedTypeReference<ApiResponse<AnnouncementIdResponse>> ID_RESPONSE =
+      new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<ApiResponse<AnnouncementDetail>> DETAIL_RESPONSE =
+      new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<ApiResponse<AnnouncementListResponse>>
+      LIST_RESPONSE = new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<
+          ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>>
+      PAGE_RESPONSE = new ParameterizedTypeReference<>() {};
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    jdbcTemplate.execute("DELETE FROM announcement");
+  }
+
+  private HttpHeaders getAdminHeaders() {
+    String adminToken = getAccessToken(ADMIN_PROVIDER_ID);
+    return createAuthHeader(adminToken);
+  }
+
+  /** 어드민으로 공지사항 등록 후 id 반환. (사용자 측에는 등록 API가 없으므로 어드민 API로 데이터 셋업) */
+  private Long createAnnouncement(
+      LocalDateTime postedAt, String titleKo, boolean published, boolean pinned) {
+    HttpHeaders adminHeaders = getAdminHeaders();
+
+    CreateAnnouncementRequest request =
+        new CreateAnnouncementRequest(
+            postedAt,
+            new LocalizedTextRequest(titleKo, null, null),
+            new LocalizedTextRequest("내용", null, null),
+            published,
+            pinned);
+
+    ResponseEntity<ApiResponse<AnnouncementIdResponse>> response =
+        restTemplate.exchange(
+            "/admin/announcements",
+            HttpMethod.POST,
+            new HttpEntity<>(request, adminHeaders),
+            ID_RESPONSE);
+
+    assert response.getBody() != null;
+    return response.getBody().data().id();
+  }
+
+  @Nested
+  @DisplayName("GET /announcements/latest - 최신 게시 공지 1건")
+  class GetLatest {
+    @Test
+    @DisplayName("성공 - 최신 게시 공지 반환")
+    void success() {
+      LocalDateTime base = LocalDateTime.now().minusHours(5);
+      createAnnouncement(base, "오래된", true, false);
+      createAnnouncement(base.plusHours(1), "중간", true, false);
+      Long latestId = createAnnouncement(base.plusHours(2), "최신", true, false);
+
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
+          restTemplate.exchange("/announcements/latest", HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      AnnouncementDetail detail = response.getBody().data();
+      assertThat(detail).isNotNull();
+      assertThat(detail.id()).isEqualTo(latestId);
+      assertThat(detail.title().ko()).isEqualTo("최신");
+    }
+
+    @Test
+    @DisplayName("성공 - 게시된 공지 없음 (data: null)")
+    void emptyWhenNoPublished() {
+      // 미게시 공지만 등록
+      createAnnouncement(LocalDateTime.now(), "미게시", false, false);
+
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
+          restTemplate.exchange("/announcements/latest", HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      assertThat(response.getBody().success()).isTrue();
+      assertThat(response.getBody().data()).isNull();
+    }
+
+    @Test
+    @DisplayName("성공 - 미게시는 무시하고 그 이전 게시 공지 반환")
+    void skipUnpublished() {
+      LocalDateTime base = LocalDateTime.now().minusHours(5);
+      Long publishedId = createAnnouncement(base, "이전 게시", true, false);
+      createAnnouncement(base.plusHours(1), "최근 미게시", false, false);
+
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
+          restTemplate.exchange("/announcements/latest", HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assert response.getBody() != null;
+      AnnouncementDetail detail = response.getBody().data();
+      assertThat(detail).isNotNull();
+      assertThat(detail.id()).isEqualTo(publishedId);
+    }
+
+    @Test
+    @DisplayName("성공 - 비인증으로도 200")
+    void successWithoutToken() {
+      createAnnouncement(LocalDateTime.now(), "공지", true, false);
+
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
+          restTemplate.exchange("/announcements/latest", HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /announcements/pinned - 게시된 고정 공지")
+  class GetPinned {
+    @Test
+    @DisplayName("성공 - 게시된 고정만 노출")
+    void success() {
+      Long publishedPinnedId = createAnnouncement(LocalDateTime.now(), "게시 고정", true, true);
+      Long unpublishedPinnedId =
+          createAnnouncement(LocalDateTime.now().minusHours(1), "미게시 고정", false, true);
+      Long publishedNormalId =
+          createAnnouncement(LocalDateTime.now().minusHours(2), "게시 일반", true, false);
+
+      ResponseEntity<ApiResponse<AnnouncementListResponse>> response =
+          restTemplate.exchange("/announcements/pinned", HttpMethod.GET, null, LIST_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      List<Long> ids =
+          response.getBody().data().items().stream().map(AnnouncementSummary::id).toList();
+      assertThat(ids).contains(publishedPinnedId);
+      assertThat(ids).doesNotContain(unpublishedPinnedId);
+      assertThat(ids).doesNotContain(publishedNormalId);
+    }
+
+    @Test
+    @DisplayName("성공 - 고정 공지 없음 (빈 목록)")
+    void empty() {
+      // 게시 일반만 등록
+      createAnnouncement(LocalDateTime.now(), "일반", true, false);
+
+      ResponseEntity<ApiResponse<AnnouncementListResponse>> response =
+          restTemplate.exchange("/announcements/pinned", HttpMethod.GET, null, LIST_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      assertThat(response.getBody().data().items()).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /announcements - 사용자 목록 조회 (커서)")
+  class GetAnnouncements {
+    @Test
+    @DisplayName("성공 - 페이지네이션 정확성 + 미게시/고정 제외 검증")
+    void successPagination() {
+      // 6개 등록: 게시 일반 4개, 미게시 1개, 게시 고정 1개
+      LocalDateTime base = LocalDateTime.now().minusHours(10);
+      Long id1 = createAnnouncement(base, "첫번째 게시", true, false);
+      Long id2 = createAnnouncement(base.plusHours(1), "두번째 게시", true, false);
+      createAnnouncement(base.plusHours(2), "세번째 미게시", false, false); // 제외
+      Long id4 = createAnnouncement(base.plusHours(3), "네번째 게시", true, false);
+      createAnnouncement(base.plusHours(4), "다섯번째 고정", true, true); // 제외
+      Long id6 = createAnnouncement(base.plusHours(5), "여섯번째 게시", true, false);
+
+      // 첫 페이지 (size=2) - 최신순이므로 id6, id4 (미게시/고정 건너뛰고)
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> page1 =
+          restTemplate.exchange("/announcements?size=2", HttpMethod.GET, null, PAGE_RESPONSE);
+
+      assertThat(page1.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert page1.getBody() != null;
+      CursorPage<AnnouncementSummary, AnnouncementCursor> data1 = page1.getBody().data();
+      assertThat(data1.getContent()).hasSize(2);
+      assertThat(data1.getContent().get(0).id()).isEqualTo(id6);
+      assertThat(data1.getContent().get(1).id()).isEqualTo(id4);
+      assertThat(data1.isHasNext()).isTrue();
+      assertThat(data1.getNextCursor()).isNotNull();
+      assertThat(data1.getNextCursor().id()).isEqualTo(id4);
+
+      // 두번째 페이지 - 미게시(세번째)와 고정(다섯번째)은 건너뛰고 id2, id1
+      AnnouncementCursor cursor = data1.getNextCursor();
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> page2 =
+          restTemplate.exchange(
+              "/announcements?size=2&cursorPostedAt="
+                  + cursor.postedAt()
+                  + "&cursorId="
+                  + cursor.id(),
+              HttpMethod.GET,
+              null,
+              PAGE_RESPONSE);
+
+      assert page2.getBody() != null;
+      CursorPage<AnnouncementSummary, AnnouncementCursor> data2 = page2.getBody().data();
+      assertThat(data2.getContent()).hasSize(2);
+      assertThat(data2.getContent().get(0).id()).isEqualTo(id2);
+      assertThat(data2.getContent().get(1).id()).isEqualTo(id1);
+      assertThat(data2.isHasNext()).isFalse();
+      assertThat(data2.getNextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("cursor 한쪽만 - 400")
+    void badRequestWhenCursorIncomplete() {
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> response =
+          restTemplate.exchange("/announcements?cursorId=1", HttpMethod.GET, null, PAGE_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("size 범위 위반 - 400")
+    void badRequestWhenSizeOutOfRange() {
+      ResponseEntity<ApiResponse<CursorPage<AnnouncementSummary, AnnouncementCursor>>> response =
+          restTemplate.exchange("/announcements?size=101", HttpMethod.GET, null, PAGE_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /announcements/{id} - 사용자 단건 조회")
+  class GetById {
+    @Test
+    @DisplayName("성공 - 게시 공지")
+    void successPublished() {
+      Long id = createAnnouncement(LocalDateTime.now(), "게시", true, false);
+
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
+          restTemplate.exchange("/announcements/" + id, HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      AnnouncementDetail detail = response.getBody().data();
+      assertThat(detail.id()).isEqualTo(id);
+      assertThat(detail.title().ko()).isEqualTo("게시");
+      assertThat(detail.content().ko()).isEqualTo("내용");
+      assertThat(detail.published()).isTrue();
+    }
+
+    @Test
+    @DisplayName("미게시 공지 - 404 (어드민과 정책 차이)")
+    void notFoundWhenUnpublished() {
+      Long id = createAnnouncement(LocalDateTime.now(), "미게시", false, false);
+
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
+          restTemplate.exchange("/announcements/" + id, HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("미존재 - 404")
+    void notFound() {
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
+          restTemplate.exchange("/announcements/999999", HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("게시된 고정 공지도 단건 조회 가능")
+    void successPinned() {
+      Long id = createAnnouncement(LocalDateTime.now(), "게시 고정", true, true);
+
+      ResponseEntity<ApiResponse<AnnouncementDetail>> response =
+          restTemplate.exchange("/announcements/" + id, HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      assertThat(response.getBody().data().pinned()).isTrue();
+    }
+  }
+}

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementServiceTest.java
@@ -13,6 +13,8 @@ import java.lang.reflect.Field;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
 import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
 import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
 import com.typingpractice.typing_practice_be.notice.announcement.exception.AnnouncementNotFoundException;
@@ -79,6 +80,7 @@ public class AdminAnnouncementServiceTest {
       Announcement announcement = adminAnnouncementService.create(request);
 
       assertThat(announcement.getId()).isEqualTo(1L);
+      assertThat(announcement.getPostedAt()).isEqualTo(TimeUtils.kstToUtc(BASE_TIME));
       verify(announcementRepository).save(any(Announcement.class));
     }
   }
@@ -103,7 +105,7 @@ public class AdminAnnouncementServiceTest {
 
       adminAnnouncementService.update(1L, request);
 
-      assertThat(existing.getPostedAt()).isEqualTo(newTime);
+      assertThat(existing.getPostedAt()).isEqualTo(TimeUtils.kstToUtc(newTime));
       assertThat(existing.getTitle().ko()).isEqualTo("새 제목");
       assertThat(existing.getContent().ko()).isEqualTo("새 내용");
       assertThat(existing.isPublished()).isFalse();
@@ -122,7 +124,7 @@ public class AdminAnnouncementServiceTest {
 
       adminAnnouncementService.update(1L, request);
 
-      assertThat(existing.getPostedAt()).isEqualTo(newTime);
+      assertThat(existing.getPostedAt()).isEqualTo(TimeUtils.kstToUtc(newTime));
       assertThat(existing.getTitle().ko()).isEqualTo("제목"); // 미변경
       assertThat(existing.getContent().ko()).isEqualTo("내용"); // 미변경
       assertThat(existing.isPublished()).isTrue(); // 미변경

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementServiceTest.java
@@ -1,0 +1,262 @@
+package com.typingpractice.typing_practice_be.notice.announcement.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.*;
+import com.typingpractice.typing_practice_be.notice.announcement.exception.AnnouncementNotFoundException;
+import com.typingpractice.typing_practice_be.notice.announcement.repository.AnnouncementRepository;
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AdminAnnouncementServiceTest {
+  @Mock private AnnouncementRepository announcementRepository;
+
+  @InjectMocks private AdminAnnouncementService adminAnnouncementService;
+
+  private static final LocalDateTime BASE_TIME = LocalDateTime.of(2026, 5, 5, 10, 0);
+
+  private Announcement createAnnouncement(
+      Long id, LocalDateTime postedAt, boolean published, boolean pinned) {
+    Announcement a =
+        Announcement.create(
+            postedAt,
+            new LocalizedText("제목", null, null),
+            new LocalizedText("내용", null, null),
+            published,
+            pinned);
+    setId(a, id);
+    return a;
+  }
+
+  private void setId(Object entity, Long id) {
+    try {
+      Field idField = entity.getClass().getDeclaredField("id");
+      idField.setAccessible(true);
+      idField.set(entity, id);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Nested
+  @DisplayName("create")
+  class Create {
+    @Test
+    @DisplayName("성공 - 저장 후 id 반환")
+    void success() {
+      CreateAnnouncementRequest request =
+          new CreateAnnouncementRequest(
+              BASE_TIME,
+              new LocalizedTextRequest("제목", null, null),
+              new LocalizedTextRequest("내용", null, null),
+              true,
+              false);
+
+      when(announcementRepository.save(any(Announcement.class)))
+          .thenAnswer(
+              invocation -> {
+                Announcement saved = invocation.getArgument(0);
+                setId(saved, 1L);
+                return saved;
+              });
+
+      Long id = adminAnnouncementService.create(request);
+
+      assertThat(id).isEqualTo(1L);
+      verify(announcementRepository).save(any(Announcement.class));
+    }
+  }
+
+  @Nested
+  @DisplayName("update")
+  class Update {
+    @Test
+    @DisplayName("성공 - 모든 필드 변경")
+    void successAllFields() {
+      Announcement existing = createAnnouncement(1L, BASE_TIME, true, false);
+      LocalDateTime newTime = BASE_TIME.plusDays(1);
+      UpdateAnnouncementRequest request =
+          new UpdateAnnouncementRequest(
+              newTime,
+              new LocalizedTextRequest("새 제목", null, null),
+              new LocalizedTextRequest("새 내용", null, null),
+              false,
+              true);
+
+      when(announcementRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+      adminAnnouncementService.update(1L, request);
+
+      assertThat(existing.getPostedAt()).isEqualTo(newTime);
+      assertThat(existing.getTitle().ko()).isEqualTo("새 제목");
+      assertThat(existing.getContent().ko()).isEqualTo("새 내용");
+      assertThat(existing.isPublished()).isFalse();
+      assertThat(existing.isPinned()).isTrue();
+    }
+
+    @Test
+    @DisplayName("성공 - null 필드는 미변경")
+    void successPartial() {
+      Announcement existing = createAnnouncement(1L, BASE_TIME, true, false);
+      LocalDateTime newTime = BASE_TIME.plusDays(1);
+      UpdateAnnouncementRequest request =
+          new UpdateAnnouncementRequest(newTime, null, null, null, null);
+
+      when(announcementRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+      adminAnnouncementService.update(1L, request);
+
+      assertThat(existing.getPostedAt()).isEqualTo(newTime);
+      assertThat(existing.getTitle().ko()).isEqualTo("제목"); // 미변경
+      assertThat(existing.getContent().ko()).isEqualTo("내용"); // 미변경
+      assertThat(existing.isPublished()).isTrue(); // 미변경
+      assertThat(existing.isPinned()).isFalse(); // 미변경
+    }
+
+    @Test
+    @DisplayName("미존재 - 404")
+    void notFound() {
+      UpdateAnnouncementRequest request =
+          new UpdateAnnouncementRequest(BASE_TIME, null, null, null, null);
+
+      when(announcementRepository.findById(1L)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> adminAnnouncementService.update(1L, request))
+          .isInstanceOf(AnnouncementNotFoundException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("delete")
+  class Delete {
+    @Test
+    @DisplayName("성공 - Repository.delete 호출")
+    void success() {
+      Announcement existing = createAnnouncement(1L, BASE_TIME, true, false);
+      when(announcementRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+      adminAnnouncementService.delete(1L);
+
+      verify(announcementRepository).delete(existing);
+    }
+
+    @Test
+    @DisplayName("미존재 - 404")
+    void notFound() {
+      when(announcementRepository.findById(1L)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> adminAnnouncementService.delete(1L))
+          .isInstanceOf(AnnouncementNotFoundException.class);
+      verify(announcementRepository, never()).delete(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("findOne")
+  class FindOne {
+    @Test
+    @DisplayName("게시된 공지 - 정상 반환")
+    void successPublished() {
+      Announcement a = createAnnouncement(1L, BASE_TIME, true, false);
+      when(announcementRepository.findById(1L)).thenReturn(Optional.of(a));
+
+      AnnouncementDetail result = adminAnnouncementService.findOne(1L);
+
+      assertThat(result.id()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("미게시 공지 - 어드민은 정상 조회")
+    void successUnpublished() {
+      Announcement a = createAnnouncement(1L, BASE_TIME, false, false);
+      when(announcementRepository.findById(1L)).thenReturn(Optional.of(a));
+
+      AnnouncementDetail result = adminAnnouncementService.findOne(1L);
+
+      assertThat(result.id()).isEqualTo(1L);
+      assertThat(result.published()).isFalse();
+    }
+
+    @Test
+    @DisplayName("미존재 - 404")
+    void notFound() {
+      when(announcementRepository.findById(1L)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> adminAnnouncementService.findOne(1L))
+          .isInstanceOf(AnnouncementNotFoundException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("findPinned")
+  class FindPinned {
+    @Test
+    @DisplayName("고정 공지 목록 반환 - 게시 여부 무관")
+    void success() {
+      Announcement published = createAnnouncement(1L, BASE_TIME, true, true);
+      Announcement unpublished = createAnnouncement(2L, BASE_TIME.minusDays(1), false, true);
+      when(announcementRepository.findAllPinned()).thenReturn(List.of(published, unpublished));
+
+      List<AnnouncementSummary> result = adminAnnouncementService.findPinned();
+
+      assertThat(result).hasSize(2);
+      assertThat(result.get(0).id()).isEqualTo(1L);
+      assertThat(result.get(1).id()).isEqualTo(2L);
+      assertThat(result.get(1).published()).isFalse();
+    }
+  }
+
+  @Nested
+  @DisplayName("findList")
+  class FindList {
+    @Test
+    @DisplayName("hasNext = true - 마지막 항목 잘라내고 nextCursor 발급")
+    void hasNext() {
+      Announcement a1 = createAnnouncement(1L, BASE_TIME, true, false);
+      Announcement a2 = createAnnouncement(2L, BASE_TIME.minusDays(1), false, false);
+      Announcement a3 = createAnnouncement(3L, BASE_TIME.minusDays(2), true, false);
+      when(announcementRepository.findAllNonPinnedByCursor(null, 2))
+          .thenReturn(List.of(a1, a2, a3));
+
+      CursorPage<AnnouncementSummary, AnnouncementCursor> result =
+          adminAnnouncementService.findList(null, 2);
+
+      assertThat(result.getContent()).hasSize(2);
+      assertThat(result.getContent().get(0).id()).isEqualTo(1L);
+      assertThat(result.getContent().get(1).id()).isEqualTo(2L);
+      assertThat(result.isHasNext()).isTrue();
+      assertThat(result.getNextCursor()).isNotNull();
+      assertThat(result.getNextCursor().id()).isEqualTo(2L);
+      assertThat(result.getNextCursor().postedAt()).isEqualTo(BASE_TIME.minusDays(1));
+    }
+
+    @Test
+    @DisplayName("hasNext = false - nextCursor null")
+    void noNext() {
+      Announcement a1 = createAnnouncement(1L, BASE_TIME, false, false);
+      Announcement a2 = createAnnouncement(2L, BASE_TIME.minusDays(1), true, false);
+      when(announcementRepository.findAllNonPinnedByCursor(null, 2)).thenReturn(List.of(a1, a2));
+
+      CursorPage<AnnouncementSummary, AnnouncementCursor> result =
+          adminAnnouncementService.findList(null, 2);
+
+      assertThat(result.getContent()).hasSize(2);
+      assertThat(result.isHasNext()).isFalse();
+      assertThat(result.getNextCursor()).isNull();
+    }
+  }
+}

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/service/AdminAnnouncementServiceTest.java
@@ -76,9 +76,9 @@ public class AdminAnnouncementServiceTest {
                 return saved;
               });
 
-      Long id = adminAnnouncementService.create(request);
+      Announcement announcement = adminAnnouncementService.create(request);
 
-      assertThat(id).isEqualTo(1L);
+      assertThat(announcement.getId()).isEqualTo(1L);
       verify(announcementRepository).save(any(Announcement.class));
     }
   }

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/service/AnnouncementServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/announcement/service/AnnouncementServiceTest.java
@@ -1,0 +1,187 @@
+package com.typingpractice.typing_practice_be.notice.announcement.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.notice.announcement.domain.Announcement;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementCursor;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementDetail;
+import com.typingpractice.typing_practice_be.notice.announcement.dto.AnnouncementSummary;
+import com.typingpractice.typing_practice_be.notice.announcement.exception.AnnouncementNotFoundException;
+import com.typingpractice.typing_practice_be.notice.announcement.repository.AnnouncementRepository;
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+public class AnnouncementServiceTest {
+  @Mock private AnnouncementRepository announcementRepository;
+
+  @InjectMocks private AnnouncementService announcementService;
+
+  private static final LocalDateTime BASE_TIME = LocalDateTime.of(2026, 5, 5, 10, 0);
+
+  private Announcement createAnnouncement(Long id, LocalDateTime postedAt, boolean published) {
+    Announcement a =
+        Announcement.create(
+            postedAt,
+            new LocalizedText("제목", null, null),
+            new LocalizedText("내용", null, null),
+            published,
+            false);
+    setId(a, id);
+    return a;
+  }
+
+  private void setId(Object entity, Long id) {
+    try {
+      Field idField = entity.getClass().getDeclaredField("id");
+      idField.setAccessible(true);
+      idField.set(entity, id);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Nested
+  @DisplayName("findLatest")
+  class FindLatest {
+    @Test
+    @DisplayName("최신 게시 공지 반환")
+    void success() {
+      Announcement latest = createAnnouncement(1L, BASE_TIME, true);
+
+      when(announcementRepository.findLatestPublished()).thenReturn(Optional.of(latest));
+
+      AnnouncementDetail result = announcementService.findLatest();
+
+      assertThat(result).isNotNull();
+      assertThat(result.id()).isEqualTo(latest.getId());
+    }
+
+    @Test
+    @DisplayName("게시된 공지 없음 - null 반환")
+    void empty() {
+      when(announcementRepository.findLatestPublished()).thenReturn(Optional.empty());
+
+      AnnouncementDetail result = announcementService.findLatest();
+
+      assertThat(result).isNull();
+    }
+  }
+
+  @Nested
+  @DisplayName("findOne")
+  class FindOne {
+    @Test
+    @DisplayName("게시된 공지 - 정상 반환")
+    void success() {
+      Announcement a = createAnnouncement(1L, BASE_TIME, true);
+      when(announcementRepository.findById(1L)).thenReturn(Optional.of(a));
+
+      AnnouncementDetail result = announcementService.findOne(1L);
+
+      assertThat(result.id()).isEqualTo(a.getId());
+    }
+
+    @Test
+    @DisplayName("미게시 공지 - 404")
+    void unpublished() {
+      Announcement a = createAnnouncement(1L, BASE_TIME, false);
+      when(announcementRepository.findById(1L)).thenReturn(Optional.of(a));
+
+      assertThatThrownBy(() -> announcementService.findOne(1L))
+          .isInstanceOf(AnnouncementNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("미존재 - 404")
+    void notFound() {
+      when(announcementRepository.findById(1L)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> announcementService.findOne(1L))
+          .isInstanceOf(AnnouncementNotFoundException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("findPinned")
+  class FindPinned {
+    @Test
+    @DisplayName("게시된 고정 공지 목록 반환")
+    void success() {
+      Announcement a1 = createAnnouncement(1L, BASE_TIME, true);
+      Announcement a2 = createAnnouncement(2L, BASE_TIME.minusDays(1), true);
+
+      when(announcementRepository.findPublishedPinned()).thenReturn(List.of(a1, a2));
+
+      List<AnnouncementSummary> result = announcementService.findPinned();
+
+      assertThat(result).hasSize(2);
+      assertThat(result.getFirst().id()).isEqualTo(1L);
+      assertThat(result.get(1).id()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("고정 공지 없음 - 빈 목록")
+    void empty() {
+      when(announcementRepository.findPublishedPinned()).thenReturn(List.of());
+
+      List<AnnouncementSummary> result = announcementService.findPinned();
+
+      assertThat(result).isEmpty();
+    }
+  }
+
+  @Nested
+  @DisplayName("findList")
+  class FindList {
+    @Test
+    @DisplayName("hasNext = true - 마지막 항목 잘라내고 nextCursor 발급")
+    void hasNext() {
+      Announcement a1 = createAnnouncement(1L, BASE_TIME, true);
+      Announcement a2 = createAnnouncement(2L, BASE_TIME.minusDays(1), true);
+      Announcement a3 = createAnnouncement(3L, BASE_TIME.minusDays(2), true);
+      when(announcementRepository.findPublishedNonPinnedByCursor(null, 2))
+          .thenReturn(List.of(a1, a2, a3));
+
+      CursorPage<AnnouncementSummary, AnnouncementCursor> result =
+          announcementService.findList(null, 2);
+
+      assertThat(result.getContent()).hasSize(2);
+      assertThat(result.getContent().getFirst().id()).isEqualTo(1L);
+      assertThat(result.getContent().get(1).id()).isEqualTo(2L);
+      assertThat(result.isHasNext()).isTrue();
+      assertThat(result.getNextCursor()).isNotNull();
+      assertThat(result.getNextCursor().id()).isEqualTo(2L);
+      assertThat(result.getNextCursor().postedAt()).isEqualTo(BASE_TIME.minusDays(1));
+    }
+
+    @Test
+    @DisplayName("hasNext = false - nextCursor null")
+    void noNext() {
+      // size=2 요청, repository는 2개 이하 반환 → hasNext=false
+      Announcement a1 = createAnnouncement(1L, BASE_TIME, true);
+      Announcement a2 = createAnnouncement(2L, BASE_TIME.minusDays(1), true);
+      when(announcementRepository.findPublishedNonPinnedByCursor(null, 2))
+          .thenReturn(List.of(a1, a2));
+
+      CursorPage<AnnouncementSummary, AnnouncementCursor> result =
+          announcementService.findList(null, 2);
+
+      assertThat(result.getContent()).hasSize(2);
+      assertThat(result.isHasNext()).isFalse();
+      assertThat(result.getNextCursor()).isNull();
+    }
+  }
+}

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/update/AdminUpdateNoteE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/update/AdminUpdateNoteE2ETest.java
@@ -1,0 +1,704 @@
+package com.typingpractice.typing_practice_be.notice.update;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.typingpractice.typing_practice_be.BaseE2ETest;
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
+import com.typingpractice.typing_practice_be.notice.update.dto.CreateUpdateNoteRequest;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteCursor;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateUpdateNoteRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class AdminUpdateNoteE2ETest extends BaseE2ETest {
+  private static final ParameterizedTypeReference<ApiResponse<UpdateNoteResponse>> DETAIL_RESPONSE =
+      new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<
+          ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>>
+      PAGE_RESPONSE = new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<ApiResponse<Void>> VOID_RESPONSE =
+      new ParameterizedTypeReference<>() {};
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    jdbcTemplate.execute("DELETE FROM update_note");
+  }
+
+  private HttpHeaders getAdminHeaders() {
+    String adminToken = getAccessToken(ADMIN_PROVIDER_ID);
+    return createAuthHeader(adminToken);
+  }
+
+  private Long createUpdateNote(String version, LocalDateTime releasedAtKst, boolean published) {
+    HttpHeaders adminHeaders = getAdminHeaders();
+
+    CreateUpdateNoteRequest request =
+        new CreateUpdateNoteRequest(
+            version,
+            releasedAtKst,
+            List.of(new LocalizedTextRequest("새 기능", null, null)),
+            List.of(new LocalizedTextRequest("개선", null, null)),
+            published);
+
+    ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+        restTemplate.exchange(
+            "/admin/update-notes",
+            HttpMethod.POST,
+            new HttpEntity<>(request, adminHeaders),
+            DETAIL_RESPONSE);
+
+    assert response.getBody() != null;
+    return response.getBody().data().id();
+  }
+
+  @Nested
+  @DisplayName("POST /admin/update-notes - 업데이트 노트 등록")
+  class PostUpdateNote {
+    @Test
+    @DisplayName("성공 - KST 입력이 UTC로 변환되어 응답")
+    void success() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      LocalDateTime kstReleasedAt = LocalDateTime.of(2026, 5, 9, 15, 0);
+      CreateUpdateNoteRequest request =
+          new CreateUpdateNoteRequest(
+              "v1.0.0",
+              kstReleasedAt,
+              List.of(new LocalizedTextRequest("새 기능", "New feature", null)),
+              List.of(new LocalizedTextRequest("개선", "Improvement", null)),
+              true);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes",
+              HttpMethod.POST,
+              new HttpEntity<>(request, adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+
+      UpdateNoteResponse data = response.getBody().data();
+      assertThat(data.id()).isNotNull();
+      assertThat(data.version()).isEqualTo("v1.0.0");
+      assertThat(data.releasedAt()).isEqualTo(TimeUtils.kstToUtc(kstReleasedAt));
+      assertThat(data.newFeatures()).hasSize(1);
+      assertThat(data.improvements()).hasSize(1);
+      assertThat(data.published()).isTrue();
+    }
+
+    @Test
+    @DisplayName("version 충돌 - 409")
+    void versionConflict() {
+      createUpdateNote("v1.0.0", LocalDateTime.now(), true);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+      CreateUpdateNoteRequest request =
+          new CreateUpdateNoteRequest(
+              "v1.0.0",
+              LocalDateTime.now(),
+              List.of(new LocalizedTextRequest("새 기능", null, null)),
+              List.of(new LocalizedTextRequest("개선", null, null)),
+              true);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes",
+              HttpMethod.POST,
+              new HttpEntity<>(request, adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    @DisplayName("version 형식 위반 - 400")
+    void badRequestWhenVersionInvalid() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      CreateUpdateNoteRequest request =
+          new CreateUpdateNoteRequest(
+              "1.0.0", // v 누락
+              LocalDateTime.now(),
+              List.of(new LocalizedTextRequest("새 기능", null, null)),
+              List.of(new LocalizedTextRequest("개선", null, null)),
+              true);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes",
+              HttpMethod.POST,
+              new HttpEntity<>(request, adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("newFeatures 항목의 ko 빈 문자열 - 400")
+    void badRequestWhenItemKoBlank() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      CreateUpdateNoteRequest request =
+          new CreateUpdateNoteRequest(
+              "v1.0.0",
+              LocalDateTime.now(),
+              List.of(new LocalizedTextRequest("", null, null)),
+              List.of(),
+              true);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes",
+              HttpMethod.POST,
+              new HttpEntity<>(request, adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("releasedAt null - 400")
+    void badRequestWhenReleasedAtNull() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+      CreateUpdateNoteRequest request =
+          new CreateUpdateNoteRequest(
+              "v1.0.0",
+              null,
+              List.of(new LocalizedTextRequest("새 기능", null, null)),
+              List.of(new LocalizedTextRequest("개선", null, null)),
+              true);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes",
+              HttpMethod.POST,
+              new HttpEntity<>(request, adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("관리자 아닌 유저 - 403")
+    void forbiddenWhenNotAdmin() {
+      String token = getAccessToken(USER_PROVIDER_ID);
+      HttpHeaders headers = createAuthHeader(token);
+
+      CreateUpdateNoteRequest request =
+          new CreateUpdateNoteRequest(
+              "v1.0.0",
+              LocalDateTime.now(),
+              List.of(new LocalizedTextRequest("새 기능", null, null)),
+              List.of(new LocalizedTextRequest("개선", null, null)),
+              true);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes",
+              HttpMethod.POST,
+              new HttpEntity<>(request, headers),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("토큰 없이 요청 - 401")
+    void unauthorizedWithoutToken() {
+      CreateUpdateNoteRequest request =
+          new CreateUpdateNoteRequest(
+              "v1.0.0",
+              LocalDateTime.now(),
+              List.of(new LocalizedTextRequest("새 기능", null, null)),
+              List.of(new LocalizedTextRequest("개선", null, null)),
+              true);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes", HttpMethod.POST, new HttpEntity<>(request), DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+  }
+
+  @Nested
+  @DisplayName("PATCH /admin/update-notes/{id} - 업데이트 노트 수정")
+  class PatchUpdateNote {
+    @Test
+    @DisplayName("성공 - 모든 필드 변경, KST 입력이 UTC로 변환되어 응답")
+    void successAllFields() {
+      Long id = createUpdateNote("v1.0.0", LocalDateTime.of(2026, 1, 1, 0, 0), true);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+      LocalDateTime newKstReleasedAt = LocalDateTime.of(2026, 5, 12, 15, 0);
+      UpdateUpdateNoteRequest request =
+          new UpdateUpdateNoteRequest(
+              "v1.0.1",
+              newKstReleasedAt,
+              List.of(new LocalizedTextRequest("바뀐 기능", null, null)),
+              List.of(new LocalizedTextRequest("바뀐 개선", null, null)),
+              false);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/" + id,
+              HttpMethod.PATCH,
+              new HttpEntity<>(request, adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+
+      UpdateNoteResponse data = response.getBody().data();
+      assertThat(data.version()).isEqualTo("v1.0.1");
+      assertThat(data.releasedAt()).isEqualTo(TimeUtils.kstToUtc(newKstReleasedAt));
+      assertThat(data.newFeatures().getFirst().ko()).isEqualTo("바뀐 기능");
+      assertThat(data.improvements().getFirst().ko()).isEqualTo("바뀐 개선");
+      assertThat(data.published()).isFalse();
+    }
+
+    @Test
+    @DisplayName("성공 - null 필드는 미변경")
+    void successPartial() {
+      Long id = createUpdateNote("v1.0.0", LocalDateTime.of(2026, 1, 1, 0, 0), true);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+      // published 만 변경
+      UpdateUpdateNoteRequest request = new UpdateUpdateNoteRequest(null, null, null, null, false);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/" + id,
+              HttpMethod.PATCH,
+              new HttpEntity<>(request, adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+
+      UpdateNoteResponse data = response.getBody().data();
+      assertThat(data.version()).isEqualTo("v1.0.0");
+      assertThat(data.published()).isFalse();
+      assertThat(data.newFeatures().getFirst().ko()).isEqualTo("새 기능");
+    }
+
+    @Test
+    @DisplayName("version 충돌 - 409")
+    void versionConflict() {
+      createUpdateNote("v1.0.0", LocalDateTime.now(), true);
+      Long otherId = createUpdateNote("v1.0.1", LocalDateTime.now().minusDays(1), true);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      UpdateUpdateNoteRequest request =
+          new UpdateUpdateNoteRequest("v1.0.0", null, null, null, null);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/" + otherId,
+              HttpMethod.PATCH,
+              new HttpEntity<>(request, adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CONFLICT);
+    }
+
+    @Test
+    @DisplayName("동일한 version으로 수정 - 자기 자신 제외하므로 정상")
+    void sameVersionAllowed() {
+      Long id = createUpdateNote("v1.0.0", LocalDateTime.of(2026, 1, 1, 0, 0), true);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+      UpdateUpdateNoteRequest request =
+          new UpdateUpdateNoteRequest("v1.0.0", null, null, null, false);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/" + id,
+              HttpMethod.PATCH,
+              new HttpEntity<>(request, adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    @DisplayName("version 형식 위반 - 400")
+    void badRequestWhenVersionInvalid() {
+      Long id = createUpdateNote("v1.0.0", LocalDateTime.now(), true);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+      UpdateUpdateNoteRequest request =
+          new UpdateUpdateNoteRequest("invalid", null, null, null, null);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/" + id,
+              HttpMethod.PATCH,
+              new HttpEntity<>(request, adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("미존재 - 404")
+    void notFound() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+      UpdateUpdateNoteRequest request =
+          new UpdateUpdateNoteRequest(null, LocalDateTime.now(), null, null, null);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/999999",
+              HttpMethod.PATCH,
+              new HttpEntity<>(request, adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("관리자 아닌 유저 - 403")
+    void forbiddenWhenNotAdmin() {
+      String token = getAccessToken(USER_PROVIDER_ID);
+      HttpHeaders headers = createAuthHeader(token);
+
+      UpdateUpdateNoteRequest request =
+          new UpdateUpdateNoteRequest(null, LocalDateTime.now(), null, null, null);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/1",
+              HttpMethod.PATCH,
+              new HttpEntity<>(request, headers),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("토큰 없이 요청 - 401")
+    void unauthorizedWithoutToken() {
+      UpdateUpdateNoteRequest request =
+          new UpdateUpdateNoteRequest(null, LocalDateTime.now(), null, null, null);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/1",
+              HttpMethod.PATCH,
+              new HttpEntity<>(request),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+  }
+
+  @Nested
+  @DisplayName("DELETE /admin/update-notes/{id} - 업데이트 노트 삭제")
+  class DeleteUpdateNote {
+    @Test
+    @DisplayName("성공 - 삭제 후 조회 시 404")
+    void success() {
+      Long id = createUpdateNote("v1.0.0", LocalDateTime.now(), true);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      ResponseEntity<ApiResponse<Void>> deleteResponse =
+          restTemplate.exchange(
+              "/admin/update-notes/" + id,
+              HttpMethod.DELETE,
+              new HttpEntity<>(adminHeaders),
+              VOID_RESPONSE);
+
+      assertThat(deleteResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+      // soft delete 확인 - 어드민 단건 조회 시 404
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> getResponse =
+          restTemplate.exchange(
+              "/admin/update-notes/" + id,
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(getResponse.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("미존재 -404")
+    void notFound() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      ResponseEntity<ApiResponse<Void>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/999999999",
+              HttpMethod.DELETE,
+              new HttpEntity<>(adminHeaders),
+              VOID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("관리자 아닌 유저 - 403")
+    void forbiddenWhenNotAdmin() {
+      String token = getAccessToken(USER_PROVIDER_ID);
+      HttpHeaders headers = createAuthHeader(token);
+
+      ResponseEntity<ApiResponse<Void>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/1", HttpMethod.DELETE, new HttpEntity<>(headers), VOID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("토큰 없이 요청 - 401")
+    void unauthorizedWithoutToken() {
+      ResponseEntity<ApiResponse<Void>> response =
+          restTemplate.exchange("/admin/update-notes/1", HttpMethod.DELETE, null, VOID_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /admin/update-notes - 어드민 목록 조회 (커서)")
+  class GetUpdateNotes {
+    @Test
+    @DisplayName("성공 - 페이지네이션 정확성 검증")
+    void successPagination() {
+      // 5개 등록, releasedAt 순서대로 (KST 입력)
+      LocalDateTime base = LocalDateTime.of(2026, 1, 1, 0, 0);
+      Long id1 = createUpdateNote("v1.0.0", base, true);
+      Long id2 = createUpdateNote("v1.0.1", base.plusDays(1), true);
+      Long id3 = createUpdateNote("v1.0.2", base.plusDays(2), false); // 미게시
+      Long id4 = createUpdateNote("v1.0.3", base.plusDays(3), true);
+      Long id5 = createUpdateNote("v1.0.4", base.plusDays(4), true);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      // 첫 페이지 (size=2) - 최신순이므로 id5, id4
+      ResponseEntity<ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>> page1 =
+          restTemplate.exchange(
+              "/admin/update-notes?size=2",
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              PAGE_RESPONSE);
+
+      assertThat(page1.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert page1.getBody() != null;
+      CursorPage<UpdateNoteResponse, UpdateNoteCursor> data1 = page1.getBody().data();
+      assertThat(data1.getContent()).hasSize(2);
+      assertThat(data1.getContent().getFirst().id()).isEqualTo(id5);
+      assertThat(data1.getContent().get(1).id()).isEqualTo(id4);
+      assertThat(data1.isHasNext()).isTrue();
+      assertThat(data1.getNextCursor()).isNotNull();
+      assertThat(data1.getNextCursor().id()).isEqualTo(id4);
+
+      // 두번째 페이지 - 미게시(id3)도 어드민에서는 노출
+      UpdateNoteCursor cursor = data1.getNextCursor();
+      ResponseEntity<ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>> page2 =
+          restTemplate.exchange(
+              "/admin/update-notes?size=2&cursorReleasedAt="
+                  + cursor.releasedAt()
+                  + "&cursorId="
+                  + cursor.id(),
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              PAGE_RESPONSE);
+
+      assert page2.getBody() != null;
+      CursorPage<UpdateNoteResponse, UpdateNoteCursor> data2 = page2.getBody().data();
+      assertThat(data2.getContent()).hasSize(2);
+      assertThat(data2.getContent().get(0).id()).isEqualTo(id3); // 미게시도 노출
+      assertThat(data2.getContent().get(1).id()).isEqualTo(id2);
+      assertThat(data2.isHasNext()).isTrue();
+
+      // 세번째 페이지 - 마지막 1개
+      cursor = data2.getNextCursor();
+      ResponseEntity<ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>> page3 =
+          restTemplate.exchange(
+              "/admin/update-notes?size=2&cursorReleasedAt="
+                  + cursor.releasedAt()
+                  + "&cursorId="
+                  + cursor.id(),
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              PAGE_RESPONSE);
+
+      assert page3.getBody() != null;
+      CursorPage<UpdateNoteResponse, UpdateNoteCursor> data3 = page3.getBody().data();
+      assertThat(data3.getContent()).hasSize(1);
+      assertThat(data3.getContent().getFirst().id()).isEqualTo(id1);
+      assertThat(data3.isHasNext()).isFalse();
+      assertThat(data3.getNextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("응답의 releasedAt이 UTC 형식")
+    void releasedAtIsUtc() {
+      LocalDateTime kstReleasedAt = LocalDateTime.of(2026, 5, 9, 15, 0);
+      createUpdateNote("v1.0.0", kstReleasedAt, true);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+      ResponseEntity<ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>> response =
+          restTemplate.exchange(
+              "/admin/update-notes", HttpMethod.GET, new HttpEntity<>(adminHeaders), PAGE_RESPONSE);
+
+      assert response.getBody() != null;
+      UpdateNoteResponse first = response.getBody().data().getContent().getFirst();
+      assertThat(first.releasedAt()).isEqualTo(TimeUtils.kstToUtc(kstReleasedAt));
+    }
+
+    @Test
+    @DisplayName("cursor 한쪽만 - 400")
+    void badRequestWhenCursorIncomplete() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      ResponseEntity<ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>> response =
+          restTemplate.exchange(
+              "/admin/update-notes?cursorId=1",
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              PAGE_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("size 범위 위반 - 400")
+    void badRequestWhenSizeOutOfRange() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      ResponseEntity<ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>> response =
+          restTemplate.exchange(
+              "/admin/update-notes?size=101",
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              PAGE_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("관리자 아닌 유저 - 403")
+    void forbiddenWhenNotAdmin() {
+      String token = getAccessToken(USER_PROVIDER_ID);
+      HttpHeaders headers = createAuthHeader(token);
+
+      ResponseEntity<ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>> response =
+          restTemplate.exchange(
+              "/admin/update-notes", HttpMethod.GET, new HttpEntity<>(headers), PAGE_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("토큰 없이 요청 - 401")
+    void unauthorizedWithoutToken() {
+      ResponseEntity<ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>> response =
+          restTemplate.exchange("/admin/update-notes", HttpMethod.GET, null, PAGE_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /admin/update-notes/{id} - 어드임 단건 조회")
+  class GetById {
+    @Test
+    @DisplayName("성공 - 게시 노트")
+    void successPublished() {
+      LocalDateTime kstReleasedAt = LocalDateTime.of(2026, 5, 12, 15, 0);
+      Long id = createUpdateNote("v1.0.0", kstReleasedAt, true);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/" + id,
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      UpdateNoteResponse data = response.getBody().data();
+      assertThat(data.id()).isEqualTo(id);
+      assertThat(data.version()).isEqualTo("v1.0.0");
+      assertThat(data.releasedAt()).isEqualTo(TimeUtils.kstToUtc(kstReleasedAt));
+      assertThat(data.published()).isTrue();
+    }
+
+    @Test
+    @DisplayName("성공 - 미게시 노트도 조회 (어드민)")
+    void successUnpublished() {
+      Long id = createUpdateNote("v1.0.0", LocalDateTime.now(), false);
+
+      HttpHeaders adminHeaders = getAdminHeaders();
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/" + id,
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      assertThat(response.getBody().data().published()).isFalse();
+    }
+
+    @Test
+    @DisplayName("미존재 - 404")
+    void notFound() {
+      HttpHeaders adminHeaders = getAdminHeaders();
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/999999",
+              HttpMethod.GET,
+              new HttpEntity<>(adminHeaders),
+              DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("관리자 아닌 유저 - 403")
+    void forbiddenWhenNotAdmin() {
+      String token = getAccessToken(USER_PROVIDER_ID);
+      HttpHeaders headers = createAuthHeader(token);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange(
+              "/admin/update-notes/1", HttpMethod.GET, new HttpEntity<>(headers), DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("토큰 없이 요청 - 401")
+    void unauthorizedWithoutToken() {
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange("/admin/update-notes/1", HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+  }
+}

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/update/UpdateNoteE2ETest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/update/UpdateNoteE2ETest.java
@@ -1,0 +1,215 @@
+package com.typingpractice.typing_practice_be.notice.update;
+
+import static org.assertj.core.api.Assertions.*;
+
+import com.typingpractice.typing_practice_be.BaseE2ETest;
+import com.typingpractice.typing_practice_be.common.ApiResponse;
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
+import com.typingpractice.typing_practice_be.notice.update.dto.CreateUpdateNoteRequest;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteCursor;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteResponse;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.*;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+public class UpdateNoteE2ETest extends BaseE2ETest {
+  private static final ParameterizedTypeReference<ApiResponse<UpdateNoteResponse>> DETAIL_RESPONSE =
+      new ParameterizedTypeReference<>() {};
+  private static final ParameterizedTypeReference<
+          ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>>
+      PAGE_RESPONSE = new ParameterizedTypeReference<>() {};
+
+  @Autowired private JdbcTemplate jdbcTemplate;
+
+  @AfterEach
+  void cleanUp() {
+    jdbcTemplate.execute("DELETE FROM update_note");
+  }
+
+  private HttpHeaders getAdminHeaders() {
+    String adminToken = getAccessToken(ADMIN_PROVIDER_ID);
+    return createAuthHeader(adminToken);
+  }
+
+  /** 어드민으로 업데이트 노트 등록 후 id 반환. (사용자 측에는 등록 API 없음) */
+  private Long createUpdateNote(String version, LocalDateTime releasedAtKst, boolean published) {
+    HttpHeaders adminHeaders = getAdminHeaders();
+
+    CreateUpdateNoteRequest request =
+        new CreateUpdateNoteRequest(
+            version,
+            releasedAtKst,
+            List.of(new LocalizedTextRequest("새 기능", null, null)),
+            List.of(new LocalizedTextRequest("개선", null, null)),
+            published);
+
+    ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+        restTemplate.exchange(
+            "/admin/update-notes",
+            HttpMethod.POST,
+            new HttpEntity<>(request, adminHeaders),
+            DETAIL_RESPONSE);
+
+    assert response.getBody() != null;
+    return response.getBody().data().id();
+  }
+
+  @Nested
+  @DisplayName("GET /update-notes/latest - 최신 게시 업데이트 노트 1건")
+  class GetLatest {
+    @Test
+    @DisplayName("성공 - 최신 게시 노트 반환 (KST->UTC 응답)")
+    void success() {
+      LocalDateTime base = LocalDateTime.of(2026, 5, 1, 10, 0);
+
+      createUpdateNote("v1.0.0", base, true);
+      createUpdateNote("v1.0.1", base.plusDays(1), true);
+      LocalDateTime latestKst = base.plusDays(2);
+      Long latestId = createUpdateNote("v1.0.2", latestKst, true);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange("/update-notes/latest", HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+
+      UpdateNoteResponse data = response.getBody().data();
+      assertThat(data).isNotNull();
+      assertThat(data.id()).isEqualTo(latestId);
+      assertThat(data.version()).isEqualTo("v1.0.2");
+      assertThat(data.releasedAt()).isEqualTo(TimeUtils.kstToUtc(latestKst));
+    }
+
+    @Test
+    @DisplayName("성공 - 게시된 노트 없음 (data: null)")
+    void emptyWhenNoPublished() {
+      createUpdateNote("v1.0.0", LocalDateTime.now(), false);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange("/update-notes/latest", HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert response.getBody() != null;
+      assertThat(response.getBody().success()).isTrue();
+      assertThat(response.getBody().data()).isNull();
+    }
+
+    @Test
+    @DisplayName("성공 - 미게시는 무시하고 그 이전 게시 노트 반환")
+    void skipUnpublished() {
+      LocalDateTime base = LocalDateTime.of(2026, 5, 1, 10, 0);
+      Long publishedId = createUpdateNote("v1.0.0", base, true);
+      createUpdateNote("v1.0.1", base.plusDays(1), false); // 최근 미게시
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange("/update-notes/latest", HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assert response.getBody() != null;
+      UpdateNoteResponse data = response.getBody().data();
+      assertThat(data).isNotNull();
+      assertThat(data.id()).isEqualTo(publishedId);
+    }
+
+    @Test
+    @DisplayName("성공 - 비인증으로도 200")
+    void successWithoutToken() {
+      createUpdateNote("v1.0.0", LocalDateTime.now(), true);
+
+      ResponseEntity<ApiResponse<UpdateNoteResponse>> response =
+          restTemplate.exchange("/update-notes/latest", HttpMethod.GET, null, DETAIL_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+  }
+
+  @Nested
+  @DisplayName("GET /update-notes - 사용자 목록 조회 (커서)")
+  class getUpdateNotes {
+    @Test
+    @DisplayName("성공 - 페이지네이션 정확성 + 미게시 제외 검증")
+    void successPagination() {
+      // 5개 등록: 게시 4개, 미게시 1개
+      LocalDateTime base = LocalDateTime.of(2026, 5, 1, 10, 0);
+      Long id1 = createUpdateNote("v1.0.0", base, true);
+      Long id2 = createUpdateNote("v1.0.1", base.plusDays(1), true);
+      createUpdateNote("v1.0.2", base.plusDays(2), false); // 미게시 → 제외
+      Long id4 = createUpdateNote("v1.0.3", base.plusDays(3), true);
+      Long id5 = createUpdateNote("v1.0.4", base.plusDays(4), true);
+
+      // 첫 페이지 (size=2) - 최신순이므로 id5, id4
+      ResponseEntity<ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>> page1 =
+          restTemplate.exchange("/update-notes?size=2", HttpMethod.GET, null, PAGE_RESPONSE);
+
+      assertThat(page1.getStatusCode()).isEqualTo(HttpStatus.OK);
+      assert page1.getBody() != null;
+      CursorPage<UpdateNoteResponse, UpdateNoteCursor> data1 = page1.getBody().data();
+      assertThat(data1.getContent()).hasSize(2);
+      assertThat(data1.getContent().get(0).id()).isEqualTo(id5);
+      assertThat(data1.getContent().get(1).id()).isEqualTo(id4);
+      assertThat(data1.isHasNext()).isTrue();
+      assertThat(data1.getNextCursor()).isNotNull();
+      assertThat(data1.getNextCursor().id()).isEqualTo(id4);
+
+      // 두번째 페이지 - 미게시(v1.0.2) 건너뛰고 id2, id1
+      UpdateNoteCursor cursor = data1.getNextCursor();
+      ResponseEntity<ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>> page2 =
+          restTemplate.exchange(
+              "/update-notes?size=2&cursorReleasedAt="
+                  + cursor.releasedAt()
+                  + "&cursorId="
+                  + cursor.id(),
+              HttpMethod.GET,
+              null,
+              PAGE_RESPONSE);
+
+      assert page2.getBody() != null;
+      CursorPage<UpdateNoteResponse, UpdateNoteCursor> data2 = page2.getBody().data();
+      assertThat(data2.getContent()).hasSize(2);
+      assertThat(data2.getContent().get(0).id()).isEqualTo(id2);
+      assertThat(data2.getContent().get(1).id()).isEqualTo(id1);
+      assertThat(data2.isHasNext()).isFalse();
+      assertThat(data2.getNextCursor()).isNull();
+    }
+
+    @Test
+    @DisplayName("응답의 releasedAt이 UTC 형식")
+    void releasedAtIsUtc() {
+      LocalDateTime kstReleasedAt = LocalDateTime.of(2026, 5, 9, 15, 0);
+      createUpdateNote("v1.0.0", kstReleasedAt, true);
+
+      ResponseEntity<ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>> response =
+          restTemplate.exchange("/update-notes", HttpMethod.GET, null, PAGE_RESPONSE);
+
+      assert response.getBody() != null;
+      UpdateNoteResponse first = response.getBody().data().getContent().getFirst();
+      assertThat(first.releasedAt()).isEqualTo(TimeUtils.kstToUtc(kstReleasedAt));
+    }
+
+    @Test
+    @DisplayName("cursor 한쪽만 - 400")
+    void badRequestWhenCursorIncomplete() {
+      ResponseEntity<ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>> response =
+          restTemplate.exchange("/update-notes?cursorId=1", HttpMethod.GET, null, PAGE_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    @DisplayName("size 범위 위반 - 400")
+    void badRequestWhenSizeOutOfRange() {
+      ResponseEntity<ApiResponse<CursorPage<UpdateNoteResponse, UpdateNoteCursor>>> response =
+          restTemplate.exchange("/update-notes?size=101", HttpMethod.GET, null, PAGE_RESPONSE);
+
+      assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+  }
+}

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/update/service/AdminUpdateNoteServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/notice/update/service/AdminUpdateNoteServiceTest.java
@@ -1,0 +1,253 @@
+package com.typingpractice.typing_practice_be.notice.update.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import com.typingpractice.typing_practice_be.common.dto.CursorPage;
+import com.typingpractice.typing_practice_be.common.utils.TimeUtils;
+import com.typingpractice.typing_practice_be.notice.domain.LocalizedText;
+import com.typingpractice.typing_practice_be.notice.dto.LocalizedTextRequest;
+import com.typingpractice.typing_practice_be.notice.update.domain.UpdateNote;
+import com.typingpractice.typing_practice_be.notice.update.dto.CreateUpdateNoteRequest;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteCursor;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateNoteResponse;
+import com.typingpractice.typing_practice_be.notice.update.dto.UpdateUpdateNoteRequest;
+import com.typingpractice.typing_practice_be.notice.update.exception.UpdateNoteNotFoundException;
+import com.typingpractice.typing_practice_be.notice.update.exception.UpdateNoteVersionConflictException;
+import com.typingpractice.typing_practice_be.notice.update.repository.UpdateNoteRepository;
+import java.lang.reflect.Field;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AdminUpdateNoteServiceTest {
+  @Mock private UpdateNoteRepository updateNoteRepository;
+
+  @InjectMocks private AdminUpdateNoteService adminUpdateNoteService;
+
+  private static final LocalDateTime KST_TIME = LocalDateTime.of(2026, 5, 9, 15, 0);
+  private static final LocalDateTime EXPECTED_UTC = TimeUtils.kstToUtc(KST_TIME);
+
+  private UpdateNote createUpdateNote(
+      Long id, String version, LocalDateTime releasedAt, boolean published) {
+    UpdateNote note =
+        UpdateNote.create(
+            version,
+            releasedAt,
+            List.of(new LocalizedText("새 기능", null, null)),
+            List.of(new LocalizedText("개선", null, null)),
+            published);
+
+    setId(note, id);
+    return note;
+  }
+
+  private void setId(Object entity, Long id) {
+    try {
+      Field idField = entity.getClass().getDeclaredField("id");
+      idField.setAccessible(true);
+      idField.set(entity, id);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Nested
+  @DisplayName("create")
+  class Create {
+    @Test
+    @DisplayName("성공 - KST를 UTC로 변환하여 저장")
+    void successKstToUtc() {
+      CreateUpdateNoteRequest request =
+          new CreateUpdateNoteRequest(
+              "v1.0.0",
+              KST_TIME,
+              List.of(new LocalizedTextRequest("새 기능", null, null)),
+              List.of(new LocalizedTextRequest("개선", null, null)),
+              true);
+
+      when(updateNoteRepository.existsByVersion("v1.0.0", null)).thenReturn(false);
+      when(updateNoteRepository.save(any(UpdateNote.class)))
+          .thenAnswer(
+              invocation -> {
+                UpdateNote saved = invocation.getArgument(0);
+                setId(saved, 1L);
+                return saved;
+              });
+
+      UpdateNote result = adminUpdateNoteService.create(request);
+
+      assertThat(result.getId()).isEqualTo(1L);
+      assertThat(result.getReleasedAt()).isEqualTo(EXPECTED_UTC);
+    }
+
+    @Test
+    @DisplayName("version 충돌 - 예외 발생, save 호출 안 함")
+    void versionConflict() {
+      CreateUpdateNoteRequest request =
+          new CreateUpdateNoteRequest("v1.0.0", KST_TIME, List.of(), List.of(), true);
+
+      when(updateNoteRepository.existsByVersion("v1.0.0", null)).thenReturn(true);
+
+      assertThatThrownBy(() -> adminUpdateNoteService.create(request))
+          .isInstanceOf(UpdateNoteVersionConflictException.class);
+      verify(updateNoteRepository, never()).save(any());
+    }
+  }
+
+  @Nested
+  @DisplayName("update")
+  class Update {
+    @Test
+    @DisplayName("성공 - 모든 필드 변경 + KST를 UTC로 변환")
+    void successAllFields() {
+      UpdateNote existing =
+          createUpdateNote(1L, "v1.0.0", LocalDateTime.of(2026, 1, 1, 0, 0), true);
+
+      UpdateUpdateNoteRequest request =
+          new UpdateUpdateNoteRequest(
+              "v1.0.1",
+              KST_TIME,
+              List.of(new LocalizedTextRequest("새 기능 변경", null, null)),
+              List.of(new LocalizedTextRequest("개선 변경", null, null)),
+              false);
+
+      when(updateNoteRepository.findById(1L)).thenReturn(Optional.of(existing));
+      when(updateNoteRepository.existsByVersion("v1.0.1", 1L)).thenReturn(false);
+
+      UpdateNote updated = adminUpdateNoteService.update(1L, request);
+
+      assertThat(updated.getVersion()).isEqualTo("v1.0.1");
+      assertThat(updated.getReleasedAt()).isEqualTo(EXPECTED_UTC);
+      assertThat(updated.getNewFeatures().getFirst().ko()).isEqualTo("새 기능 변경");
+      assertThat(updated.getImprovements().getFirst().ko()).isEqualTo("개선 변경");
+      assertThat(updated.isPublished()).isFalse();
+    }
+
+    @Test
+    @DisplayName("성공 - null 필드 미변경")
+    void successPartial() {
+      UpdateNote existing =
+          createUpdateNote(1L, "v1.0.0", LocalDateTime.of(2026, 1, 1, 0, 0), true);
+      // published만 변경
+      UpdateUpdateNoteRequest request = new UpdateUpdateNoteRequest(null, null, null, null, false);
+
+      when(updateNoteRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+      UpdateNote updated = adminUpdateNoteService.update(1L, request);
+
+      assertThat(updated.getVersion()).isEqualTo("v1.0.0"); // 미변경
+      assertThat(updated.getReleasedAt()).isEqualTo(LocalDateTime.of(2026, 1, 1, 0, 0)); // 미변경
+      assertThat(updated.getNewFeatures().getFirst().ko()).isEqualTo("새 기능"); // 미변경
+      assertThat(updated.isPublished()).isFalse(); // 변경됨
+    }
+
+    @Test
+    @DisplayName("version null - 충돌 체크 스킵")
+    void skipVersionCheckWhenNull() {
+      UpdateNote existing =
+          createUpdateNote(1L, "v1.0.0", LocalDateTime.of(2026, 1, 1, 0, 0), true);
+      UpdateUpdateNoteRequest request =
+          new UpdateUpdateNoteRequest(null, KST_TIME, null, null, null);
+
+      when(updateNoteRepository.findById(1L)).thenReturn(Optional.of(existing));
+
+      adminUpdateNoteService.update(1L, request);
+
+      verify(updateNoteRepository, never()).existsByVersion(any(), any());
+    }
+
+    @Test
+    @DisplayName("version 변경 - 자기 자신 제외하고 충돌 체크")
+    void versionCheckExcludeSelf() {
+      UpdateNote existing =
+          createUpdateNote(1L, "v1.0.0", LocalDateTime.of(2026, 1, 1, 0, 0), true);
+      UpdateUpdateNoteRequest request =
+          new UpdateUpdateNoteRequest("v1.0.1", null, null, null, null);
+
+      when(updateNoteRepository.findById(1L)).thenReturn(Optional.of(existing));
+      when(updateNoteRepository.existsByVersion("v1.0.1", 1L)).thenReturn(false);
+
+      adminUpdateNoteService.update(1L, request);
+
+      verify(updateNoteRepository).existsByVersion("v1.0.1", 1L);
+    }
+
+    @Test
+    @DisplayName("version 충돌 - 예외 발생")
+    void versionConflict() {
+      UpdateNote existing =
+          createUpdateNote(1L, "v1.0.0", LocalDateTime.of(2026, 1, 1, 0, 0), true);
+      UpdateUpdateNoteRequest request =
+          new UpdateUpdateNoteRequest("v1.0.1", null, null, null, null);
+
+      when(updateNoteRepository.findById(1L)).thenReturn(Optional.of(existing));
+      when(updateNoteRepository.existsByVersion("v1.0.1", 1L)).thenReturn(true);
+
+      assertThatThrownBy(() -> adminUpdateNoteService.update(1L, request))
+          .isInstanceOf(UpdateNoteVersionConflictException.class);
+    }
+
+    @Test
+    @DisplayName("미존재 - 404")
+    void notFound() {
+      UpdateUpdateNoteRequest request = new UpdateUpdateNoteRequest(null, null, null, null, true);
+
+      when(updateNoteRepository.findById(1L)).thenReturn(Optional.empty());
+
+      assertThatThrownBy(() -> adminUpdateNoteService.update(1L, request))
+          .isInstanceOf(UpdateNoteNotFoundException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("findList")
+  class FindList {
+    @Test
+    @DisplayName("hasNext = true - 마지막 항목 잘라내고 nextCursor 발급")
+    void hasNext() {
+      LocalDateTime base = LocalDateTime.of(2026, 1, 1, 0, 0);
+      UpdateNote n1 = createUpdateNote(1L, "v1.0.2", base.plusDays(2), true);
+      UpdateNote n2 = createUpdateNote(2L, "v1.0.1", base.plusDays(1), false);
+      UpdateNote n3 = createUpdateNote(3L, "v1.0.0", base, true);
+
+      // size=2 요청, repository는 size+1=3개 반환
+      when(updateNoteRepository.findAllByCursor(null, 2)).thenReturn(List.of(n1, n2, n3));
+
+      CursorPage<UpdateNoteResponse, UpdateNoteCursor> result =
+          adminUpdateNoteService.findList(null, 2);
+
+      assertThat(result.getContent()).hasSize(2);
+      assertThat(result.isHasNext()).isTrue();
+      assertThat(result.getNextCursor()).isNotNull();
+      assertThat(result.getNextCursor().id()).isEqualTo(2L);
+      assertThat(result.getNextCursor().releasedAt()).isEqualTo(base.plusDays(1));
+    }
+
+    @Test
+    @DisplayName("hasNext = false - nextCursor null")
+    void noNext() {
+      LocalDateTime base = LocalDateTime.of(2026, 1, 1, 0, 0);
+      UpdateNote n1 = createUpdateNote(1L, "v1.0.1", base.plusDays(1), true);
+      UpdateNote n2 = createUpdateNote(2L, "v1.0.0", base, true);
+
+      when(updateNoteRepository.findAllByCursor(null, 2)).thenReturn(List.of(n1, n2));
+
+      CursorPage<?, UpdateNoteCursor> result = adminUpdateNoteService.findList(null, 2);
+
+      assertThat(result.getContent()).hasSize(2);
+      assertThat(result.isHasNext()).isFalse();
+      assertThat(result.getNextCursor()).isNull();
+    }
+  }
+}

--- a/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteServiceTest.java
+++ b/typing-practice-be/src/test/java/com/typingpractice/typing_practice_be/quote/service/QuoteServiceTest.java
@@ -11,27 +11,23 @@ import com.typingpractice.typing_practice_be.member.domain.Member;
 import com.typingpractice.typing_practice_be.member.exception.MemberNotFoundException;
 import com.typingpractice.typing_practice_be.member.repository.MemberRepository;
 import com.typingpractice.typing_practice_be.quote.domain.*;
-import com.typingpractice.typing_practice_be.quote.dto.PublicQuoteRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteCreateRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuotePaginationRequest;
 import com.typingpractice.typing_practice_be.quote.dto.QuoteUpdateRequest;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotFoundException;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotOwnedException;
 import com.typingpractice.typing_practice_be.quote.exception.QuoteNotProcessableException;
-import com.typingpractice.typing_practice_be.quote.query.PublicQuoteQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuoteCreateQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuotePaginationQuery;
 import com.typingpractice.typing_practice_be.quote.query.QuoteUpdateQuery;
 import com.typingpractice.typing_practice_be.quote.repository.QuoteRepository;
-
-import java.lang.reflect.Field;
-import java.util.List;
-import java.util.Optional;
-
 import com.typingpractice.typing_practice_be.quote.service.difficulty.DifficultySeedCalculator;
 import com.typingpractice.typing_practice_be.quote.service.difficulty.QuoteProfileCalculator;
 import com.typingpractice.typing_practice_be.quote.statistics.domain.GlobalQuoteStatistics;
 import com.typingpractice.typing_practice_be.quote.statistics.service.GlobalQuoteStatisticsService;
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -42,492 +38,484 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class QuoteServiceTest {
-	@Mock
-	private QuoteRepository quoteRepository;
-	@Mock
-	private MemberRepository memberRepository;
-	@Mock
-	private DailyLimitService dailyLimitService;
-
-	@Mock
-	private QuoteLanguageValidator quoteLanguageValidator;
-	@Mock
-	private QuoteProfileCalculator quoteProfileCalculator;
-	@Mock
-	private DifficultySeedCalculator difficultySeedCalculator;
-	@Mock
-	private GlobalQuoteStatisticsService globalQuoteStatisticsService;
-
-	@InjectMocks
-	private QuoteService quoteService;
-
-	private Member createMember(Long id) {
-		Member member = Member.createMember("test-provider-id", "test@test.com", "testMember");
-		setId(member, id);
-		return member;
-	}
-
-	private void setId(Object entity, Long id) {
-		try {
-			Field idField = entity.getClass().getDeclaredField("id");
-			idField.setAccessible(true);
-			idField.set(entity, id);
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		}
-	}
-
-	private Quote createQuote(Member member, QuoteType type, QuoteStatus status) {
-		Quote quote =
-						Quote.create(member, "테스트 문장입니다.", "저자", type, QuoteLanguage.KOREAN, null, 0f, "hash");
-		if (type == QuoteType.PUBLIC && status == QuoteStatus.ACTIVE) {
-			quote.approvePublish();
-		}
-
-		return quote;
-	}
-
-	private QuoteCreateQuery createCreateQuery(QuoteType type) {
-		QuoteCreateRequest request =
-						QuoteCreateRequest.create("테스트 문장입니다.", "저자", QuoteLanguage.KOREAN);
-		return QuoteCreateQuery.from(request, type, QuoteLanguage.KOREAN);
-	}
-
-	private QuoteUpdateQuery createUpdateQuery(String sentence, String author) {
-		QuoteUpdateRequest request = QuoteUpdateRequest.create(sentence, author);
-		return QuoteUpdateQuery.from(request);
-	}
-
-	private QuotePaginationQuery createPaginationQuery() {
-		QuotePaginationRequest request =
-						new QuotePaginationRequest(1, 10, SortDirection.DESC, null, null, QuoteOrderBy.id);
-		return QuotePaginationQuery.from(request);
-	}
-
-	@Nested
-	@DisplayName("findById")
-	class FindById {
-		@Test
-		@DisplayName("조회 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when
-			Quote result = quoteService.findById(1L);
-
-			// then
-			assertThat(result).isEqualTo(quote);
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 문장 - 예외 발생")
-		void notFound() {
-			// given
-			when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.findById(1L))
-							.isInstanceOf(QuoteNotFoundException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("create")
-	class Create {
-		@Test
-		@DisplayName("PRIVATE 문장 생성 성공")
-		void successPrivate() {
-			// given
-			Member member = createMember(1L);
-			QuoteCreateQuery query = createCreateQuery(QuoteType.PRIVATE);
-
-			when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-			when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(true);
-			when(quoteProfileCalculator.calculate(anyString(), any(QuoteLanguage.class)))
-							.thenReturn(QuoteProfile.create());
-			when(globalQuoteStatisticsService.getByLanguage(any(QuoteLanguage.class)))
-							.thenReturn(GlobalQuoteStatistics.createKoreanDefault());
-			when(difficultySeedCalculator.calculate(any(), any(), any())).thenReturn(0f);
-
-			// when
-			Quote result = quoteService.create(1L, query);
-
-			// then
-			assertThat(result.getType()).isEqualTo(QuoteType.PRIVATE);
-			assertThat(result.getStatus()).isEqualTo(QuoteStatus.ACTIVE);
-			verify(quoteRepository).save(any(Quote.class));
-		}
-
-		@Test
-		@DisplayName("PUBLIC 문장 생성 성공 - PENDING 상태")
-		void successPublic() {
-			// given
-			Member member = createMember(1L);
-			QuoteCreateQuery query = createCreateQuery(QuoteType.PUBLIC);
-
-			when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-			when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(true);
-			when(quoteProfileCalculator.calculate(anyString(), any(QuoteLanguage.class)))
-							.thenReturn(QuoteProfile.create());
-			when(globalQuoteStatisticsService.getByLanguage(any(QuoteLanguage.class)))
-							.thenReturn(GlobalQuoteStatistics.createKoreanDefault());
-			when(difficultySeedCalculator.calculate(any(), any(), any())).thenReturn(0f);
-
-			// when
-			Quote result = quoteService.create(1L, query);
-
-			// then
-			assertThat(result.getType()).isEqualTo(QuoteType.PUBLIC);
-			assertThat(result.getStatus()).isEqualTo(QuoteStatus.PENDING);
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 회원 - 예외 발생")
-		void memberNotFound() {
-			// given
-			QuoteCreateQuery query = createCreateQuery(QuoteType.PUBLIC);
-
-			when(memberRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.create(1L, query))
-							.isInstanceOf(MemberNotFoundException.class);
-		}
-
-		@Test
-		@DisplayName("일일 업로드 제한 초과 - 예외 발생")
-		void dailyLimitExceeded() {
-			// given
-			Member member = createMember(1L);
-			QuoteCreateQuery query = createCreateQuery(QuoteType.PUBLIC);
-
-			when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-			when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(false);
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.create(1L, query))
-							.isInstanceOf(DailyQuoteUploadLimitException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("updatePrivateQuote")
-	class UpdatePrivateQuote {
-		@Test
-		@DisplayName("수정 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-			QuoteUpdateQuery query = createUpdateQuery("수정된 문장입니다.", "수정된 저자");
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when
-			Quote result = quoteService.updatePrivateQuote(1L, 1L, query);
-
-			// then
-			assertThat(result.getSentence()).isEqualTo("수정된 문장입니다.");
-			assertThat(result.getAuthor()).isEqualTo("수정된 저자");
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 문장 - 예외 발생")
-		void quoteNotFound() {
-			// given
-			QuoteUpdateQuery query = createUpdateQuery("수정된 문장", "수정된 저자");
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.updatePrivateQuote(1L, 1L, query))
-							.isInstanceOf(QuoteNotFoundException.class);
-		}
-
-		@Test
-		@DisplayName("본인 문장이 아님 - 예외 발생")
-		void notOwned() {
-			// given
-			Member otherMember = createMember(2L);
-			Quote quote = createQuote(otherMember, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-			QuoteUpdateQuery query = createUpdateQuery("수정된 문장", "수정된 저자");
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.updatePrivateQuote(1L, 1L, query))
-							.isInstanceOf(QuoteNotOwnedException.class);
-		}
-
-		@Test
-		@DisplayName("PUBLIC 문장 수정 시도 - 예외 발생")
-		void publicNotProcessable() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
-			QuoteUpdateQuery query = createUpdateQuery("수정된 문장", "수정된 저자");
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.updatePrivateQuote(1L, 1L, query))
-							.isInstanceOf(QuoteNotProcessableException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("deleteQuote")
-	class DeleteQuote {
-		@Test
-		@DisplayName("삭제 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when
-			quoteService.deleteQuote(1L, 1L);
-
-			// then
-			verify(quoteRepository).deleteQuote(quote);
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 문장 - 예외 발생")
-		void quoteNotFound() {
-			// given
-			when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & given
-			assertThatThrownBy(() -> quoteService.deleteQuote(1L, 1L))
-							.isInstanceOf(QuoteNotFoundException.class);
-		}
-
-		@Test
-		@DisplayName("본인 문장이 아님 - 예외 발생")
-		void notOwned() {
-			// given
-			Member otherMember = createMember(2L);
-			Quote quote = createQuote(otherMember, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.deleteQuote(1L, 1L))
-							.isInstanceOf(QuoteNotOwnedException.class);
-		}
-
-		@Test
-		@DisplayName("PUBLIC 문장 삭제 시도 - 예외 발생")
-		void publicNotProcessable() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.deleteQuote(1L, 1L))
-							.isInstanceOf(QuoteNotProcessableException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("getMyQuotes")
-	class GetMyQuotes {
-		@Test
-		@DisplayName("조회 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-			QuotePaginationQuery query = createPaginationQuery();
-
-			when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
-			when(quoteRepository.findByMember(member, query)).thenReturn(List.of(quote));
-
-			// when
-			PageResult<Quote> result = quoteService.getMyQuotes(1L, query);
-
-			// then
-			assertThat(result.getContent()).hasSize(1);
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 회원 - 예외 발생")
-		void memberNotFound() {
-			// given
-			QuotePaginationQuery query = createPaginationQuery();
-
-			when(memberRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.getMyQuotes(1L, query))
-							.isInstanceOf(MemberNotFoundException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("publishQuote")
-	class PublishQuote {
-		@Test
-		@DisplayName("공개 전환 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when
-			Quote result = quoteService.publishQuote(1L, 1L);
-
-			// then
-			assertThat(result.getType()).isEqualTo(QuoteType.PUBLIC);
-			assertThat(result.getStatus()).isEqualTo(QuoteStatus.PENDING);
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 문장 - 예외 발생")
-		void quoteNotFound() {
-			// given
-			when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.publishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotFoundException.class);
-		}
-
-		@Test
-		@DisplayName("본인 문장이 아님 - 예외 발생")
-		void notOwned() {
-			// given
-			Member otherMember = createMember(2L);
-			Quote quote = createQuote(otherMember, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.publishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotOwnedException.class);
-		}
-
-		@Test
-		@DisplayName("이미 PUBLIC 문장 - 예외 발생")
-		void alreadyPublic() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.publishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotProcessableException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("cancelPublishQuote")
-	class CancelPublishQuote {
-		@Test
-		@DisplayName("공개 전환 취소 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.PENDING);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-			// when
-			Quote result = quoteService.cancelPublishQuote(1L, 1L);
-
-			// then
-			assertThat(result.getType()).isEqualTo(QuoteType.PRIVATE);
-			assertThat(result.getStatus()).isEqualTo(QuoteStatus.ACTIVE);
-		}
-
-		@Test
-		@DisplayName("존재하지 않는 문장 - 예외 발생")
-		void quoteNotFound() {
-			// given
-			when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotFoundException.class);
-		}
-
-		@Test
-		@DisplayName("본인 문장이 아님 - 예외 발생")
-		void notOwned() {
-			// given
-			Member otherMember = createMember(2L);
-			Quote quote = createQuote(otherMember, QuoteType.PUBLIC, QuoteStatus.PENDING);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotOwnedException.class);
-		}
-
-		@Test
-		@DisplayName("PENDING 상태가 아님 - 예외 발생")
-		void notPending() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotProcessableException.class);
-		}
-
-		@Test
-		@DisplayName("PRIVATE 문장 취소 시도 - 예외 발생")
-		void privateNotProcessable() {
-			// given
-			Member member = createMember(1L);
-			Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
-
-			when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
-
-			// when & then
-			assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
-							.isInstanceOf(QuoteNotProcessableException.class);
-		}
-	}
-
-	@Nested
-	@DisplayName("findRandomPublicQuotes")
-	class FindRandomPublicQuotes {
-
-		@Test
-		@DisplayName("조회 성공")
-		void success() {
-			// given
-			Member member = createMember(1L);
-			Quote quote1 = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
-			Quote quote2 = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
-			PublicQuoteRequest request = new PublicQuoteRequest(1, 10, false, 0.5f, QuoteLanguage.KOREAN);
-			PublicQuoteQuery query = PublicQuoteQuery.from(1L, request);
-
-			when(quoteRepository.findPublicQuotes(query)).thenReturn(List.of(quote1, quote2));
-
-			// when
-			PageResult<Quote> result = quoteService.findRandomPublicQuotes(query);
-
-			// then
-			assertThat(result.getContent()).hasSize(2);
-			verify(quoteRepository).findPublicQuotes(query);
-		}
-	}
+  @Mock private QuoteRepository quoteRepository;
+  @Mock private MemberRepository memberRepository;
+  @Mock private DailyLimitService dailyLimitService;
+
+  @Mock private QuoteLanguageValidator quoteLanguageValidator;
+  @Mock private QuoteProfileCalculator quoteProfileCalculator;
+  @Mock private DifficultySeedCalculator difficultySeedCalculator;
+  @Mock private GlobalQuoteStatisticsService globalQuoteStatisticsService;
+
+  @InjectMocks private QuoteService quoteService;
+
+  private Member createMember(Long id) {
+    Member member = Member.createMember("test-provider-id", "test@test.com", "testMember");
+    setId(member, id);
+    return member;
+  }
+
+  private void setId(Object entity, Long id) {
+    try {
+      Field idField = entity.getClass().getDeclaredField("id");
+      idField.setAccessible(true);
+      idField.set(entity, id);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private Quote createQuote(Member member, QuoteType type, QuoteStatus status) {
+    Quote quote =
+        Quote.create(member, "테스트 문장입니다.", "저자", type, QuoteLanguage.KOREAN, null, 0f, "hash");
+    if (type == QuoteType.PUBLIC && status == QuoteStatus.ACTIVE) {
+      quote.approvePublish();
+    }
+
+    return quote;
+  }
+
+  private QuoteCreateQuery createCreateQuery(QuoteType type) {
+    QuoteCreateRequest request =
+        QuoteCreateRequest.create("테스트 문장입니다.", "저자", QuoteLanguage.KOREAN);
+    return QuoteCreateQuery.from(request, type, QuoteLanguage.KOREAN);
+  }
+
+  private QuoteUpdateQuery createUpdateQuery(String sentence, String author) {
+    QuoteUpdateRequest request = QuoteUpdateRequest.create(sentence, author);
+    return QuoteUpdateQuery.from(request);
+  }
+
+  private QuotePaginationQuery createPaginationQuery() {
+    QuotePaginationRequest request =
+        new QuotePaginationRequest(1, 10, SortDirection.DESC, null, null, QuoteOrderBy.id);
+    return QuotePaginationQuery.from(request);
+  }
+
+  @Nested
+  @DisplayName("findById")
+  class FindById {
+    @Test
+    @DisplayName("조회 성공")
+    void success() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when
+      Quote result = quoteService.findById(1L);
+
+      // then
+      assertThat(result).isEqualTo(quote);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문장 - 예외 발생")
+    void notFound() {
+      // given
+      when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.findById(1L))
+          .isInstanceOf(QuoteNotFoundException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("create")
+  class Create {
+    @Test
+    @DisplayName("PRIVATE 문장 생성 성공")
+    void successPrivate() {
+      // given
+      Member member = createMember(1L);
+      QuoteCreateQuery query = createCreateQuery(QuoteType.PRIVATE);
+
+      when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+      when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(true);
+      when(quoteProfileCalculator.calculate(anyString(), any(QuoteLanguage.class)))
+          .thenReturn(QuoteProfile.create());
+      when(globalQuoteStatisticsService.getByLanguage(any(QuoteLanguage.class)))
+          .thenReturn(GlobalQuoteStatistics.createKoreanDefault());
+      when(difficultySeedCalculator.calculate(any(), any(), any())).thenReturn(0f);
+
+      // when
+      Quote result = quoteService.create(1L, query);
+
+      // then
+      assertThat(result.getType()).isEqualTo(QuoteType.PRIVATE);
+      assertThat(result.getStatus()).isEqualTo(QuoteStatus.ACTIVE);
+      verify(quoteRepository).save(any(Quote.class));
+    }
+
+    @Test
+    @DisplayName("PUBLIC 문장 생성 성공 - PENDING 상태")
+    void successPublic() {
+      // given
+      Member member = createMember(1L);
+      QuoteCreateQuery query = createCreateQuery(QuoteType.PUBLIC);
+
+      when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+      when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(true);
+      when(quoteProfileCalculator.calculate(anyString(), any(QuoteLanguage.class)))
+          .thenReturn(QuoteProfile.create());
+      when(globalQuoteStatisticsService.getByLanguage(any(QuoteLanguage.class)))
+          .thenReturn(GlobalQuoteStatistics.createKoreanDefault());
+      when(difficultySeedCalculator.calculate(any(), any(), any())).thenReturn(0f);
+
+      // when
+      Quote result = quoteService.create(1L, query);
+
+      // then
+      assertThat(result.getType()).isEqualTo(QuoteType.PUBLIC);
+      assertThat(result.getStatus()).isEqualTo(QuoteStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원 - 예외 발생")
+    void memberNotFound() {
+      // given
+      QuoteCreateQuery query = createCreateQuery(QuoteType.PUBLIC);
+
+      when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.create(1L, query))
+          .isInstanceOf(MemberNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("일일 업로드 제한 초과 - 예외 발생")
+    void dailyLimitExceeded() {
+      // given
+      Member member = createMember(1L);
+      QuoteCreateQuery query = createCreateQuery(QuoteType.PUBLIC);
+
+      when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+      when(dailyLimitService.tryIncrementQuoteUploadCount(1L)).thenReturn(false);
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.create(1L, query))
+          .isInstanceOf(DailyQuoteUploadLimitException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("updatePrivateQuote")
+  class UpdatePrivateQuote {
+    @Test
+    @DisplayName("수정 성공")
+    void success() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+      QuoteUpdateQuery query = createUpdateQuery("수정된 문장입니다.", "수정된 저자");
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when
+      Quote result = quoteService.updatePrivateQuote(1L, 1L, query);
+
+      // then
+      assertThat(result.getSentence()).isEqualTo("수정된 문장입니다.");
+      assertThat(result.getAuthor()).isEqualTo("수정된 저자");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문장 - 예외 발생")
+    void quoteNotFound() {
+      // given
+      QuoteUpdateQuery query = createUpdateQuery("수정된 문장", "수정된 저자");
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.updatePrivateQuote(1L, 1L, query))
+          .isInstanceOf(QuoteNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("본인 문장이 아님 - 예외 발생")
+    void notOwned() {
+      // given
+      Member otherMember = createMember(2L);
+      Quote quote = createQuote(otherMember, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+      QuoteUpdateQuery query = createUpdateQuery("수정된 문장", "수정된 저자");
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.updatePrivateQuote(1L, 1L, query))
+          .isInstanceOf(QuoteNotOwnedException.class);
+    }
+
+    @Test
+    @DisplayName("PUBLIC 문장 수정 시도 - 예외 발생")
+    void publicNotProcessable() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
+      QuoteUpdateQuery query = createUpdateQuery("수정된 문장", "수정된 저자");
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.updatePrivateQuote(1L, 1L, query))
+          .isInstanceOf(QuoteNotProcessableException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("deleteQuote")
+  class DeleteQuote {
+    @Test
+    @DisplayName("삭제 성공")
+    void success() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when
+      quoteService.deleteQuote(1L, 1L);
+
+      // then
+      verify(quoteRepository).deleteQuote(quote);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문장 - 예외 발생")
+    void quoteNotFound() {
+      // given
+      when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & given
+      assertThatThrownBy(() -> quoteService.deleteQuote(1L, 1L))
+          .isInstanceOf(QuoteNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("본인 문장이 아님 - 예외 발생")
+    void notOwned() {
+      // given
+      Member otherMember = createMember(2L);
+      Quote quote = createQuote(otherMember, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.deleteQuote(1L, 1L))
+          .isInstanceOf(QuoteNotOwnedException.class);
+    }
+
+    @Test
+    @DisplayName("PUBLIC 문장 삭제 시도 - 예외 발생")
+    void publicNotProcessable() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.deleteQuote(1L, 1L))
+          .isInstanceOf(QuoteNotProcessableException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("getMyQuotes")
+  class GetMyQuotes {
+    @Test
+    @DisplayName("조회 성공")
+    void success() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+      QuotePaginationQuery query = createPaginationQuery();
+
+      when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+      when(quoteRepository.findByMember(member, query)).thenReturn(List.of(quote));
+
+      // when
+      PageResult<Quote> result = quoteService.getMyQuotes(1L, query);
+
+      // then
+      assertThat(result.getContent()).hasSize(1);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 회원 - 예외 발생")
+    void memberNotFound() {
+      // given
+      QuotePaginationQuery query = createPaginationQuery();
+
+      when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.getMyQuotes(1L, query))
+          .isInstanceOf(MemberNotFoundException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("publishQuote")
+  class PublishQuote {
+    @Test
+    @DisplayName("공개 전환 성공")
+    void success() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when
+      Quote result = quoteService.publishQuote(1L, 1L);
+
+      // then
+      assertThat(result.getType()).isEqualTo(QuoteType.PUBLIC);
+      assertThat(result.getStatus()).isEqualTo(QuoteStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문장 - 예외 발생")
+    void quoteNotFound() {
+      // given
+      when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.publishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("본인 문장이 아님 - 예외 발생")
+    void notOwned() {
+      // given
+      Member otherMember = createMember(2L);
+      Quote quote = createQuote(otherMember, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.publishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotOwnedException.class);
+    }
+
+    @Test
+    @DisplayName("이미 PUBLIC 문장 - 예외 발생")
+    void alreadyPublic() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.publishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotProcessableException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("cancelPublishQuote")
+  class CancelPublishQuote {
+    @Test
+    @DisplayName("공개 전환 취소 성공")
+    void success() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.PENDING);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+      // when
+      Quote result = quoteService.cancelPublishQuote(1L, 1L);
+
+      // then
+      assertThat(result.getType()).isEqualTo(QuoteType.PRIVATE);
+      assertThat(result.getStatus()).isEqualTo(QuoteStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 문장 - 예외 발생")
+    void quoteNotFound() {
+      // given
+      when(quoteRepository.findById(1L)).thenReturn(Optional.empty());
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("본인 문장이 아님 - 예외 발생")
+    void notOwned() {
+      // given
+      Member otherMember = createMember(2L);
+      Quote quote = createQuote(otherMember, QuoteType.PUBLIC, QuoteStatus.PENDING);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotOwnedException.class);
+    }
+
+    @Test
+    @DisplayName("PENDING 상태가 아님 - 예외 발생")
+    void notPending() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotProcessableException.class);
+    }
+
+    @Test
+    @DisplayName("PRIVATE 문장 취소 시도 - 예외 발생")
+    void privateNotProcessable() {
+      // given
+      Member member = createMember(1L);
+      Quote quote = createQuote(member, QuoteType.PRIVATE, QuoteStatus.ACTIVE);
+
+      when(quoteRepository.findById(1L)).thenReturn(Optional.of(quote));
+
+      // when & then
+      assertThatThrownBy(() -> quoteService.cancelPublishQuote(1L, 1L))
+          .isInstanceOf(QuoteNotProcessableException.class);
+    }
+  }
+
+  @Nested
+  @DisplayName("findRandomPublicQuotes")
+  class FindRandomPublicQuotes {
+
+    /*@Test
+    @DisplayName("조회 성공")
+    void success() {
+    	// given
+    	Member member = createMember(1L);
+    	Quote quote1 = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
+    	Quote quote2 = createQuote(member, QuoteType.PUBLIC, QuoteStatus.ACTIVE);
+    	PublicQuoteRequest request = new PublicQuoteRequest(1, 10, false, 0.5f, QuoteLanguage.KOREAN);
+    	PublicQuoteQuery query = PublicQuoteQuery.from(1L, request);
+
+    	when(quoteRepository.findPublicQuotes(query)).thenReturn(List.of(quote1, quote2));
+
+    	// when
+    	PageResult<Quote> result = quoteService.findRandomPublicQuotes(query);
+
+    	// then
+    	assertThat(result.getContent()).hasSize(2);
+    	verify(quoteRepository).findPublicQuotes(query);
+    }*/
+  }
 }


### PR DESCRIPTION
## 주요 내용

### 공지사항 / 업데이트 노트 도메인 추가
- 어드민이 등록한 공지사항/업데이트 노트를 클라이언트가 조회하는 구조 도입
- 기존 클라이언트 내장 정적 데이터를 서버 조회 방식으로 전환하기 위한 백엔드 작업

### Quote 영구 삭제 기능
- Quote 논리 삭제 일관성 보완 및 영구 삭제 엔드포인트 추가

## 상세 내용

### Notice 도메인 (announcement + update_note)

**공통**
- `notice` 패키지 하위에 `announcement`, `update` 서브 도메인 구성
- 다국어 record `LocalizedText` (ko 필수, en/ja 선택) 공유
- 공통 커서 페이지네이션 DTO `CursorPage<T, C>` 추가
- 클라이언트 KST 입력을 Service 레이어에서 UTC 로 변환 (`TimeUtils.kstToUtc`)
- 응답은 UTC 로 내려 클라이언트가 변환하는 기존 컨벤션 유지

**Announcement**
- 어드민: 등록/수정(PATCH)/삭제/목록/고정 목록/단건 조회 (6개)
- 사용자: 팝업용 최신 1건/고정 목록/목록(커서)/단건 조회 (4개)
- `pinned` 플래그로 상단 고정 기능
- `published` 플래그로 게시 여부 관리

**Update Note**
- 어드민: 등록/수정(PATCH)/삭제/목록/단건 조회 (5개)
- 사용자: 팝업용 최신 1건/목록(커서) (2개)
- `version` unique 제약 + `@Pattern` 으로 `v{major}.{minor}.{fix}` 형식 강제
- `DataIntegrityViolationException` 핸들러로 동시성 안전성 보강 (409 Conflict)
- `newFeatures`, `improvements` 를 JSONB 항목 리스트로 저장

**검증**
- 모든 도메인 PATCH 는 `null = 미변경` 시맨틱
- 사용자 GET 은 `permitAll`, 어드민은 기존 `/admin/**` 인증 적용
- 단위 테스트: 시간 변환 및 분기 로직 중심 검증
- E2E 테스트: 모든 엔드포인트 + 인증/인가 + 시간 변환 라운드트립

### Quote 영구 삭제
- 논리 삭제 일관성 보완 (`@SQLRestriction`, `@SQLDelete`)
- 영구 삭제 엔드포인트 추가
- QuoteRepository fetch join 적용으로 N+1 제거

## 마이그레이션
- `src/main/resources/db/migration/V20260513_1__create_notice_tables.sql` 추가
- Flyway 미적용 상태이므로 운영 DB 에 직접 SQL 실행 필요
- announcement, update_note 테이블 + 시퀀스 생성

## 배포 후 작업
- 운영 DB 마이그레이션 SQL 실행
- 첫 공지사항 등록 (저작권 안내)
- 기존 클라이언트의 updateHistory 데이터를 어드민 클라이언트로 입력