### PR TITLE
feat: 공지사항/업데이트 노트 서버 기반 전환 + 헤더 뱃지

### DIFF
--- a/tp-react/src/App.jsx
+++ b/tp-react/src/App.jsx
@@ -16,6 +16,7 @@ import MyQuotes from "./pages/MyQuotes/MyQuotes";
 import MyReports from "./pages/MyReports/MyReports";
 import Stats from "./pages/Stats/Stats";
 import Updates from "./pages/Updates/Updates";
+import NoticeList from "./pages/Notices/NoticeList";
 import OAuthCallback from "./pages/OAuthCallback/OAuthCallback";
 import PrivacyPolicy from "./pages/PrivacyPolicy/PrivacyPolicy";
 import TermsOfService from "./pages/TermsOfService/TermsOfService";
@@ -39,6 +40,7 @@ function App() {
                   <Route path="/quote/report" element={<MyReports />} />
                   <Route path="/stats" element={<Stats />} />
                   <Route path="/updates" element={<Updates />} />
+                  <Route path="/notices" element={<NoticeList />} />
                   <Route path="/oauth/callback" element={<OAuthCallback />} />
                   <Route path="/privacy" element={<PrivacyPolicy />} />
                   <Route path="/terms" element={<TermsOfService />} />

--- a/tp-react/src/components/AppDiv/AppDiv.jsx
+++ b/tp-react/src/components/AppDiv/AppDiv.jsx
@@ -7,7 +7,7 @@ const AppDiv = ({ children }) => {
   const location = useLocation();
   
   // 상단 여백이 필요 없는 페이지
-  const isCompactPage = location.pathname.startsWith('/quote/') || location.pathname === '/stats' || location.pathname === '/updates' || location.pathname === '/privacy' || location.pathname === '/terms';
+  const isCompactPage = location.pathname.startsWith('/quote/') || location.pathname === '/stats' || location.pathname === '/updates' || location.pathname.startsWith('/notices') || location.pathname === '/privacy' || location.pathname === '/terms';
   
   return (
     <div className={`background ${isDark ? "dark" : ""} ${isCompactPage ? "compact" : ""}`}>

--- a/tp-react/src/components/Head/Head.jsx
+++ b/tp-react/src/components/Head/Head.jsx
@@ -9,9 +9,18 @@ import NicknamePopup from "../NicknamePopup/NicknamePopup";
 import {useAuth} from "../../Context/AuthContext";
 import {useGoogleLogin} from "@react-oauth/google";
 import {t} from "@/utils/i18n.ts";
-import {Storage_Last_Mode, Session_Login_Redirect} from "@/const/config.const.ts";
+import {Storage_Last_Mode, Session_Login_Redirect, Storage_Last_Seen_Notice_Id, Storage_Last_Seen_Update_Note_Id} from "@/const/config.const.ts";
 import FeatureGuide from "../FeatureGuide/FeatureGuide";
+import NavBadge from "./NavBadge";
+import {getLatestAnnouncement} from "@/utils/noticeApi.ts";
+import {getLatestUpdateNote} from "@/utils/updateNoteApi.ts";
 import "./Head.css";
+
+const shouldShowBadge = (latest, storedId) => {
+    if (!latest) return false;
+    if (!storedId) return true;
+    return String(latest.id) !== storedId;
+};
 
 // UUID 형식 체크 함수
 const isUuidFormat = (str) => {
@@ -26,6 +35,10 @@ const Head = () => {
     const {user, accessToken, refreshToken, isLoading, login, loginTrigger} = useAuth();
     const [showNicknamePopup, setShowNicknamePopup] = useState(false);
     const prevLoginTriggerRef = useRef(loginTrigger);
+    const [latestAnnouncementId, setLatestAnnouncementId] = useState(null);
+    const [latestUpdateNoteId, setLatestUpdateNoteId] = useState(null);
+    const [showNoticeBadge, setShowNoticeBadge] = useState(false);
+    const [showUpdateBadge, setShowUpdateBadge] = useState(false);
 
     // user가 변경될 때마다 닉네임이 UUID 형식인지 체크
     useEffect(() => {
@@ -48,6 +61,36 @@ const Head = () => {
             googleLogin();
         }
     }, [loginTrigger, googleLogin]);
+
+    // 마운트 시 /latest 두 API 호출 → 뱃지 표시 여부 판단
+    useEffect(() => {
+        const fetchBadgeData = async () => {
+            try {
+                const [n, u] = await Promise.all([getLatestAnnouncement(), getLatestUpdateNote()]);
+                setLatestAnnouncementId(n?.id ?? null);
+                setLatestUpdateNoteId(u?.id ?? null);
+                const storedNoticeId = localStorage.getItem(Storage_Last_Seen_Notice_Id);
+                const storedUpdateId = localStorage.getItem(Storage_Last_Seen_Update_Note_Id);
+                setShowNoticeBadge(shouldShowBadge(n, storedNoticeId));
+                setShowUpdateBadge(shouldShowBadge(u, storedUpdateId));
+            } catch {
+                // silent fail — 뱃지 미표시
+            }
+        };
+        fetchBadgeData();
+    }, []);
+
+    // 페이지 진입 시 본 것으로 간주 → localStorage 저장 + 뱃지 숨김
+    useEffect(() => {
+        if (location.pathname === '/updates' && latestUpdateNoteId !== null) {
+            localStorage.setItem(Storage_Last_Seen_Update_Note_Id, String(latestUpdateNoteId));
+            setShowUpdateBadge(false);
+        }
+        if (location.pathname === '/notices' && latestAnnouncementId !== null) {
+            localStorage.setItem(Storage_Last_Seen_Notice_Id, String(latestAnnouncementId));
+            setShowNoticeBadge(false);
+        }
+    }, [location.pathname, latestAnnouncementId, latestUpdateNoteId]);
 
     const handleLogin = () => {
         googleLogin();
@@ -98,6 +141,14 @@ const Head = () => {
                             onClick={() => navigate('/updates')}
                         >
                             {t('updateHistory')}
+                            <NavBadge show={showUpdateBadge} />
+                        </button>
+                        <button
+                            className={`nav-link ${location.pathname === '/notices' ? 'nav-active' : ''}`}
+                            onClick={() => navigate('/notices')}
+                        >
+                            {t('noticeMenu')}
+                            <NavBadge show={showNoticeBadge} />
                         </button>
                     </div>
                 </div>

--- a/tp-react/src/components/Head/NavBadge.css
+++ b/tp-react/src/components/Head/NavBadge.css
@@ -1,0 +1,10 @@
+.nav-badge-dot {
+    position: absolute;
+    top: 1.25rem;
+    right: 0.4rem;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: #ef4444;
+    pointer-events: none;
+}

--- a/tp-react/src/components/Head/NavBadge.jsx
+++ b/tp-react/src/components/Head/NavBadge.jsx
@@ -1,0 +1,12 @@
+import './NavBadge.css';
+
+/**
+ * 빨간 점 형태의 알림 뱃지. show 가 false 면 렌더링 안 함.
+ * 부모 요소가 position: relative 여야 우측 상단에 절대 배치된다.
+ */
+const NavBadge = ({show}) => {
+    if (!show) return null;
+    return <span className="nav-badge-dot" aria-label="new" />;
+};
+
+export default NavBadge;

--- a/tp-react/src/const/config.const.ts
+++ b/tp-react/src/const/config.const.ts
@@ -13,6 +13,8 @@ export const Storage_Feature_Guide = "Typing-Practice-featureGuide" as const;
 export const Storage_Controls_Collapsed = "Typing-Practice-controlsCollapsed" as const;
 export const Storage_Anonymous_Id = "Typing-Practice-anonymousId" as const;
 export const Storage_Session_Id = "Typing-Practice-sessionId" as const;
+export const Storage_Last_Seen_Notice_Id = "Typing-Practice-lastSeenNoticeId" as const;
+export const Storage_Last_Seen_Update_Note_Id = "Typing-Practice-lastSeenUpdateNoteId" as const;
 
 // Quote 관련 상수
 export const MIN_SENTENCE_LENGTH = 5 as const;

--- a/tp-react/src/pages/Home/Home.jsx
+++ b/tp-react/src/pages/Home/Home.jsx
@@ -1,7 +1,5 @@
 import {useEffect} from 'react';
 import {useNavigate} from 'react-router-dom';
-import UpdatePopup from './components/UpdatePopup/UpdatePopup';
-import NoticePopup from '../../components/NoticePopup/NoticePopup';
 import SessionResult from './components/SessionResult/SessionResult';
 import Info from './components/Info/Info';
 import Quote from './components/Quote/Quote';
@@ -30,8 +28,6 @@ function Home() {
 
     return (
         <SettingContextProvider>
-            <UpdatePopup/>
-            <NoticePopup/>
             <Info/>
             <QuoteContextProvider>
                 {showPopup ? (

--- a/tp-react/src/pages/Notices/NoticeDetail.css
+++ b/tp-react/src/pages/Notices/NoticeDetail.css
@@ -1,0 +1,146 @@
+.notice-detail-popup {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 40rem;
+    max-width: 90vw;
+    height: 32rem;
+    max-height: 80vh;
+    background: var(--color-bg);
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+    z-index: 1000;
+    overflow: hidden;
+}
+
+.notice-detail-popup-body {
+    height: 100%;
+    overflow-y: auto;
+    padding: 2.5rem 2rem 2rem;
+}
+
+.notice-detail-popup-close {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    width: 2rem;
+    height: 2rem;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    border-radius: 0.375rem;
+    background: var(--color-bg);
+    color: var(--color-text-muted);
+    cursor: pointer;
+    font-size: 1.25rem;
+    z-index: 1;
+}
+
+.notice-detail-popup-close:hover {
+    background: var(--color-primary-bg);
+    color: var(--color-text);
+}
+
+.notice-detail-header {
+    margin-bottom: 1.5rem;
+    padding-bottom: 1.25rem;
+    border-bottom: 1px solid var(--color-border);
+}
+
+.notice-detail-title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+    padding-right: 2rem;
+}
+
+.notice-detail-pin {
+    font-size: 1.25rem;
+    color: var(--color-primary);
+    flex-shrink: 0;
+}
+
+.notice-detail-title {
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0;
+    letter-spacing: -0.025em;
+}
+
+.notice-detail-date {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+}
+
+.notice-detail-content {
+    font-size: 1rem;
+    line-height: 1.7;
+    color: var(--color-text);
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+
+.notice-detail-skeleton-title {
+    height: 1.5rem;
+    width: 60%;
+    border-radius: 0.25rem;
+    background: var(--color-border);
+    margin-bottom: 0.75rem;
+    animation: notice-detail-shimmer 1.4s ease-in-out infinite;
+    opacity: 0.5;
+}
+
+.notice-detail-skeleton-date {
+    height: 0.875rem;
+    width: 8rem;
+    border-radius: 0.25rem;
+    background: var(--color-border);
+    margin-bottom: 1.5rem;
+    animation: notice-detail-shimmer 1.4s ease-in-out infinite;
+    opacity: 0.4;
+}
+
+.notice-detail-skeleton-body {
+    height: 8rem;
+    border-radius: 0.25rem;
+    background: var(--color-border);
+    animation: notice-detail-shimmer 1.4s ease-in-out infinite;
+    opacity: 0.3;
+}
+
+@keyframes notice-detail-shimmer {
+    0%, 100% { opacity: 0.3; }
+    50%      { opacity: 0.6; }
+}
+
+.notice-detail-message {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 2rem 1rem;
+    color: var(--color-text-muted);
+    text-align: center;
+}
+
+.notice-detail-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg);
+    color: var(--color-text);
+    cursor: pointer;
+    font-size: 0.875rem;
+}
+
+.notice-detail-btn:hover {
+    background: var(--color-primary-bg);
+}

--- a/tp-react/src/pages/Notices/NoticeDetail.jsx
+++ b/tp-react/src/pages/Notices/NoticeDetail.jsx
@@ -1,0 +1,94 @@
+import {useCallback, useEffect, useState} from 'react';
+import {MdPushPin, MdClose} from 'react-icons/md';
+import {getAnnouncement} from '@/utils/noticeApi.ts';
+import {formatLocalizedDate} from '@/utils/formatDate.ts';
+import {localized} from '@/utils/localizedText.ts';
+import {t} from '@/utils/i18n.ts';
+import './NoticeDetail.css';
+
+function NoticeDetail({id, onClose}) {
+    const [notice, setNotice] = useState(null);
+    const [isLoading, setIsLoading] = useState(true);
+    const [notFound, setNotFound] = useState(false);
+    const [error, setError] = useState(false);
+
+    const load = useCallback(async () => {
+        const numericId = Number(id);
+        if (!Number.isFinite(numericId)) {
+            setNotFound(true);
+            setIsLoading(false);
+            return;
+        }
+        setIsLoading(true);
+        setError(false);
+        setNotFound(false);
+        try {
+            const data = await getAnnouncement(numericId);
+            setNotice(data);
+        } catch (e) {
+            if (e?.response?.status === 404) {
+                setNotFound(true);
+            } else {
+                setError(true);
+            }
+        } finally {
+            setIsLoading(false);
+        }
+    }, [id]);
+
+    useEffect(() => {
+        load();
+    }, [load]);
+
+    useEffect(() => {
+        const handleKey = (e) => {
+            if (e.key === 'Escape') onClose();
+        };
+        window.addEventListener('keydown', handleKey);
+        return () => window.removeEventListener('keydown', handleKey);
+    }, [onClose]);
+
+    return (
+        <div className="notice-detail-popup" role="dialog" aria-modal="true">
+            <button className="notice-detail-popup-close" onClick={onClose} aria-label={t('close')}>
+                <MdClose />
+            </button>
+            <div className="notice-detail-popup-body">
+                {isLoading && (
+                    <>
+                        <div className="notice-detail-skeleton-title" />
+                        <div className="notice-detail-skeleton-date" />
+                        <div className="notice-detail-skeleton-body" />
+                    </>
+                )}
+                {!isLoading && notFound && (
+                    <div className="notice-detail-message">
+                        <p>{t('noticeNotFound')}</p>
+                    </div>
+                )}
+                {!isLoading && !notFound && error && (
+                    <div className="notice-detail-message">
+                        <p>{t('errorTemporary')}</p>
+                        <button className="notice-detail-btn" onClick={load}>
+                            {t('errorRetry')}
+                        </button>
+                    </div>
+                )}
+                {!isLoading && !notFound && !error && notice && (
+                    <>
+                        <header className="notice-detail-header">
+                            <div className="notice-detail-title-row">
+                                {notice.pinned && <MdPushPin className="notice-detail-pin" aria-label={t('pinned')} />}
+                                <h1 className="notice-detail-title">{localized(notice.title)}</h1>
+                            </div>
+                            <time className="notice-detail-date">{formatLocalizedDate(notice.postedAt)}</time>
+                        </header>
+                        <div className="notice-detail-content">{localized(notice.content)}</div>
+                    </>
+                )}
+            </div>
+        </div>
+    );
+}
+
+export default NoticeDetail;

--- a/tp-react/src/pages/Notices/NoticeList.css
+++ b/tp-react/src/pages/Notices/NoticeList.css
@@ -1,0 +1,150 @@
+.notices-container {
+    width: 100%;
+    max-width: 72rem;
+    margin: 0 auto;
+    padding: 2.5rem 2rem;
+}
+
+.notices-title {
+    font-size: 2.25rem;
+    font-weight: 500;
+    color: var(--color-text);
+    letter-spacing: -0.025em;
+    margin: 0 0 2rem 0;
+}
+
+.notices-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    border-top: 1px solid var(--color-border);
+}
+
+.notice-item {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1rem 0.5rem;
+    border-bottom: 1px solid var(--color-border);
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.notice-item:hover {
+    background: var(--color-primary-bg);
+}
+
+.notice-item.pinned {
+    background: color-mix(in srgb, var(--color-primary-bg) 40%, transparent);
+}
+
+.notice-item.pinned:hover {
+    background: var(--color-primary-bg);
+}
+
+.notice-item-title-row {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex: 1;
+    min-width: 0;
+}
+
+.notice-pin-icon {
+    font-size: 1rem;
+    color: var(--color-primary);
+    flex-shrink: 0;
+}
+
+.notice-item-title {
+    font-size: 1rem;
+    font-weight: 500;
+    color: var(--color-text);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.notice-item-date {
+    font-size: 0.875rem;
+    color: var(--color-text-muted);
+    flex-shrink: 0;
+}
+
+.notice-skeleton-item {
+    cursor: default;
+    pointer-events: none;
+}
+
+.notice-skeleton-title {
+    height: 1rem;
+    width: 50%;
+    border-radius: 0.25rem;
+    background: var(--color-border);
+    animation: notices-skeleton-shimmer 1.4s ease-in-out infinite;
+    opacity: 0.5;
+}
+
+.notice-skeleton-date {
+    height: 0.875rem;
+    width: 5rem;
+    border-radius: 0.25rem;
+    background: var(--color-border);
+    animation: notices-skeleton-shimmer 1.4s ease-in-out infinite;
+    opacity: 0.4;
+}
+
+@keyframes notices-skeleton-shimmer {
+    0%, 100% { opacity: 0.3; }
+    50%      { opacity: 0.6; }
+}
+
+.notices-empty {
+    text-align: center;
+    color: var(--color-text-muted);
+    padding: 3rem 1rem;
+}
+
+.notices-error {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 3rem 1rem;
+    color: var(--color-text-muted);
+    text-align: center;
+}
+
+.notices-error-inline {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 1.5rem 1rem;
+    color: var(--color-text-muted);
+    text-align: center;
+}
+
+.notices-retry-btn {
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg);
+    color: var(--color-text);
+    cursor: pointer;
+    font-size: 0.875rem;
+}
+
+.notices-retry-btn:hover {
+    background: var(--color-primary-bg);
+}
+
+.notices-loading-more {
+    padding: 1rem;
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
+}

--- a/tp-react/src/pages/Notices/NoticeList.jsx
+++ b/tp-react/src/pages/Notices/NoticeList.jsx
@@ -1,0 +1,160 @@
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {MdPushPin} from 'react-icons/md';
+import {getAnnouncements, getPinnedAnnouncements} from '@/utils/noticeApi.ts';
+import {formatLocalizedDate} from '@/utils/formatDate.ts';
+import {localized} from '@/utils/localizedText.ts';
+import {t} from '@/utils/i18n.ts';
+import NoticeDetail from './NoticeDetail';
+import './NoticeList.css';
+
+function NoticeList() {
+    const [selectedId, setSelectedId] = useState(null);
+    const [pinned, setPinned] = useState([]);
+    const [normal, setNormal] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
+    const [error, setError] = useState(false);
+    const [pageError, setPageError] = useState(false);
+
+    const isLoadingRef = useRef(false);
+    const hasNextRef = useRef(true);
+    const cursorRef = useRef(null);
+    const loadMoreRef = useRef(null);
+
+    const loadInitial = useCallback(async () => {
+        setIsLoading(true);
+        setError(false);
+        setPageError(false);
+        try {
+            const [pinnedRes, listRes] = await Promise.all([
+                getPinnedAnnouncements(),
+                getAnnouncements({size: 50}),
+            ]);
+            setPinned(pinnedRes.items);
+            setNormal(listRes.content);
+            cursorRef.current = listRes.nextCursor;
+            hasNextRef.current = listRes.hasNext;
+        } catch {
+            setPageError(true);
+        } finally {
+            setIsLoading(false);
+        }
+    }, []);
+
+    const loadMore = useCallback(async () => {
+        if (isLoadingRef.current || !hasNextRef.current) return;
+        isLoadingRef.current = true;
+        setIsLoadingMore(true);
+        setError(false);
+        try {
+            const cursor = cursorRef.current;
+            const res = await getAnnouncements({
+                cursorPostedAt: cursor?.postedAt,
+                cursorId: cursor?.id,
+                size: 50,
+            });
+            setNormal(prev => [...prev, ...res.content]);
+            cursorRef.current = res.nextCursor;
+            hasNextRef.current = res.hasNext;
+        } catch {
+            setError(true);
+        } finally {
+            isLoadingRef.current = false;
+            setIsLoadingMore(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        loadInitial();
+    }, [loadInitial]);
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries[0].isIntersecting && !isLoadingRef.current && hasNextRef.current) {
+                    loadMore();
+                }
+            },
+            {threshold: 0.1}
+        );
+        if (loadMoreRef.current) observer.observe(loadMoreRef.current);
+        return () => observer.disconnect();
+    }, [loadMore, normal.length]);
+
+    const renderItem = (item, isPinned) => (
+        <li
+            key={`${isPinned ? 'p' : 'n'}-${item.id}`}
+            className={`notice-item${isPinned ? ' pinned' : ''}`}
+            onClick={() => setSelectedId(item.id)}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => { if (e.key === 'Enter') setSelectedId(item.id); }}
+        >
+            <div className="notice-item-title-row">
+                {isPinned && <MdPushPin className="notice-pin-icon" aria-label={t('pinned')} />}
+                <span className="notice-item-title">{localized(item.title)}</span>
+            </div>
+            <time className="notice-item-date">{formatLocalizedDate(item.postedAt)}</time>
+        </li>
+    );
+
+    let body;
+    if (isLoading) {
+        body = (
+            <ul className="notices-list">
+                {[0, 1, 2, 3].map(i => (
+                    <li key={i} className="notice-item notice-skeleton-item">
+                        <div className="notice-skeleton-title" />
+                        <div className="notice-skeleton-date" />
+                    </li>
+                ))}
+            </ul>
+        );
+    } else if (pageError) {
+        body = (
+            <div className="notices-error">
+                <p>{t('errorTemporary')}</p>
+                <button className="notices-retry-btn" onClick={loadInitial}>
+                    {t('errorRetry')}
+                </button>
+            </div>
+        );
+    } else if (pinned.length === 0 && normal.length === 0) {
+        body = <p className="notices-empty">{t('noticesEmpty')}</p>;
+    } else {
+        body = (
+            <>
+                <ul className="notices-list">
+                    {pinned.map(item => renderItem(item, true))}
+                    {normal.map(item => renderItem(item, false))}
+                </ul>
+                <div ref={loadMoreRef} style={{height: '1px'}} />
+                {isLoadingMore && (
+                    <div className="notices-loading-more">{t('loading')}</div>
+                )}
+                {error && (
+                    <div className="notices-error-inline">
+                        <p>{t('errorTemporary')}</p>
+                        <button className="notices-retry-btn" onClick={loadMore}>
+                            {t('errorRetry')}
+                        </button>
+                    </div>
+                )}
+            </>
+        );
+    }
+
+    return (
+        <>
+            <div className="notices-container">
+                <h1 className="notices-title">{t('noticesTitle')}</h1>
+                {body}
+            </div>
+            {selectedId !== null && (
+                <NoticeDetail id={selectedId} onClose={() => setSelectedId(null)} />
+            )}
+        </>
+    );
+}
+
+export default NoticeList;

--- a/tp-react/src/pages/Updates/Updates.css
+++ b/tp-react/src/pages/Updates/Updates.css
@@ -1,4 +1,5 @@
 .updates-container {
+    width: 100%;
     max-width: 56rem;
     margin: 0 auto;
     padding: 2.5rem 2rem;
@@ -164,4 +165,76 @@
 
 .timeline-bullet.primary {
     background: var(--color-primary);
+}
+
+/* 스켈레톤 */
+.updates-skeleton-version {
+    height: 1.875rem;
+    width: 8rem;
+    border-radius: 0.25rem;
+    background: var(--color-border);
+    margin-bottom: 0.75rem;
+    animation: updates-skeleton-shimmer 1.4s ease-in-out infinite;
+    opacity: 0.5;
+}
+
+.updates-skeleton-line {
+    height: 0.875rem;
+    border-radius: 0.25rem;
+    background: var(--color-border);
+    margin-bottom: 0.5rem;
+    animation: updates-skeleton-shimmer 1.4s ease-in-out infinite;
+    opacity: 0.4;
+}
+
+.updates-skeleton-line.short {
+    width: 60%;
+}
+
+@keyframes updates-skeleton-shimmer {
+    0%, 100% { opacity: 0.3; }
+    50%      { opacity: 0.6; }
+}
+
+/* 에러 / 재시도 */
+.updates-error {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 3rem 1rem;
+    color: var(--color-text-muted);
+    text-align: center;
+}
+
+.updates-error-inline {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 1.5rem 1rem;
+    color: var(--color-text-muted);
+    text-align: center;
+}
+
+.updates-retry-btn {
+    padding: 0.5rem 1rem;
+    border-radius: 0.375rem;
+    border: 1px solid var(--color-border);
+    background: var(--color-bg);
+    color: var(--color-text);
+    cursor: pointer;
+    font-size: 0.875rem;
+}
+
+.updates-retry-btn:hover {
+    background: var(--color-primary-bg);
+}
+
+/* 로딩 더 */
+.updates-loading-more {
+    padding: 1rem;
+    text-align: center;
+    color: var(--color-text-muted);
+    font-size: 0.875rem;
 }

--- a/tp-react/src/pages/Updates/Updates.jsx
+++ b/tp-react/src/pages/Updates/Updates.jsx
@@ -1,75 +1,150 @@
-import {formatUpdateDate, localize, updateHistory} from '@/data/updateHistory.ts';
+import {useCallback, useEffect, useRef, useState} from 'react';
+import {MdAutoAwesome, MdTune} from 'react-icons/md';
+import {getUpdateNotes} from '@/utils/updateNoteApi.ts';
+import {formatLocalizedDate} from '@/utils/formatDate.ts';
+import {localized} from '@/utils/localizedText.ts';
 import {t} from '@/utils/i18n.ts';
-import {MdAutoAwesome, MdTune, MdCampaign} from 'react-icons/md';
 import './Updates.css';
 
 function Updates() {
-    const visibleUpdates = updateHistory.filter(u => !u.hidden);
+    const [notes, setNotes] = useState([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isLoadingMore, setIsLoadingMore] = useState(false);
+    const [error, setError] = useState(false);
+
+    const isLoadingRef = useRef(false);
+    const hasNextRef = useRef(true);
+    const cursorRef = useRef(null);
+    const loadMoreRef = useRef(null);
+
+    const loadNotes = useCallback(async (isFirst = false) => {
+        if (isLoadingRef.current) return;
+        if (!isFirst && !hasNextRef.current) return;
+        isLoadingRef.current = true;
+        if (isFirst) setIsLoading(true);
+        else setIsLoadingMore(true);
+        setError(false);
+        try {
+            const cursor = isFirst ? undefined : cursorRef.current;
+            const res = await getUpdateNotes({
+                cursorReleasedAt: cursor?.releasedAt,
+                cursorId: cursor?.id,
+                size: 50,
+            });
+            setNotes(prev => isFirst ? res.content : [...prev, ...res.content]);
+            cursorRef.current = res.nextCursor;
+            hasNextRef.current = res.hasNext;
+        } catch {
+            setError(true);
+        } finally {
+            isLoadingRef.current = false;
+            setIsLoading(false);
+            setIsLoadingMore(false);
+        }
+    }, []);
+
+    useEffect(() => {
+        loadNotes(true);
+    }, [loadNotes]);
+
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries[0].isIntersecting && !isLoadingRef.current && hasNextRef.current) {
+                    loadNotes();
+                }
+            },
+            {threshold: 0.1}
+        );
+        if (loadMoreRef.current) observer.observe(loadMoreRef.current);
+        return () => observer.disconnect();
+    }, [loadNotes, notes.length]);
+
+    const handleRetry = () => loadNotes(true);
+
+    if (isLoading) {
+        return (
+            <div className="updates-container">
+                <header className="updates-header">
+                    <h1 className="updates-title">{t('updateHistoryTitle')}</h1>
+                </header>
+                <div className="updates-timeline">
+                    {[0, 1, 2].map(i => (
+                        <div key={i} className="timeline-entry">
+                            <div className="updates-skeleton-version" />
+                            <div className="updates-skeleton-line" />
+                            <div className="updates-skeleton-line short" />
+                        </div>
+                    ))}
+                </div>
+            </div>
+        );
+    }
+
+    if (error && notes.length === 0) {
+        return (
+            <div className="updates-container">
+                <header className="updates-header">
+                    <h1 className="updates-title">{t('updateHistoryTitle')}</h1>
+                </header>
+                <div className="updates-error">
+                    <p>{t('errorTemporary')}</p>
+                    <button className="updates-retry-btn" onClick={handleRetry}>
+                        {t('errorRetry')}
+                    </button>
+                </div>
+            </div>
+        );
+    }
 
     return (
         <div className="updates-container">
             <header className="updates-header">
-                <span className="updates-latest-badge">v{visibleUpdates[0]?.version} Released</span>
+                {notes[0] && <span className="updates-latest-badge">{notes[0].version} Released</span>}
                 <h1 className="updates-title">{t('updateHistoryTitle')}</h1>
             </header>
             <div className="updates-timeline">
                 <div className="timeline-line"/>
-                {visibleUpdates.map((update, idx) => {
+                {notes.map((note, idx) => {
                     const isLatest = idx === 0;
                     return (
-                        <section className={`timeline-entry${isLatest ? '' : ' past'}`} key={update.version}>
+                        <section className={`timeline-entry${isLatest ? '' : ' past'}`} key={note.id}>
                             <div className={`timeline-dot${isLatest ? ' latest' : ''}`}>
                                 <div className="timeline-dot-inner"/>
                             </div>
                             <div className="timeline-content">
                                 <div className="timeline-version-row">
-                                    <h2 className="timeline-version">v{update.version}</h2>
-                                    <time className="timeline-date">{formatUpdateDate(update.date)}</time>
+                                    <h2 className="timeline-version">{note.version}</h2>
+                                    <time className="timeline-date">{formatLocalizedDate(note.releasedAt)}</time>
                                 </div>
                                 <div className="timeline-sections">
-                                    {update.notices && update.notices.length > 0 && (
-                                        <div className="timeline-section timeline-section-full">
-                                            <div className="timeline-section-header">
-                                                <MdCampaign className="timeline-section-icon primary"/>
-                                                <h3 className="timeline-section-title">{t('updateNotices')}</h3>
-                                            </div>
-                                            <ul className="timeline-list">
-                                                {update.notices.map((item, i) => (
-                                                    <li key={i}>
-                                                        <span className="timeline-bullet primary"/>
-                                                        <span>{localize(item)}</span>
-                                                    </li>
-                                                ))}
-                                            </ul>
-                                        </div>
-                                    )}
-                                    {update.features && update.features.length > 0 && (
+                                    {note.newFeatures && note.newFeatures.length > 0 && (
                                         <div className="timeline-section">
                                             <div className="timeline-section-header">
                                                 <MdAutoAwesome className="timeline-section-icon primary"/>
                                                 <h3 className="timeline-section-title">{t('updateFeatures')}</h3>
                                             </div>
                                             <ul className="timeline-list">
-                                                {update.features.map((item, i) => (
+                                                {note.newFeatures.map((item, i) => (
                                                     <li key={i}>
                                                         <span className={`timeline-bullet${isLatest ? ' primary' : ''}`}/>
-                                                        <span>{localize(item)}</span>
+                                                        <span>{localized(item)}</span>
                                                     </li>
                                                 ))}
                                             </ul>
                                         </div>
                                     )}
-                                    {update.improvements && update.improvements.length > 0 && (
+                                    {note.improvements && note.improvements.length > 0 && (
                                         <div className="timeline-section">
                                             <div className="timeline-section-header">
                                                 <MdTune className="timeline-section-icon"/>
                                                 <h3 className="timeline-section-title">{t('updateImprovements')}</h3>
                                             </div>
                                             <ul className="timeline-list">
-                                                {update.improvements.map((item, i) => (
+                                                {note.improvements.map((item, i) => (
                                                     <li key={i}>
                                                         <span className="timeline-bullet"/>
-                                                        <span>{localize(item)}</span>
+                                                        <span>{localized(item)}</span>
                                                     </li>
                                                 ))}
                                             </ul>
@@ -80,6 +155,18 @@ function Updates() {
                         </section>
                     );
                 })}
+                <div ref={loadMoreRef} style={{height: '1px'}} />
+                {isLoadingMore && (
+                    <div className="updates-loading-more">{t('loading')}</div>
+                )}
+                {error && notes.length > 0 && (
+                    <div className="updates-error-inline">
+                        <p>{t('errorTemporary')}</p>
+                        <button className="updates-retry-btn" onClick={() => loadNotes()}>
+                            {t('errorRetry')}
+                        </button>
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/tp-react/src/types/notice.types.ts
+++ b/tp-react/src/types/notice.types.ts
@@ -1,0 +1,67 @@
+export interface LocalizedText {
+    ko: string;
+    en: string | null;
+    ja: string | null;
+}
+
+export interface AnnouncementLatest {
+    id: number;
+    postedAt: string;
+    title: LocalizedText;
+    content: LocalizedText;
+    published: boolean;
+    pinned: boolean;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface AnnouncementSummary {
+    id: number;
+    postedAt: string;
+    title: LocalizedText;
+    published: boolean;
+    pinned: boolean;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface AnnouncementDetail extends AnnouncementSummary {
+    content: LocalizedText;
+}
+
+export interface PinnedAnnouncementListResponse {
+    items: AnnouncementSummary[];
+}
+
+export interface AnnouncementCursor {
+    postedAt: string;
+    id: number;
+}
+
+export interface AnnouncementCursorResponse {
+    content: AnnouncementSummary[];
+    nextCursor: AnnouncementCursor | null;
+    hasNext: boolean;
+}
+
+export interface UpdateNote {
+    id: number;
+    version: string;
+    releasedAt: string;
+    newFeatures: LocalizedText[];
+    improvements: LocalizedText[];
+    published: boolean;
+    createdAt: string;
+    updatedAt: string;
+}
+
+export interface UpdateNoteCursor {
+    releasedAt: string;
+    id: number;
+}
+
+export interface UpdateNoteCursorResponse {
+    content: UpdateNote[];
+    nextCursor: UpdateNoteCursor | null;
+    hasNext: boolean;
+}

--- a/tp-react/src/utils/formatDate.ts
+++ b/tp-react/src/utils/formatDate.ts
@@ -1,3 +1,5 @@
+import {lang, MONTH_NAMES} from './i18n';
+
 /**
  * 날짜를 YYYY.MM.DD 형식으로 포맷
  */
@@ -7,4 +9,19 @@ export const formatDate = (dateString: string | Date): string => {
     const month = String(date.getMonth() + 1).padStart(2, '0');
     const day = String(date.getDate()).padStart(2, '0');
     return `${year}.${month}.${day}`;
+};
+
+/**
+ * UTC ISO LocalDateTime 문자열을 사용자 로컬 타임존의 Y/M/D 로 포맷.
+ * 백엔드가 'Z' 접미사 없이 UTC 시각을 보내므로 명시적으로 'Z' 를 붙여 UTC 로 파싱한다.
+ */
+export const formatLocalizedDate = (utcIsoString: string): string => {
+    const normalized = utcIsoString.endsWith('Z') ? utcIsoString : utcIsoString + 'Z';
+    const d = new Date(normalized);
+    const y = d.getFullYear();
+    const m = d.getMonth() + 1;
+    const day = d.getDate();
+    if (lang === 'ko') return `${y}년 ${m}월 ${day}일`;
+    if (lang === 'ja') return `${y}年${m}月${day}日`;
+    return `${MONTH_NAMES[m - 1]} ${day}, ${y}`;
 };

--- a/tp-react/src/utils/i18n.ts
+++ b/tp-react/src/utils/i18n.ts
@@ -2,7 +2,7 @@ export type Lang = 'ko' | 'ja' | 'en';
 export const lang: Lang = navigator.language.startsWith('ko') ? 'ko' : navigator.language.startsWith('ja') ? 'ja' : 'en';
 document.documentElement.lang = lang;
 const l = (ko: string, ja: string, en: string) => lang === 'ko' ? ko : lang === 'ja' ? ja : en;
-const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+export const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
 const translations = {
     // 공통
@@ -313,6 +313,19 @@ const translations = {
         if (m > 0) return `${m}m ${s}s`;
         return `${s}s`;
     },
+
+    // 공지사항
+    noticeMenu: l('공지', 'お知らせ', 'Notices'),
+    noticesTitle: l('공지사항', 'お知らせ', 'Notices'),
+    noticesEmpty: l('등록된 공지가 없습니다.', '登録されたお知らせがありません。', 'No notices available.'),
+    noticeBack: l('목록으로', '一覧へ', 'Back to list'),
+    noticeNotFound: l('공지를 찾을 수 없습니다.', 'お知らせが見つかりません。', 'Notice not found.'),
+    pinned: l('고정', '固定', 'Pinned'),
+
+    // 통합 에러
+    errorTemporary: l('일시적인 문제가 발생했습니다. 다시 시도해주세요.', '一時的な問題が発生しました。もう一度お試しください。', 'A temporary error occurred. Please try again.'),
+    errorNetwork: l('인터넷 연결을 확인해주세요.', 'インターネット接続を確認してください。', 'Please check your internet connection.'),
+    errorRetry: l('다시 시도', '再試行', 'Retry'),
 
     // 업데이트 팝업
     updateNotice: l('업데이트 안내', 'アップデート情報', 'Update'),

--- a/tp-react/src/utils/localizedText.ts
+++ b/tp-react/src/utils/localizedText.ts
@@ -1,0 +1,9 @@
+import {lang} from './i18n';
+import {LocalizedText} from '../types/notice.types';
+
+export function localized(text: LocalizedText | null | undefined): string {
+    if (!text) return '';
+    const value = text[lang];
+    if (value !== null && value !== undefined) return value;
+    return text.ko;
+}

--- a/tp-react/src/utils/noticeApi.ts
+++ b/tp-react/src/utils/noticeApi.ts
@@ -1,0 +1,44 @@
+import apiClient from './apiClient';
+import {ApiResponse} from '../types/api.types';
+import {
+    AnnouncementLatest,
+    AnnouncementDetail,
+    AnnouncementCursorResponse,
+    PinnedAnnouncementListResponse,
+} from '../types/notice.types';
+
+export const getLatestAnnouncement = async (): Promise<AnnouncementLatest | null> => {
+    const res = await apiClient.get<ApiResponse<AnnouncementLatest | null>>('/announcements/latest');
+    return res.data.data;
+};
+
+export const getPinnedAnnouncements = async (): Promise<PinnedAnnouncementListResponse> => {
+    const res = await apiClient.get<ApiResponse<PinnedAnnouncementListResponse>>('/announcements/pinned');
+    return res.data.data;
+};
+
+interface GetAnnouncementsParams {
+    cursorPostedAt?: string;
+    cursorId?: number;
+    size?: number;
+}
+
+export const getAnnouncements = async (
+    params: GetAnnouncementsParams = {}
+): Promise<AnnouncementCursorResponse> => {
+    const query = new URLSearchParams();
+    if (params.cursorPostedAt && params.cursorId !== undefined) {
+        query.append('cursorPostedAt', params.cursorPostedAt);
+        query.append('cursorId', String(params.cursorId));
+    }
+    query.append('size', String(params.size ?? 50));
+    const res = await apiClient.get<ApiResponse<AnnouncementCursorResponse>>(
+        `/announcements?${query.toString()}`
+    );
+    return res.data.data;
+};
+
+export const getAnnouncement = async (id: number): Promise<AnnouncementDetail> => {
+    const res = await apiClient.get<ApiResponse<AnnouncementDetail>>(`/announcements/${id}`);
+    return res.data.data;
+};

--- a/tp-react/src/utils/updateNoteApi.ts
+++ b/tp-react/src/utils/updateNoteApi.ts
@@ -1,0 +1,29 @@
+import apiClient from './apiClient';
+import {ApiResponse} from '../types/api.types';
+import {UpdateNote, UpdateNoteCursorResponse} from '../types/notice.types';
+
+export const getLatestUpdateNote = async (): Promise<UpdateNote | null> => {
+    const res = await apiClient.get<ApiResponse<UpdateNote | null>>('/update-notes/latest');
+    return res.data.data;
+};
+
+interface GetUpdateNotesParams {
+    cursorReleasedAt?: string;
+    cursorId?: number;
+    size?: number;
+}
+
+export const getUpdateNotes = async (
+    params: GetUpdateNotesParams = {}
+): Promise<UpdateNoteCursorResponse> => {
+    const query = new URLSearchParams();
+    if (params.cursorReleasedAt && params.cursorId !== undefined) {
+        query.append('cursorReleasedAt', params.cursorReleasedAt);
+        query.append('cursorId', String(params.cursorId));
+    }
+    query.append('size', String(params.size ?? 50));
+    const res = await apiClient.get<ApiResponse<UpdateNoteCursorResponse>>(
+        `/update-notes?${query.toString()}`
+    );
+    return res.data.data;
+};


### PR DESCRIPTION
## 주요내용
- 기존 정적 데이터(updateHistory, noticeData) 기반 → 서버 API 조회 방식으로 전환
- 헤더 네비게이션에 신규 항목 알림 빨간 점 뱃지 추가
- 공지사항 목록 페이지 신규 추가 (/notices), 상세는 팝업으로 표시
- 업데이트 이력 페이지에 무한 스크롤 적용
- 다국어/시간대 처리 일관화 (UTC → 로컬 Y/M/D)
- 기존 진입 팝업(UpdatePopup, NoticePopup) Home 에서 제거

## 세부내용

### API 및 공통 유틸
- noticeApi.ts: 공지 4개 엔드포인트 (latest, pinned, list, detail)
- updateNoteApi.ts: 업데이트 노트 2개 엔드포인트 (latest, list)
- notice.types.ts: AnnouncementLatest/Summary/Detail, UpdateNote 등 타입 정의
- localizedText.ts: 다국어 fallback (선택 언어 null 시 ko)
- formatDate.ts: formatLocalizedDate 추가 (UTC ISO → 로컬 타임존 Y/M/D, 언어별 포맷)
- i18n.ts: MONTH_NAMES export, 공지/에러 관련 키 9개 추가
- config.const.ts: Storage_Last_Seen_Notice_Id, Storage_Last_Seen_Update_Note_Id 추가

### 헤더 뱃지
- NavBadge 컴포넌트 신규 (빨간 점, 글자 우측 상단)
- Head.jsx: 마운트 시 /latest 두 API 호출 → localStorage 비교 → 뱃지 표시
- 페이지 진입 시 본 것으로 간주, localStorage 저장 + 뱃지 숨김
- "공지" 메뉴 항목 신규 추가

### 업데이트 이력 페이지 (Updates)
- 정적 updateHistory 대체 → getUpdateNotes() 호출
- 무한 스크롤 (IntersectionObserver, 커서 페이지네이션, size=50)
- 스켈레톤 UI + 통합 에러/재시도 UI
- 컨테이너 width: 100% + max-width: 56rem (flex 부모에서 일관된 폭)

### 공지 페이지 (Notices)
- NoticeList.jsx: 고정 공지 + 일반 공지 병합 표시, 핀 아이콘, 무한 스크롤
- NoticeDetail.jsx: state 기반 팝업 (URL 라우트 없음)
  - 오버레이/dim 처리 없음, 단순 카드 팝업
  - 고정 크기 (40rem × 32rem), 내부 스크롤
  - ESC 키 + X 버튼 닫기

### 기타
- App.jsx: /notices 라우트 등록
- AppDiv.jsx: /notices 를 compact 페이지로 처리 (상단 여백 통일)
- Home.jsx: <UpdatePopup/>, <NoticePopup/> JSX 사용 제거 (컴포넌트 파일 자체는 유지)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>